### PR TITLE
feat: standardize dependency outage responses

### DIFF
--- a/docs/reliability/dependency-outages.md
+++ b/docs/reliability/dependency-outages.md
@@ -1,0 +1,87 @@
+# Dependency Outage Handling
+
+This document describes how ChronoPay handles Redis and database outages consistently and safely.
+
+## Overview
+
+When a required dependency (Redis or PostgreSQL) is unavailable, the API fails **closed** — it returns a deterministic `503 Service Unavailable` response rather than silently degrading or allowing unsafe partial processing.
+
+## 503 Payload Shape
+
+All dependency-outage responses use the same envelope:
+
+```json
+{
+  "success": false,
+  "code": "DEPENDENCY_UNAVAILABLE",
+  "error": "<dependency> is currently unavailable"
+}
+```
+
+This matches the existing `FEATURE_DISABLED` envelope shape used by feature flags, giving clients a single consistent pattern to handle.
+
+## Components
+
+### `src/middleware/dependencyStatus.ts`
+
+Centralized status provider. Exposes one function:
+
+```ts
+isDependencyAvailable(dep: "redis" | "db"): Promise<boolean>
+```
+
+- **redis** — delegates to `isRedisReady()` from `src/cache/redisClient.ts` (synchronous flag set by lifecycle events).
+- **db** — runs a lightweight `SELECT 1` probe against the pool. The probe is injectable via `_setDbReadyProbe()` for tests.
+
+Internal connection strings and error details are never surfaced to callers.
+
+### `src/middleware/requireDependency.ts`
+
+Middleware factory for route-level dependency guards:
+
+```ts
+router.post("/api/v1/slots", requireDependency("redis"), handler);
+```
+
+Returns `503 DEPENDENCY_UNAVAILABLE` immediately if the dependency is down; calls `next()` otherwise.
+
+### `src/middleware/idempotency.ts` (updated)
+
+Previously passed through (`next()`) when Redis was unavailable. Now **fails closed**: if the Redis client is `null` and an `Idempotency-Key` header is present, the middleware returns `503 DEPENDENCY_UNAVAILABLE` without calling `next()`.
+
+Rationale: without Redis, idempotency guarantees cannot be upheld. Allowing the request through would risk duplicate processing of financial operations.
+
+### `src/middleware/errorHandling.ts` (updated)
+
+`genericErrorHandler` now emits the consistent `{ success, code, error }` envelope for **any** `AppError`-shaped error (i.e., any `Error` with `statusCode` and `code` properties). Previously only `415`/`406` errors were handled this way.
+
+## Behavior by Scenario
+
+| Scenario | Endpoint behavior |
+|---|---|
+| Redis down, `Idempotency-Key` present | `503 DEPENDENCY_UNAVAILABLE` |
+| Redis down, no `Idempotency-Key` | Request proceeds normally (idempotency is opt-in) |
+| DB down, route guarded with `requireDependency("db")` | `503 DEPENDENCY_UNAVAILABLE` |
+| Both down, route guarded with `requireDependency("redis")` | `503 DEPENDENCY_UNAVAILABLE` (Redis checked first) |
+| `ServiceUnavailableError` thrown and caught by `genericErrorHandler` | `503 SERVICE_UNAVAILABLE` with consistent envelope |
+
+## Security Notes
+
+- Error responses never include connection strings, hostnames, credentials, or stack traces.
+- The dependency name in the error message is a static label (`"Redis"` / `"Database"`), not derived from any runtime value.
+- The `_setDbReadyProbe()` and `_setDbReadyProbe()` escape hatches are marked `@internal` and are only used in tests — they are not exported from any public barrel.
+
+## Testing
+
+Tests live in `src/__tests__/dependency-outage.test.ts` and cover:
+
+- `isDependencyAvailable` with Redis up/down and DB up/down
+- `requireDependency` middleware: 503 when down, pass-through when up, partial outage (redis down + db up)
+- Idempotency fail-closed: 503 returned, `next()` not called
+- `genericErrorHandler`: consistent envelope for `ServiceUnavailableError`, generic AppError-shaped errors, and regression for `415`/`406`
+
+Run with:
+
+```bash
+npm test -- --testPathPattern dependency-outage
+```

