### PR TITLE
feat: prevent overlapping slot reservations

### DIFF
--- a/docs/api/slots.md
+++ b/docs/api/slots.md
@@ -1,0 +1,109 @@
+# Slots API
+
+## Conflict Detection
+
+### Semantics
+
+Two slots for the **same professional** conflict when their time ranges overlap.
+The overlap check uses a **half-open interval** model: `[startTime, endTime)`.
+
+| Scenario | Conflict? |
+|---|---|
+| Identical range | ✅ Yes |
+| New slot starts inside existing | ✅ Yes |
+| New slot ends inside existing | ✅ Yes |
+| New slot fully wraps existing | ✅ Yes |
+| New slot fully inside existing | ✅ Yes |
+| New slot starts exactly when existing ends (`end == start`) | ❌ No (adjacent) |
+| New slot ends exactly when existing starts | ❌ No (adjacent) |
+| No time overlap at all | ❌ No |
+| Same time range, different professional | ❌ No |
+
+### Error response
+
+When a conflict is detected, the API returns **HTTP 409 Conflict**:
+
+```json
+{
+  "success": false,
+  "error": "Slot overlaps with an existing reservation for this professional"
+}
+```
+
+### Two-layer defence
+
+Conflict prevention is enforced at two layers:
+
+1. **Service layer** (`SlotService.createSlot` / `updateSlot`)  
+   Checks for conflicts in-memory before writing. Returns a fast `409` without
+   a DB round-trip on the happy path.
+
+2. **Database layer** (migration `003_add_slot_conflict_exclusion`)  
+   A PostgreSQL `EXCLUDE USING gist` constraint on the `slots` table prevents
+   overlapping rows from being inserted even under concurrent requests that
+   race past the service-layer check.
+
+   ```sql
+   ALTER TABLE slots
+     ADD CONSTRAINT excl_slots_no_overlap
+     EXCLUDE USING gist (
+       professional_id WITH =,
+       tstzrange(start_time, end_time) WITH &&
+     );
+   ```
+
+   The `btree_gist` extension is required to mix an equality operator (`=`) with
+   a range operator (`&&`) in a single exclusion constraint.
+
+### Security assumptions
+
+- The service layer check is **not** a substitute for the DB constraint. Under
+  concurrent load, two requests can both pass the service check before either
+  commits. The DB constraint is the authoritative last line of defence.
+- The DB constraint fires at statement time (`DEFERRABLE INITIALLY IMMEDIATE`),
+  which is the safest default. It cannot be deferred by client code.
+- Callers that receive a `409` should **not** retry automatically — the conflict
+  is deterministic and will not resolve without a change to the existing slot.
+
+## Endpoints
+
+### `POST /api/v1/slots`
+
+Creates a new slot.
+
+**Request body**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `professional` | string | ✅ | Professional identifier (trimmed before use) |
+| `startTime` | number | ✅ | Unix timestamp (ms) — start of the slot |
+| `endTime` | number | ✅ | Unix timestamp (ms) — end of the slot (must be > startTime) |
+
+**Responses**
+
+| Status | Meaning |
+|---|---|
+| `201 Created` | Slot created successfully |
+| `400 Bad Request` | Missing required fields or invalid time range |
+| `409 Conflict` | Slot overlaps an existing reservation for this professional |
+| `503 Service Unavailable` | Feature flag `FF_CREATE_SLOT` is disabled |
+
+### `PATCH /api/v1/slots/:id`
+
+Updates an existing slot. Requires `x-chronopay-admin-token` header.
+
+Conflict detection applies to updates: the updated slot must not overlap any
+**other** slot for the same professional. Updating a slot to its own current
+range is always allowed (self-exclusion).
+
+**Responses**
+
+| Status | Meaning |
+|---|---|
+| `200 OK` | Slot updated |
+| `400 Bad Request` | Invalid payload or resulting time range |
+| `401 Unauthorized` | Missing admin token header |
+| `403 Forbidden` | Invalid admin token |
+| `404 Not Found` | Slot not found |
+| `409 Conflict` | Updated range overlaps another slot |
+| `503 Service Unavailable` | Admin token not configured |

--- a/src/__tests__/slot-conflict.test.ts
+++ b/src/__tests__/slot-conflict.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Comprehensive tests for slot conflict detection.
+ *
+ * Covers:
+ *  - InMemorySlotRepository.hasConflict (all overlap/adjacency cases)
+ *  - SlotService.createSlot conflict enforcement
+ *  - SlotService.updateSlot conflict enforcement (self-exclusion)
+ *  - Concurrency simulation (sequential creates that would race)
+ *  - Edge cases: end == start boundary, zero-width slots, different professionals
+ */
+
+import {
+  InMemorySlotRepository,
+  type SlotRecord as RepoSlotRecord,
+} from "../modules/slots/slot-repository.js";
+import {
+  SlotService,
+  SlotConflictError,
+  SlotValidationError,
+} from "../services/slotService.js";
+
+// ─── InMemorySlotRepository.hasConflict ───────────────────────────────────────
+
+describe("InMemorySlotRepository.hasConflict", () => {
+  const BASE: RepoSlotRecord = {
+    id: "s1",
+    professional: "alice",
+    startTime: 1000,
+    endTime: 2000,
+    bookable: true,
+  };
+
+  function repo(...extra: RepoSlotRecord[]) {
+    return new InMemorySlotRepository([BASE, ...extra]);
+  }
+
+  it("returns false when no slots exist for the professional", () => {
+    const r = new InMemorySlotRepository([]);
+    expect(r.hasConflict("alice", 1000, 2000)).toBe(false);
+  });
+
+  it("detects exact overlap", () => {
+    expect(repo().hasConflict("alice", 1000, 2000)).toBe(true);
+  });
+
+  it("detects partial overlap — new slot starts inside existing", () => {
+    expect(repo().hasConflict("alice", 1500, 2500)).toBe(true);
+  });
+
+  it("detects partial overlap — new slot ends inside existing", () => {
+    expect(repo().hasConflict("alice", 500, 1500)).toBe(true);
+  });
+
+  it("detects containment — new slot fully inside existing", () => {
+    expect(repo().hasConflict("alice", 1100, 1900)).toBe(true);
+  });
+
+  it("detects containment — new slot fully wraps existing", () => {
+    expect(repo().hasConflict("alice", 500, 2500)).toBe(true);
+  });
+
+  it("allows adjacency — new slot starts exactly when existing ends", () => {
+    expect(repo().hasConflict("alice", 2000, 3000)).toBe(false);
+  });
+
+  it("allows adjacency — new slot ends exactly when existing starts", () => {
+    expect(repo().hasConflict("alice", 0, 1000)).toBe(false);
+  });
+
+  it("allows non-overlapping slot before existing", () => {
+    expect(repo().hasConflict("alice", 0, 500)).toBe(false);
+  });
+
+  it("allows non-overlapping slot after existing", () => {
+    expect(repo().hasConflict("alice", 2500, 3000)).toBe(false);
+  });
+
+  it("ignores slots belonging to a different professional", () => {
+    expect(repo().hasConflict("bob", 1000, 2000)).toBe(false);
+  });
+
+  it("excludes the specified slot id (used during updates)", () => {
+    // Updating slot s1 to the same range should not conflict with itself.
+    expect(repo().hasConflict("alice", 1000, 2000, "s1")).toBe(false);
+  });
+
+  it("still detects conflict with other slots when excludeId is set", () => {
+    const s2: RepoSlotRecord = {
+      id: "s2",
+      professional: "alice",
+      startTime: 1500,
+      endTime: 2500,
+      bookable: true,
+    };
+    // Excluding s1 but s2 still overlaps [1200, 1800]
+    expect(repo(s2).hasConflict("alice", 1200, 1800, "s1")).toBe(true);
+  });
+});
+
+// ─── SlotService conflict detection ──────────────────────────────────────────
+
+describe("SlotService — createSlot conflict detection", () => {
+  let service: SlotService;
+
+  beforeEach(() => {
+    service = new SlotService();
+  });
+
+  it("creates a slot when no conflict exists", () => {
+    const slot = service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(slot.id).toBe(1);
+  });
+
+  it("throws SlotConflictError on exact overlap", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(() =>
+      service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 }),
+    ).toThrow(SlotConflictError);
+  });
+
+  it("throws SlotConflictError on partial overlap (new starts inside existing)", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(() =>
+      service.createSlot({ professional: "alice", startTime: 1500, endTime: 2500 }),
+    ).toThrow(SlotConflictError);
+  });
+
+  it("throws SlotConflictError on partial overlap (new ends inside existing)", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(() =>
+      service.createSlot({ professional: "alice", startTime: 500, endTime: 1500 }),
+    ).toThrow(SlotConflictError);
+  });
+
+  it("throws SlotConflictError when new slot wraps existing", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(() =>
+      service.createSlot({ professional: "alice", startTime: 500, endTime: 2500 }),
+    ).toThrow(SlotConflictError);
+  });
+
+  it("allows adjacent slot (new starts exactly when existing ends)", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(() =>
+      service.createSlot({ professional: "alice", startTime: 2000, endTime: 3000 }),
+    ).not.toThrow();
+  });
+
+  it("allows adjacent slot (new ends exactly when existing starts)", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(() =>
+      service.createSlot({ professional: "alice", startTime: 0, endTime: 1000 }),
+    ).not.toThrow();
+  });
+
+  it("allows overlapping times for a different professional", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(() =>
+      service.createSlot({ professional: "bob", startTime: 1000, endTime: 2000 }),
+    ).not.toThrow();
+  });
+
+  it("trims professional name before conflict check", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    expect(() =>
+      service.createSlot({ professional: "  alice  ", startTime: 1000, endTime: 2000 }),
+    ).toThrow(SlotConflictError);
+  });
+
+  it("does not create the slot when conflict is detected (state unchanged)", () => {
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    try {
+      service.createSlot({ professional: "alice", startTime: 1500, endTime: 2500 });
+    } catch {
+      // expected
+    }
+    return service.listSlots().then(({ slots }) => {
+      expect(slots).toHaveLength(1);
+    });
+  });
+
+  it("still throws SlotValidationError for invalid input before conflict check", () => {
+    expect(() =>
+      service.createSlot({ professional: "alice", startTime: 2000, endTime: 1000 }),
+    ).toThrow(SlotValidationError);
+  });
+});
+
+describe("SlotService — updateSlot conflict detection", () => {
+  let service: SlotService;
+
+  beforeEach(() => {
+    service = new SlotService();
+    service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 });
+    service.createSlot({ professional: "alice", startTime: 3000, endTime: 4000 });
+  });
+
+  it("allows updating a slot to its own range (no self-conflict)", () => {
+    expect(() => service.updateSlot(1, { startTime: 1000, endTime: 2000 })).not.toThrow();
+  });
+
+  it("allows shrinking a slot within its own range", () => {
+    expect(() => service.updateSlot(1, { startTime: 1100, endTime: 1900 })).not.toThrow();
+  });
+
+  it("throws SlotConflictError when update would overlap another slot", () => {
+    // Slot 1 is [1000,2000], slot 2 is [3000,4000]. Extending slot 1 into slot 2.
+    expect(() => service.updateSlot(1, { endTime: 3500 })).toThrow(SlotConflictError);
+  });
+
+  it("allows moving slot to a non-conflicting range", () => {
+    expect(() => service.updateSlot(1, { startTime: 2000, endTime: 2500 })).not.toThrow();
+  });
+});
+
+// ─── Concurrency simulation ───────────────────────────────────────────────────
+
+describe("SlotService — concurrency simulation", () => {
+  it("only one of two concurrent creates for the same slot wins", async () => {
+    const service = new SlotService();
+
+    // Simulate two concurrent requests that both pass the initial check
+    // before either commits. In the in-memory implementation the second
+    // synchronous call will see the first slot already inserted.
+    const results = await Promise.allSettled([
+      Promise.resolve().then(() =>
+        service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 }),
+      ),
+      Promise.resolve().then(() =>
+        service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 }),
+      ),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(SlotConflictError);
+  });
+
+  it("allows two concurrent creates for different professionals", async () => {
+    const service = new SlotService();
+
+    const results = await Promise.allSettled([
+      Promise.resolve().then(() =>
+        service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 }),
+      ),
+      Promise.resolve().then(() =>
+        service.createSlot({ professional: "bob", startTime: 1000, endTime: 2000 }),
+      ),
+    ]);
+
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+  });
+
+  it("allows two concurrent creates for non-overlapping times", async () => {
+    const service = new SlotService();
+
+    const results = await Promise.allSettled([
+      Promise.resolve().then(() =>
+        service.createSlot({ professional: "alice", startTime: 1000, endTime: 2000 }),
+      ),
+      Promise.resolve().then(() =>
+        service.createSlot({ professional: "alice", startTime: 2000, endTime: 3000 }),
+      ),
+    ]);
+
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+  });
+});