--- a/src/__tests__/dependency-outage.test.ts
+++ b/src/__tests__/dependency-outage.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for dependency outage handling (#116).
+ *
+ * Covers:
+ *  - dependencyStatus: redis down, redis up, db down, db up
+ *  - requireDependency middleware: 503 when down, passes through when up
+ *  - idempotency middleware: fail-closed (503) when Redis is null
+ *  - genericErrorHandler: consistent {success,code,error} envelope for AppError-shaped errors
+ */
+
+import { jest, describe, it, expect, afterEach } from "@jest/globals";
+import type { Request, Response, NextFunction } from "express";
+import express from "express";
+import request from "supertest";
+
+// ── dependency status ────────────────────────────────────────────────────────
+
+import {
+  isDependencyAvailable,
+  _setRedisReadyProbe,
+  _setDbReadyProbe,
+} from "../middleware/dependencyStatus.js";
+
+describe("isDependencyAvailable", () => {
+  afterEach(() => {
+    // Reset probes to defaults that return false (safe baseline)
+    _setRedisReadyProbe(() => false);
+    _setDbReadyProbe(async () => false);
+  });
+
+  describe("redis", () => {
+    it("returns false when the redis probe returns false", async () => {
+      _setRedisReadyProbe(() => false);
+      await expect(isDependencyAvailable("redis")).resolves.toBe(false);
+    });
+
+    it("returns true when the redis probe returns true", async () => {
+      _setRedisReadyProbe(() => true);
+      await expect(isDependencyAvailable("redis")).resolves.toBe(true);
+    });
+  });
+
+  describe("db", () => {
+    it("returns false when the db probe returns false", async () => {
+      _setDbReadyProbe(async () => false);
+      await expect(isDependencyAvailable("db")).resolves.toBe(false);
+    });
+
+    it("returns true when the db probe returns true", async () => {
+      _setDbReadyProbe(async () => true);
+      await expect(isDependencyAvailable("db")).resolves.toBe(true);
+    });
+  });
+});
+
+// ── requireDependency middleware ─────────────────────────────────────────────
+
+import { requireDependency } from "../middleware/requireDependency.js";
+
+function makeMiddlewareApp(dep: "redis" | "db") {
+  const app = express();
+  app.use(express.json());
+  app.get("/test", requireDependency(dep), (_req, res) => {
+    res.json({ success: true });
+  });
+  return app;
+}
+
+describe("requireDependency middleware", () => {
+  afterEach(() => {
+    _setRedisReadyProbe(() => false);
+    _setDbReadyProbe(async () => false);
+  });
+
+  describe("redis dependency", () => {
+    it("returns 503 with DEPENDENCY_UNAVAILABLE when Redis is down", async () => {
+      _setRedisReadyProbe(() => false);
+      const res = await request(makeMiddlewareApp("redis")).get("/test");
+      expect(res.status).toBe(503);
+      expect(res.body).toEqual({
+        success: false,
+        code: "DEPENDENCY_UNAVAILABLE",
+        error: "Redis is currently unavailable",
+      });
+    });
+
+    it("passes through when Redis is up", async () => {
+      _setRedisReadyProbe(() => true);
+      const res = await request(makeMiddlewareApp("redis")).get("/test");
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+
+  describe("db dependency", () => {
+    it("returns 503 with DEPENDENCY_UNAVAILABLE when DB is down", async () => {
+      _setDbReadyProbe(async () => false);
+      const res = await request(makeMiddlewareApp("db")).get("/test");
+      expect(res.status).toBe(503);
+      expect(res.body).toEqual({
+        success: false,
+        code: "DEPENDENCY_UNAVAILABLE",
+        error: "Database is currently unavailable",
+      });
+    });
+
+    it("passes through when DB is up", async () => {
+      _setDbReadyProbe(async () => true);
+      const res = await request(makeMiddlewareApp("db")).get("/test");
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+
+  describe("partial outage (redis down, db up)", () => {
+    it("redis endpoint returns 503 while db endpoint returns 200", async () => {
+      _setRedisReadyProbe(() => false);
+      _setDbReadyProbe(async () => true);
+
+      const redisRes = await request(makeMiddlewareApp("redis")).get("/test");
+      const dbRes = await request(makeMiddlewareApp("db")).get("/test");
+
+      expect(redisRes.status).toBe(503);
+      expect(dbRes.status).toBe(200);
+    });
+  });
+});
+
+// ── idempotency middleware fail-closed ───────────────────────────────────────
+
+import { idempotencyMiddleware } from "../middleware/idempotency.js";
+import { setRedisClient } from "../cache/redisClient.js";
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: "POST",
+    originalUrl: "/api/v1/slots",
+    body: {},
+    header: jest.fn<(name: string) => string | undefined>().mockReturnValue("key-001"),
+    ...overrides,
+  } as unknown as Request;
+}
+
+function mockRes(): Response {
+  const res = {
+    status: jest.fn<Response["status"]>().mockReturnThis(),
+    json: jest.fn<Response["json"]>().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+}
+
+describe("idempotencyMiddleware — fail-closed on Redis outage", () => {
+  afterEach(() => {
+    setRedisClient(null);
+  });
+
+  it("returns 503 DEPENDENCY_UNAVAILABLE when Redis client is null", async () => {
+    setRedisClient(null);
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await idempotencyMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: "DEPENDENCY_UNAVAILABLE",
+      error: "Redis is currently unavailable",
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call next() when Redis is down (fail-closed, not fail-open)", async () => {
+    setRedisClient(null);
+    const next = jest.fn() as unknown as NextFunction;
+    await idempotencyMiddleware(mockReq(), mockRes(), next);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next() when no Idempotency-Key header is present (opt-in)", async () => {
+    setRedisClient(null);
+    const req = mockReq({
+      header: jest.fn<(name: string) => string | undefined>().mockReturnValue(undefined),
+    });
+    const next = jest.fn() as unknown as NextFunction;
+    await idempotencyMiddleware(req, mockRes(), next);
+    // No key → middleware is bypassed regardless of Redis state
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+// ── genericErrorHandler consistent 503 envelope ──────────────────────────────
+
+import {
+  genericErrorHandler,
+  notFoundHandler,
+  jsonParseErrorHandler,
+} from "../middleware/errorHandling.js";
+import { ServiceUnavailableError } from "../errors/AppError.js";
+
+function makeErrorApp(thrownError: unknown) {
+  const app = express();
+  app.get("/boom", (_req, _res, next) => next(thrownError));
+  app.use(notFoundHandler);
+  app.use(jsonParseErrorHandler);
+  app.use(genericErrorHandler);
+  return app;
+}
+
+describe("genericErrorHandler", () => {
+  it("returns 503 with consistent envelope for ServiceUnavailableError", async () => {
+    const err = new ServiceUnavailableError("Redis is currently unavailable");
+    const res = await request(makeErrorApp(err)).get("/boom");
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      success: false,
+      code: "SERVICE_UNAVAILABLE",
+      error: "Redis is currently unavailable",
+    });
+  });
+
+  it("returns 503 for a generic AppError-shaped dependency error", async () => {
+    const err = Object.assign(new Error("DB gone"), {
+      statusCode: 503,
+      code: "DEPENDENCY_UNAVAILABLE",
+    });
+    const res = await request(makeErrorApp(err)).get("/boom");
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      success: false,
+      code: "DEPENDENCY_UNAVAILABLE",
+      error: "DB gone",
+    });
+  });
+
+  it("returns 415 envelope for UNSUPPORTED_MEDIA_TYPE (regression)", async () => {
+    const err = Object.assign(new Error("Unsupported Media Type"), {
+      statusCode: 415,
+      code: "UNSUPPORTED_MEDIA_TYPE",
+    });
+    const res = await request(makeErrorApp(err)).get("/boom");
+    expect(res.status).toBe(415);
+    expect(res.body.code).toBe("UNSUPPORTED_MEDIA_TYPE");
+  });
+
+  it("returns 500 for plain Error (no statusCode/code)", async () => {
+    const res = await request(makeErrorApp(new Error("boom"))).get("/boom");
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/src/__tests__/idempotency.test.ts
+++ b/src/__tests__/idempotency.test.ts
@@ -102,7 +102,7 @@ describe.skip("Idempotency Middleware (integration)", () => {
     expect(redis.get).not.toHaveBeenCalled();
   });
 
-  it("bypasses idempotency when Redis is unavailable", async () => {
+  it("returns 503 DEPENDENCY_UNAVAILABLE when Redis is unavailable (fail-closed)", async () => {
     setRedisClient(null);
     const req = mockRequest({
       method: "POST",
@@ -115,7 +115,13 @@ describe.skip("Idempotency Middleware (integration)", () => {
 
     await idempotencyMiddleware(req, res, next);
 
-    expect(next).toHaveBeenCalledWith();
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: "DEPENDENCY_UNAVAILABLE",
+      error: "Redis is currently unavailable",
+    });
+    expect(next).not.toHaveBeenCalled();
   });
 
   it("replays a stored completed response", async () => {

--- a/src/middleware/dependencyStatus.ts
+++ b/src/middleware/dependencyStatus.ts
@@ -1,0 +1,60 @@
+/**
+ * Centralized dependency status provider.
+ *
+ * Exposes a single `isDependencyAvailable(dep)` function that returns whether
+ * a named dependency (redis | db) is currently healthy.  Callers never touch
+ * the underlying clients directly, which keeps the status logic in one place
+ * and makes it easy to stub in tests.
+ *
+ * Security note: status checks never surface connection strings, credentials,
+ * or internal error details to callers.
+ */
+
+import { isRedisReady } from "../cache/redisClient.js";
+
+export type Dependency = "redis" | "db";
+
+/**
+ * Replaceable Redis-ready probe — defaults to `isRedisReady()`.
+ * Tests override this via `_setRedisReadyProbe()`.
+ * @internal
+ */
+let _redisReadyProbe: () => boolean = () => isRedisReady();
+
+/** @internal — for test injection only */
+export function _setRedisReadyProbe(probe: () => boolean): void {
+  _redisReadyProbe = probe;
+}
+
+/**
+ * Replaceable DB-ready probe — defaults to a live pool query.
+ * Tests override this via `_setDbReadyProbe()`.
+ * @internal
+ */
+let _dbReadyProbe: () => Promise<boolean> = async () => {
+  try {
+    const { getPool } = await import("../db/connection.js");
+    await getPool().query("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** @internal — for test injection only */
+export function _setDbReadyProbe(probe: () => Promise<boolean>): void {
+  _dbReadyProbe = probe;
+}
+
+/**
+ * Returns true when the named dependency is available.
+ *
+ * - `redis`: delegates to the Redis-ready probe (sync).
+ * - `db`:    runs a lightweight `SELECT 1` probe (async).
+ */
+export async function isDependencyAvailable(dep: Dependency): Promise<boolean> {
+  if (dep === "redis") {
+    return _redisReadyProbe();
+  }
+  return _dbReadyProbe();
+}

--- a/src/middleware/errorHandling.ts
+++ b/src/middleware/errorHandling.ts
@@ -35,10 +35,9 @@ export function genericErrorHandler(
     "code" in err
   ) {
     const e = err as any;
-    if (
-      (e.statusCode === 415 || e.statusCode === 406) &&
-      (e.code === "UNSUPPORTED_MEDIA_TYPE" || e.code === "NOT_ACCEPTABLE")
-    ) {
+    // Emit a consistent envelope for any AppError-shaped error (includes
+    // ServiceUnavailableError / 503 from dependency outages).
+    if (typeof e.statusCode === "number" && typeof e.code === "string") {
       return res.status(e.statusCode).json({
         success: false,
         code: e.code,

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -33,7 +33,13 @@ export const idempotencyMiddleware = async (
 
   const redis = getRedisClient();
   if (!redis) {
-    next();
+    // Fail closed: without Redis we cannot guarantee idempotency, so reject
+    // rather than silently allowing duplicate processing.
+    res.status(503).json({
+      success: false,
+      code: "DEPENDENCY_UNAVAILABLE",
+      error: "Redis is currently unavailable",
+    });
     return;
   }
 

--- a/src/middleware/requireDependency.ts
+++ b/src/middleware/requireDependency.ts
@@ -1,0 +1,36 @@
+/**
+ * Middleware factory that fails closed with a consistent 503 payload when a
+ * named dependency (redis | db) is unavailable.
+ *
+ * Usage:
+ *   router.post("/api/v1/slots", requireDependency("redis"), handler);
+ *
+ * 503 payload shape (matches featureFlags.ts convention):
+ *   { success: false, code: "DEPENDENCY_UNAVAILABLE", error: "<message>" }
+ *
+ * Security note: the error message names the dependency type only — no
+ * connection strings, hostnames, or internal error details are exposed.
+ */
+
+import type { NextFunction, Request, Response } from "express";
+import { isDependencyAvailable, type Dependency } from "./dependencyStatus.js";
+
+const DEPENDENCY_LABELS: Record<Dependency, string> = {
+  redis: "Redis",
+  db: "Database",
+};
+
+export function requireDependency(dep: Dependency) {
+  return async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const available = await isDependencyAvailable(dep);
+    if (!available) {
+      res.status(503).json({
+        success: false,
+        code: "DEPENDENCY_UNAVAILABLE",
+        error: `${DEPENDENCY_LABELS[dep]} is currently unavailable`,
+      });
+      return;
+    }
+    next();
+  };
+}


### PR DESCRIPTION
Closes #116 
- Add centralized dependencyStatus provider (isDependencyAvailable) with injectable probes for Redis and DB (testable without ESM spy hacks)
- Add requireDependency middleware factory for route-level guards
- Idempotency middleware now fails closed (503) when Redis is null instead of silently passing through (fail-open)
- genericErrorHandler emits consistent {success,code,error} envelope for all AppError-shaped errors, not just 415/406
- 16 new tests: redis/db up+down, partial outage, fail-closed idempotency, error handler envelope regression
- docs/reliability/dependency-outages.md

Closes #116