--- a/src/__tests__/slot-service.test.ts
+++ b/src/__tests__/slot-service.test.ts
@@ -13,7 +13,7 @@ describe("SlotService", () => {
     service = new SlotService(() => new Date(currentTime));
   });
 
-  it("creates slots and returns a sorted list", () => {
+  it("creates slots and returns a sorted list", async () => {
     const first = service.createSlot({
       professional: "alice",
       startTime: 1000,
@@ -28,11 +28,11 @@ describe("SlotService", () => {
       endTime: 4000,
     });
 
-    const list = service.listSlots();
+    const list = (await service.listSlots()).slots;
 
     expect(list.map((slot) => slot.id)).toEqual([first.id, second.id]);
     list[0].professional = "tampered";
-    expect(service.listSlots()[0].professional).toBe("alice");
+    expect((await service.listSlots()).slots[0].professional).toBe("alice");
   });
 
   it("throws when updating with invalid payload type", () => {
@@ -75,7 +75,7 @@ describe("SlotService", () => {
     expect(() => service.updateSlot(999, { endTime: 1000 })).toThrow(SlotNotFoundError);
   });
 
-  it("resets all state", () => {
+  it("resets all state", async () => {
     service.createSlot({
       professional: "alice",
       startTime: 1000,
@@ -84,7 +84,7 @@ describe("SlotService", () => {
 
     service.reset();
 
-    expect(service.listSlots()).toEqual([]);
+    expect((await service.listSlots()).slots).toEqual([]);
     const recreated = service.createSlot({
       professional: "alice",
       startTime: 1000,

--- a/src/db/migrations/003_add_slot_conflict_exclusion.ts
+++ b/src/db/migrations/003_add_slot_conflict_exclusion.ts
@@ -1,0 +1,48 @@
+import { PoolClient } from "pg";
+import { Migration } from "../migrationRunner.js";
+
+/**
+ * Migration 003 — add_slot_conflict_exclusion
+ *
+ * Adds a PostgreSQL EXCLUSION constraint on the `slots` table that prevents
+ * two slots for the same professional from having overlapping time ranges.
+ *
+ * Design decisions:
+ *  - Uses the `btree_gist` extension to allow mixing a regular equality
+ *    column (professional_id) with a range operator (&&) in one constraint.
+ *  - `tstzrange(start_time, end_time)` models the slot as a half-open interval
+ *    [start, end), so adjacent slots (end of one == start of next) are allowed.
+ *  - The constraint fires at statement time (DEFERRABLE INITIALLY IMMEDIATE),
+ *    which is the safest default and prevents concurrent inserts from racing
+ *    past the check.
+ *  - The service layer also checks for conflicts before inserting, providing
+ *    a fast-path 409 response without a DB round-trip on the happy path.
+ *    The DB constraint is the authoritative last line of defence under
+ *    concurrent requests.
+ */
+export const migration: Migration = {
+  id: "003",
+  name: "add_slot_conflict_exclusion",
+
+  async up(client: PoolClient): Promise<void> {
+    // btree_gist is required to mix equality (=) and range (&&) operators
+    // in a single EXCLUDE constraint.
+    await client.query(`CREATE EXTENSION IF NOT EXISTS btree_gist`);
+
+    await client.query(`
+      ALTER TABLE slots
+        ADD CONSTRAINT excl_slots_no_overlap
+        EXCLUDE USING gist (
+          professional_id WITH =,
+          tstzrange(start_time, end_time) WITH &&
+        )
+    `);
+  },
+
+  async down(client: PoolClient): Promise<void> {
+    await client.query(`
+      ALTER TABLE slots DROP CONSTRAINT IF EXISTS excl_slots_no_overlap
+    `);
+    // We intentionally do NOT drop btree_gist — other constraints may rely on it.
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -11,8 +11,9 @@
 import { Migration } from "../migrationRunner.js";
 import { migration as migration001 } from "./001_create_users_table.js";
 import { migration as migration002 } from "./002_create_slots_table.js";
+import { migration as migration003 } from "./003_add_slot_conflict_exclusion.js";
 
-export const migrations: Migration[] = [migration001, migration002];
+export const migrations: Migration[] = [migration001, migration002, migration003];
 
 // ─── Duplicate-ID guard ───────────────────────────────────────────────────────
 // This runs once when the module is first imported. Fail-fast here is safer

--- a/src/modules/slots/slot-repository.ts
+++ b/src/modules/slots/slot-repository.ts
@@ -9,6 +9,17 @@ export interface SlotRecord {
 export interface SlotRepository {
   list(): SlotRecord[];
   findById(slotId: string): SlotRecord | undefined;
+  /**
+   * Returns true if any existing slot for the same professional overlaps
+   * [startTime, endTime). Adjacency (end == start) is NOT a conflict.
+   * Optionally excludes a slot by id (used during updates).
+   */
+  hasConflict(
+    professional: string,
+    startTime: number,
+    endTime: number,
+    excludeId?: string,
+  ): boolean;
 }
 
 const DEFAULT_SLOTS: SlotRecord[] = [
@@ -49,5 +60,20 @@ export class InMemorySlotRepository implements SlotRepository {
   findById(slotId: string): SlotRecord | undefined {
     const slot = this.slots.find((entry) => entry.id === slotId);
     return slot ? { ...slot } : undefined;
+  }
+
+  hasConflict(
+    professional: string,
+    startTime: number,
+    endTime: number,
+    excludeId?: string,
+  ): boolean {
+    return this.slots.some(
+      (s) =>
+        s.professional === professional &&
+        s.id !== excludeId &&
+        s.startTime < endTime &&
+        s.endTime > startTime,
+    );
   }
 }

--- a/src/services/slotService.ts
+++ b/src/services/slotService.ts
@@ -1,9 +1,229 @@
 import { PaginatedSlots, Slot } from "../types.js";
 import { getSlotsCount, getSlotsPage } from "../repositories/slotRepository.js";
+import { InMemoryCache } from "../cache/inMemoryCache.js";
 
 const MAX_LIMIT = 100;
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 10;
+
+export const SLOT_LIST_CACHE_TTL_MS = 60_000;
+const SLOT_LIST_CACHE_KEY = "slots:list:all";
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export class SlotValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SlotValidationError";
+  }
+}
+
+export class SlotNotFoundError extends Error {
+  constructor(id: number) {
+    super(`Slot ${id} was not found`);
+    this.name = "SlotNotFoundError";
+  }
+}
+
+export class SlotConflictError extends Error {
+  constructor() {
+    super("Slot overlaps with an existing reservation for this professional");
+    this.name = "SlotConflictError";
+  }
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SlotInput {
+  professional: string;
+  startTime: number;
+  endTime: number;
+}
+
+export interface SlotRecord {
+  id: number;
+  professional: string;
+  startTime: number;
+  endTime: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type { SlotRecord as Slot };
+
+// ─── SlotService ──────────────────────────────────────────────────────────────
+
+export class SlotService {
+  private slots: SlotRecord[] = [];
+  private nextId = 1;
+  private readonly cache: InMemoryCache<SlotRecord[]> | null;
+  private readonly clock: () => Date;
+
+  /**
+   * @param cacheOrClock - Either an InMemoryCache instance (with optional clock
+   *   as second arg), or a clock function directly (cache disabled).
+   */
+  constructor(
+    cacheOrClock?: InMemoryCache<SlotRecord[]> | (() => Date),
+    clock?: () => Date,
+  ) {
+    if (typeof cacheOrClock === "function") {
+      this.cache = null;
+      this.clock = cacheOrClock;
+    } else {
+      this.cache = cacheOrClock ?? null;
+      this.clock = clock ?? (() => new Date());
+    }
+  }
+
+  // ── Validation helpers ──────────────────────────────────────────────────────
+
+  private static validateInput(input: SlotInput): void {
+    if (typeof input.professional !== "string" || input.professional.trim() === "") {
+      throw new SlotValidationError("professional must be a non-empty string");
+    }
+    if (!Number.isFinite(input.startTime) || !Number.isFinite(input.endTime)) {
+      throw new SlotValidationError("startTime and endTime must be finite numbers");
+    }
+    if (input.endTime <= input.startTime) {
+      throw new SlotValidationError("endTime must be greater than startTime");
+    }
+  }
+
+  // ── Conflict detection ──────────────────────────────────────────────────────
+
+  /**
+   * Returns true if any existing slot for the same professional overlaps the
+   * given half-open interval [startTime, endTime).
+   * Adjacency (end == start of another) is NOT a conflict.
+   */
+  hasConflict(
+    professional: string,
+    startTime: number,
+    endTime: number,
+    excludeId?: number,
+  ): boolean {
+    return this.slots.some(
+      (s) =>
+        s.professional === professional &&
+        s.id !== excludeId &&
+        s.startTime < endTime &&
+        s.endTime > startTime,
+    );
+  }
+
+  // ── CRUD ────────────────────────────────────────────────────────────────────
+
+  createSlot(input: SlotInput): SlotRecord {
+    SlotService.validateInput(input);
+
+    const professional = input.professional.trim();
+
+    if (this.hasConflict(professional, input.startTime, input.endTime)) {
+      throw new SlotConflictError();
+    }
+
+    const now = this.clock().toISOString();
+    const slot: SlotRecord = {
+      id: this.nextId++,
+      professional,
+      startTime: input.startTime,
+      endTime: input.endTime,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.slots.push(slot);
+    this.cache?.invalidate(SLOT_LIST_CACHE_KEY);
+
+    return { ...slot };
+  }
+
+  updateSlot(
+    id: number,
+    patch: Partial<Pick<SlotInput, "professional" | "startTime" | "endTime">>,
+  ): SlotRecord {
+    if (patch === null || typeof patch !== "object") {
+      throw new SlotValidationError("update payload must be an object");
+    }
+
+    if (Object.keys(patch).length === 0) {
+      throw new SlotValidationError("update payload must include at least one field");
+    }
+
+    const index = this.slots.findIndex((s) => s.id === id);
+    if (index === -1) {
+      throw new SlotNotFoundError(id);
+    }
+
+    const existing = this.slots[index];
+
+    if ("professional" in patch) {
+      if (typeof patch.professional !== "string") {
+        throw new SlotValidationError("professional must be a string");
+      }
+    }
+
+    if (
+      ("startTime" in patch && !Number.isFinite(patch.startTime)) ||
+      ("endTime" in patch && !Number.isFinite(patch.endTime))
+    ) {
+      throw new SlotValidationError("startTime and endTime must be finite numbers");
+    }
+
+    const professional = (patch.professional?.trim() ?? existing.professional);
+    const startTime = patch.startTime ?? existing.startTime;
+    const endTime = patch.endTime ?? existing.endTime;
+
+    if (endTime <= startTime) {
+      throw new SlotValidationError("endTime must be greater than startTime");
+    }
+
+    if (this.hasConflict(professional, startTime, endTime, id)) {
+      throw new SlotConflictError();
+    }
+
+    const updated: SlotRecord = {
+      ...existing,
+      professional,
+      startTime,
+      endTime,
+      updatedAt: this.clock().toISOString(),
+    };
+
+    this.slots[index] = updated;
+    this.cache?.invalidate(SLOT_LIST_CACHE_KEY);
+
+    return { ...updated };
+  }
+
+  async listSlots(): Promise<{ slots: SlotRecord[]; cache: "hit" | "miss" }> {
+    if (this.cache) {
+      const result = await this.cache.getOrLoad(SLOT_LIST_CACHE_KEY, () =>
+        this.slots.map((s) => ({ ...s })),
+      );
+      return {
+        slots: result.value.map((s) => ({ ...s })),
+        cache: result.source === "cache" ? "hit" : "miss",
+      };
+    }
+
+    return { slots: this.slots.map((s) => ({ ...s })), cache: "miss" };
+  }
+
+  reset(): void {
+    this.slots = [];
+    this.nextId = 1;
+    this.cache?.clear();
+  }
+}
+
+/** Singleton used by route handlers. */
+export const slotService = new SlotService(
+  new InMemoryCache<SlotRecord[]>({ ttlMs: SLOT_LIST_CACHE_TTL_MS }),
+);
+
+// ─── Legacy functional API (kept for backward compatibility) ──────────────────
 
 export interface PaginationOptions {
   page?: number;
@@ -43,7 +263,6 @@ export const listSlots = async (
   const offset = (page - 1) * limit;
 
   if (offset >= total && total > 0) {
-    // requested page beyond number of items results empty data, keep page
     return {
       data: [],
       page,
@@ -64,6 +283,5 @@ export const listSlots = async (
 };
 
 export const listSlotsWithFailure = async (options: PaginationOptions): Promise<PaginatedSlots> => {
-  // wrapper for simulating DB failures in tests (not used in production)
   return listSlots(options);
 };


### PR DESCRIPTION
closes #143 

- Add hasConflict() to SlotRepository interface and InMemorySlotRepository using half-open interval semantics (adjacency is not a conflict)
- Add SlotService class with createSlot/updateSlot conflict detection; throws SlotConflictError (409) on overlap
- Add migration 003: PostgreSQL EXCLUDE USING gist constraint as DB-level guard against concurrent races past the service layer
- Add 31 tests covering all overlap/adjacency/concurrency edge cases
- Add docs/api/slots.md documenting conflict semantics and two-layer defence