### PR TITLE
feat: add tracing spans for core flows

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,150 @@
+# Tracing Conventions
+
+ChronoPay uses **AsyncLocalStorage**-based distributed tracing. Spans are
+lightweight in-process records; no external collector is required to run the
+service, but one can be plugged in via the exporter API.
+
+## Architecture
+
+```
+Request
+  └─ tracingMiddleware          (creates root TraceContext in AsyncLocalStorage)
+       └─ route handler
+            └─ withSpan(...)    (creates child span, propagates context)
+                 └─ service method
+                      └─ withSpan(...)   (nested child span)
+```
+
+### Key modules
+
+| File | Purpose |
+|---|---|
+| `src/tracing/context.ts` | `TraceContext`, `AsyncLocalStorage`, `runWithTraceContext`, `createChildContext` |
+| `src/tracing/middleware.ts` | `tracingMiddleware` — extracts/generates trace headers, seeds root context |
+| `src/tracing/hooks.ts` | `withSpan` — wraps work in a child span; `getCurrentSpan` |
+| `src/tracing/spanExporter.ts` | `addSpanExporter` / `removeSpanExporter` / `emitSpan` — pluggable sink |
+| `src/tracing/index.ts` | Barrel re-export of all public symbols |
+
+## HTTP headers
+
+| Header | Direction | Purpose |
+|---|---|---|
+| `x-trace-id` | in + out | Identifies the full request path across services |
+| `x-span-id` | out | Identifies the root span for this service |
+| `x-parent-span-id` | in | Caller's span ID (for cross-service linking) |
+
+## Span naming convention
+
+Use `<domain>.<operation>` in lower-case:
+
+```
+slots.create
+slots.update
+slots.list
+checkout.createSession
+checkout.getSession
+checkout.completeSession
+checkout.cancelSession
+bookingIntents.create
+```
+
+## Stable span attributes
+
+Every span records these attributes automatically via `withSpan`:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `route` | string | HTTP method + path template, e.g. `POST /api/v1/slots` |
+| `outcome` | `"ok"` \| `"error"` | Whether the operation succeeded |
+| `latency` | number | Duration in milliseconds |
+| `error` | boolean | Present and `true` only on failure |
+| `error.message` | string | Sanitised error message (no stack trace) |
+
+Additional domain-specific attributes (e.g. `slotId`, `paymentMethod`) may be
+added when they are **not PII**.
+
+## Security rules — what must NOT appear in span attributes
+
+- Email addresses, phone numbers, names
+- Customer IDs, user IDs, session tokens
+- Payment card numbers, bank account details
+- Any value derived from user-supplied free-text
+
+If you need to correlate a span with a user for debugging, use the `requestId`
+(from `x-request-id`) which is already present in logs.
+
+## Adding a span
+
+```typescript
+import { withSpan } from "../tracing/index.js";
+
+// In a service method:
+async function doWork(input: Input): Promise<Result> {
+  return withSpan("domain.operation", { route: "POST /api/v1/resource" }, async () => {
+    // ... your logic
+  });
+}
+```
+
+`withSpan` automatically:
+- Creates a child `TraceContext` linked to the current parent
+- Records `outcome`, `latency`, `error`, `error.message`
+- Emits the span to all registered exporters
+
+## Plugging in a span exporter
+
+```typescript
+import { addSpanExporter, removeSpanExporter } from "../tracing/index.js";
+import type { Span } from "../tracing/index.js";
+
+const myExporter = (span: Span) => {
+  // send to your collector
+};
+
+addSpanExporter(myExporter);
+// later:
+removeSpanExporter(myExporter);
+```
+
+Exporters must not throw — any exception is silently swallowed to protect the
+request path.
+
+## Enabling debug logging
+
+Set `DEBUG_TRACING=true` to print every span to stdout:
+
+```bash
+DEBUG_TRACING=true npm run dev
+```
+
+## Propagating context to outbound calls
+
+Use `getPropagationHeaders()` to forward the current trace context:
+
+```typescript
+import { getPropagationHeaders } from "../tracing/index.js";
+
+const headers = getPropagationHeaders();
+// { "x-trace-id": "...", "x-parent-span-id": "..." }
+await fetch(upstreamUrl, { headers: { ...headers } });
+```
+
+## Testing
+
+Use `addSpanExporter` / `removeSpanExporter` to capture spans in tests:
+
+```typescript
+import { addSpanExporter, removeSpanExporter } from "../tracing/index.js";
+import type { Span } from "../tracing/index.js";
+
+const spans: Span[] = [];
+const exporter = (s: Span) => spans.push(s);
+addSpanExporter(exporter);
+
+// ... exercise code under test ...
+
+removeSpanExporter(exporter);
+expect(spans[0].attributes.outcome).toBe("ok");
+```
+
+See `src/__tests__/tracing-spans.test.ts` for full examples.

--- a/src/__tests__/tracing-spans.test.ts
+++ b/src/__tests__/tracing-spans.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for core flow tracing spans (issue #131).
+ *
+ * Covers:
+ *  - spanExporter: registration, removal, emit
+ *  - withSpan: ok path, error path, nested/async propagation
+ *  - SlotService traced wrappers
+ *  - CheckoutSessionService traced wrappers
+ *  - BookingIntentService traced wrapper
+ *  - No PII in span attributes
+ */
+
+import { runWithTraceContext, getTraceContext } from "../tracing/context.js";
+import { withSpan, getCurrentSpan } from "../tracing/hooks.js";
+import {
+  addSpanExporter,
+  removeSpanExporter,
+  emitSpan,
+} from "../tracing/spanExporter.js";
+import type { Span } from "../tracing/hooks.js";
+import { SlotService } from "../services/slotService.js";
+import { CheckoutSessionService } from "../services/checkout.js";
+import { BookingIntentService } from "../modules/booking-intents/booking-intent-service.js";
+import { InMemoryBookingIntentRepository } from "../modules/booking-intents/booking-intent-repository.js";
+import { InMemorySlotRepository } from "../modules/slots/slot-repository.js";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function collectSpans(): { spans: Span[]; cleanup: () => void } {
+  const spans: Span[] = [];
+  const exporter = (s: Span) => spans.push(s);
+  addSpanExporter(exporter);
+  return { spans, cleanup: () => removeSpanExporter(exporter) };
+}
+
+// ─── spanExporter ─────────────────────────────────────────────────────────────
+
+describe("spanExporter", () => {
+  it("calls registered exporter with emitted span", () => {
+    const received: Span[] = [];
+    const fn = (s: Span) => received.push(s);
+    addSpanExporter(fn);
+
+    const span: Span = {
+      name: "test",
+      traceId: "t1",
+      spanId: "s1",
+      startTime: Date.now(),
+      endTime: Date.now(),
+      duration: 1,
+      attributes: { outcome: "ok", latency: 1 },
+    };
+    emitSpan(span);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].name).toBe("test");
+    removeSpanExporter(fn);
+  });
+
+  it("does not call exporter after removal", () => {
+    const received: Span[] = [];
+    const fn = (s: Span) => received.push(s);
+    addSpanExporter(fn);
+    removeSpanExporter(fn);
+
+    emitSpan({ name: "x", traceId: "t", spanId: "s", startTime: 0, attributes: {} });
+    expect(received).toHaveLength(0);
+  });
+
+  it("swallows exporter errors so the request is not affected", () => {
+    const boom = () => { throw new Error("exporter crash"); };
+    addSpanExporter(boom);
+    expect(() =>
+      emitSpan({ name: "x", traceId: "t", spanId: "s", startTime: 0, attributes: {} }),
+    ).not.toThrow();
+    removeSpanExporter(boom);
+  });
+});
+
+// ─── withSpan ─────────────────────────────────────────────────────────────────
+
+describe("withSpan", () => {
+  it("records outcome=ok and latency on success", async () => {
+    const { spans, cleanup } = collectSpans();
+    await withSpan("op.success", { route: "GET /test" }, async () => "result");
+    cleanup();
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].attributes.outcome).toBe("ok");
+    expect(typeof spans[0].attributes.latency).toBe("number");
+    expect(spans[0].attributes.error).toBeUndefined();
+  });
+
+  it("records outcome=error and error.message on failure", async () => {
+    const { spans, cleanup } = collectSpans();
+    await expect(
+      withSpan("op.fail", {}, async () => { throw new Error("boom"); }),
+    ).rejects.toThrow("boom");
+    cleanup();
+
+    expect(spans[0].attributes.outcome).toBe("error");
+    expect(spans[0].attributes.error).toBe(true);
+    expect(spans[0].attributes["error.message"]).toBe("boom");
+  });
+
+  it("propagates async context so child can read parent traceId", async () => {
+    const parentCtx = {
+      traceId: "parent-trace",
+      spanId: "parent-span",
+      startTime: Date.now(),
+    };
+
+    await runWithTraceContext(parentCtx, async () => {
+      await withSpan("child.op", {}, async (span) => {
+        // child span must inherit the parent traceId
+        expect(span.traceId).toBe("parent-trace");
+        expect(span.parentSpanId).toBe("parent-span");
+      });
+    });
+  });
+
+  it("nested spans each get unique spanIds", async () => {
+    const { spans, cleanup } = collectSpans();
+    await withSpan("outer", {}, async () => {
+      await withSpan("inner", {}, async () => "done");
+    });
+    cleanup();
+
+    expect(spans).toHaveLength(2);
+    expect(spans[0].spanId).not.toBe(spans[1].spanId);
+  });
+
+  it("does not include PII fields in attributes", async () => {
+    const { spans, cleanup } = collectSpans();
+    await withSpan("slots.create", { route: "POST /api/v1/slots" }, async () => "ok");
+    cleanup();
+
+    const attrs = spans[0].attributes;
+    const keys = Object.keys(attrs);
+    const piiKeys = ["email", "password", "token", "customerId", "userId", "phone"];
+    for (const pii of piiKeys) {
+      expect(keys).not.toContain(pii);
+    }
+  });
+
+  it("getCurrentSpan returns context inside withSpan", async () => {
+    await withSpan("ctx.check", {}, async () => {
+      const current = getCurrentSpan();
+      expect(current).toBeDefined();
+      expect(current?.traceId).toBeDefined();
+    });
+  });
+
+  it("getCurrentSpan returns undefined outside any context", () => {
+    expect(getCurrentSpan()).toBeUndefined();
+  });
+});
+
+// ─── SlotService traced wrappers ──────────────────────────────────────────────
+
+describe("SlotService traced wrappers", () => {
+  let service: SlotService;
+
+  beforeEach(() => {
+    service = new SlotService();
+  });
+
+  it("createSlotTraced emits a span with route attribute", async () => {
+    const { spans, cleanup } = collectSpans();
+    await service.createSlotTraced({ professional: "alice", startTime: 1000, endTime: 2000 });
+    cleanup();
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("slots.create");
+    expect(spans[0].attributes.route).toBe("POST /api/v1/slots");
+    expect(spans[0].attributes.outcome).toBe("ok");
+  });
+
+  it("createSlotTraced records error outcome on validation failure", async () => {
+    const { spans, cleanup } = collectSpans();
+    await expect(
+      service.createSlotTraced({ professional: "", startTime: 1000, endTime: 2000 }),
+    ).rejects.toThrow();
+    cleanup();
+
+    expect(spans[0].attributes.outcome).toBe("error");
+    expect(spans[0].attributes.error).toBe(true);
+  });
+
+  it("updateSlotTraced emits a span with slotId attribute", async () => {
+    const slot = service.createSlot({ professional: "bob", startTime: 100, endTime: 200 });
+    const { spans, cleanup } = collectSpans();
+    await service.updateSlotTraced(slot.id, { endTime: 300 });
+    cleanup();
+
+    expect(spans[0].name).toBe("slots.update");
+    expect(spans[0].attributes.slotId).toBe(slot.id);
+    expect(spans[0].attributes.outcome).toBe("ok");
+  });
+
+  it("updateSlotTraced records error on not-found", async () => {
+    const { spans, cleanup } = collectSpans();
+    await expect(service.updateSlotTraced(9999, { endTime: 300 })).rejects.toThrow();
+    cleanup();
+
+    expect(spans[0].attributes.outcome).toBe("error");
+  });
+
+  it("listSlotsTraced emits a span", async () => {
+    const { spans, cleanup } = collectSpans();
+    await service.listSlotsTraced();
+    cleanup();
+
+    expect(spans[0].name).toBe("slots.list");
+    expect(spans[0].attributes.route).toBe("GET /api/v1/slots");
+    expect(spans[0].attributes.outcome).toBe("ok");
+  });
+});
+
+// ─── CheckoutSessionService traced wrappers ───────────────────────────────────
+
+describe("CheckoutSessionService traced wrappers", () => {
+  const validRequest = {
+    payment: { amount: 100, currency: "USD" as const, paymentMethod: "credit_card" as const },
+    customer: { customerId: "cust-1", email: "test@example.com" },
+  };
+
+  beforeEach(() => {
+    CheckoutSessionService.clearAllSessions();
+  });
+
+  it("createSessionTraced emits a span without PII", async () => {
+    const { spans, cleanup } = collectSpans();
+    await CheckoutSessionService.createSessionTraced(validRequest);
+    cleanup();
+
+    expect(spans[0].name).toBe("checkout.createSession");
+    expect(spans[0].attributes.outcome).toBe("ok");
+    // paymentMethod is safe; email/customerId must not appear
+    expect(spans[0].attributes.paymentMethod).toBe("credit_card");
+    expect(Object.keys(spans[0].attributes)).not.toContain("email");
+    expect(Object.keys(spans[0].attributes)).not.toContain("customerId");
+  });
+
+  it("getSessionTraced emits a span", async () => {
+    const session = CheckoutSessionService.createSession(validRequest);
+    const { spans, cleanup } = collectSpans();
+    await CheckoutSessionService.getSessionTraced(session.id);
+    cleanup();
+
+    expect(spans[0].name).toBe("checkout.getSession");
+    expect(spans[0].attributes.outcome).toBe("ok");
+  });
+
+  it("getSessionTraced records error for missing session", async () => {
+    const { spans, cleanup } = collectSpans();
+    await expect(
+      CheckoutSessionService.getSessionTraced("nonexistent-id"),
+    ).rejects.toThrow();
+    cleanup();
+
+    expect(spans[0].attributes.outcome).toBe("error");
+  });
+
+  it("completeSessionTraced emits a span", async () => {
+    const session = CheckoutSessionService.createSession(validRequest);
+    const { spans, cleanup } = collectSpans();
+    await CheckoutSessionService.completeSessionTraced(session.id);
+    cleanup();
+
+    expect(spans[0].name).toBe("checkout.completeSession");
+    expect(spans[0].attributes.outcome).toBe("ok");
+  });
+
+  it("cancelSessionTraced emits a span", async () => {
+    const session = CheckoutSessionService.createSession(validRequest);
+    const { spans, cleanup } = collectSpans();
+    await CheckoutSessionService.cancelSessionTraced(session.id);
+    cleanup();
+
+    expect(spans[0].name).toBe("checkout.cancelSession");
+    expect(spans[0].attributes.outcome).toBe("ok");
+  });
+});
+
+// ─── BookingIntentService traced wrapper ──────────────────────────────────────
+
+describe("BookingIntentService traced wrapper", () => {
+  function makeService() {
+    const slotRepo = new InMemorySlotRepository([
+      { id: "slot-1", professional: "pro-1", bookable: true, startTime: 1_900_000_000_000, endTime: 1_900_000_360_000 },
+    ]);
+    const intentRepo = new InMemoryBookingIntentRepository();
+    return new BookingIntentService(intentRepo, slotRepo);
+  }
+
+  it("createIntentTraced emits a span with route attribute", async () => {
+    const service = makeService();
+    const { spans, cleanup } = collectSpans();
+    await service.createIntentTraced(
+      { slotId: "slot-1" },
+      { userId: "cust-1", role: "customer" },
+    );
+    cleanup();
+
+    expect(spans[0].name).toBe("bookingIntents.create");
+    expect(spans[0].attributes.route).toBe("POST /api/v1/booking-intents");
+    expect(spans[0].attributes.outcome).toBe("ok");
+  });
+
+  it("createIntentTraced records error when slot not found", async () => {
+    const service = makeService();
+    const { spans, cleanup } = collectSpans();
+    await expect(
+      service.createIntentTraced({ slotId: "missing" }, { userId: "cust-1", role: "customer" }),
+    ).rejects.toThrow();
+    cleanup();
+
+    expect(spans[0].attributes.outcome).toBe("error");
+  });
+
+  it("createIntentTraced records error when professional tries to book own slot", async () => {
+    const service = makeService();
+    const { spans, cleanup } = collectSpans();
+    await expect(
+      service.createIntentTraced({ slotId: "slot-1" }, { userId: "pro-1", role: "customer" }),
+    ).rejects.toThrow();
+    cleanup();
+
+    expect(spans[0].attributes.outcome).toBe("error");
+    // userId must NOT appear in span attributes
+    expect(Object.keys(spans[0].attributes)).not.toContain("userId");
+  });
+});
+
+// ─── Async context propagation across await boundaries ────────────────────────
+
+describe("async context propagation", () => {
+  it("preserves traceId across multiple awaits", async () => {
+    const ctx = { traceId: "async-trace", spanId: "async-span", startTime: Date.now() };
+
+    await runWithTraceContext(ctx, async () => {
+      await Promise.resolve(); // yield
+      expect(getTraceContext()?.traceId).toBe("async-trace");
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(getTraceContext()?.traceId).toBe("async-trace");
+    });
+  });
+
+  it("isolates context between concurrent spans", async () => {
+    const results: string[] = [];
+
+    await Promise.all([
+      withSpan("span-a", {}, async () => {
+        await new Promise<void>((r) => setTimeout(r, 5));
+        results.push(getTraceContext()?.spanId ?? "none");
+      }),
+      withSpan("span-b", {}, async () => {
+        await new Promise<void>((r) => setTimeout(r, 2));
+        results.push(getTraceContext()?.spanId ?? "none");
+      }),
+    ]);
+
+    // Both spans ran and each had its own spanId
+    expect(results).toHaveLength(2);
+    expect(results[0]).not.toBe(results[1]);
+  });
+});

--- a/src/modules/booking-intents/booking-intent-service.ts
+++ b/src/modules/booking-intents/booking-intent-service.ts
@@ -4,6 +4,7 @@ import type {
   BookingIntentRecord,
   BookingIntentRepository,
 } from "./booking-intent-repository.js";
+import { withSpan } from "../../tracing/hooks.js";
 
 export interface CreateBookingIntentInput {
   slotId: string;
@@ -64,6 +65,14 @@ export class BookingIntentService {
       note: input.note,
       createdAt: this.now(),
     });
+  }
+
+  createIntentTraced(input: CreateBookingIntentInput, actor: AuthContext): Promise<BookingIntentRecord> {
+    return withSpan(
+      "bookingIntents.create",
+      { route: "POST /api/v1/booking-intents" },
+      () => this.createIntent(input, actor),
+    );
   }
 }
 

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -18,6 +18,7 @@ import {
   CheckoutErrorCode,
 } from "../types/checkout.js";
 import { defaultAuditLogger } from "./auditLogger.js";
+import { withSpan } from "../tracing/hooks.js";
 
 /**
  * Session storage configuration
@@ -322,5 +323,42 @@ export class CheckoutSessionService {
    */
   static getSessionCount(): number {
     return sessionStore.size;
+  }
+
+  // ── Traced wrappers ──────────────────────────────────────────────────────────
+
+  static createSessionTraced(
+    request: CreateCheckoutSessionRequest,
+    authorizationToken?: string,
+  ): Promise<CheckoutSession> {
+    return withSpan(
+      "checkout.createSession",
+      { route: "POST /api/v1/checkout/sessions", paymentMethod: request.payment.paymentMethod },
+      () => this.createSession(request, authorizationToken),
+    );
+  }
+
+  static getSessionTraced(sessionId: string): Promise<CheckoutSession> {
+    return withSpan(
+      "checkout.getSession",
+      { route: "GET /api/v1/checkout/sessions/:sessionId" },
+      () => this.getSession(sessionId),
+    );
+  }
+
+  static completeSessionTraced(sessionId: string, paymentToken?: string): Promise<CheckoutSession> {
+    return withSpan(
+      "checkout.completeSession",
+      { route: "POST /api/v1/checkout/sessions/:sessionId/complete" },
+      () => this.completeSession(sessionId, paymentToken),
+    );
+  }
+
+  static cancelSessionTraced(sessionId: string): Promise<CheckoutSession> {
+    return withSpan(
+      "checkout.cancelSession",
+      { route: "POST /api/v1/checkout/sessions/:sessionId/cancel" },
+      () => this.cancelSession(sessionId),
+    );
   }
 }

--- a/src/services/slotService.ts
+++ b/src/services/slotService.ts
@@ -1,7 +1,7 @@
 import { InMemoryCache } from "../cache/inMemoryCache.js";
 import { PaginatedSlots, Slot as PaginatedSlot } from "../types.js";
 import { getSlotsCount, getSlotsPage } from "../repositories/slotRepository.js";
-import { InMemoryCache } from "../cache/inMemoryCache.js";
+import { withSpan } from "../tracing/hooks.js";
 
 // Internal Slot type for SlotService
 export interface Slot {
@@ -150,6 +150,13 @@ export class SlotService {
     return { ...slot };
   }
 
+  /** Traced wrapper — use this from route handlers. */
+  createSlotTraced(input: SlotInput): Promise<SlotRecord> {
+    return withSpan("slots.create", { route: "POST /api/v1/slots" }, () =>
+      this.createSlot(input),
+    );
+  }
+
   updateSlot(
     id: number,
     patch: Partial<Pick<SlotInput, "professional" | "startTime" | "endTime">>,
@@ -208,6 +215,16 @@ export class SlotService {
     return { ...updated };
   }
 
+  /** Traced wrapper — use this from route handlers. */
+  updateSlotTraced(
+    id: number,
+    patch: Partial<Pick<SlotInput, "professional" | "startTime" | "endTime">>,
+  ): Promise<SlotRecord> {
+    return withSpan("slots.update", { route: "PATCH /api/v1/slots/:id", slotId: id }, () =>
+      this.updateSlot(id, patch),
+    );
+  }
+
   async listSlots(): Promise<{ slots: SlotRecord[]; cache: "hit" | "miss" }> {
     if (this.cache) {
       const result = await this.cache.getOrLoad(SLOT_LIST_CACHE_KEY, () =>
@@ -220,6 +237,13 @@ export class SlotService {
     }
 
     return { slots: this.slots.map((s) => ({ ...s })), cache: "miss" };
+  }
+
+  /** Traced wrapper — use this from route handlers. */
+  listSlotsTraced(): Promise<{ slots: SlotRecord[]; cache: "hit" | "miss" }> {
+    return withSpan("slots.list", { route: "GET /api/v1/slots" }, () =>
+      this.listSlots(),
+    );
   }
 
   reset(): void {
@@ -297,142 +321,3 @@ export const listSlotsWithFailure = async (options: PaginationOptions): Promise<
   return listSlots(options);
 };
 
-export const SLOT_LIST_CACHE_TTL_MS = 60_000;
-const SLOT_LIST_CACHE_KEY = "slots:list:all";
-
-export interface Slot {
-  id: number;
-  professional: string;
-  startTime: number;
-  endTime: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface CreateSlotInput {
-  professional: string;
-  startTime: number;
-  endTime: number;
-}
-
-interface UpdateSlotInput {
-  professional?: string;
-  startTime?: number;
-  endTime?: number;
-}
-
-export class SlotValidationError extends Error {}
-export class SlotNotFoundError extends Error {}
-
-export class SlotService {
-  private readonly slots: Slot[] = [];
-  private nextId = 1;
-  private readonly cache: InMemoryCache<Slot[]>;
-  private readonly now: () => Date;
-  private readonly includeCacheMetadata: boolean;
-
-  constructor(
-    cacheOrNow: InMemoryCache<Slot[]> | (() => Date) = () => new Date(),
-    maybeNow?: () => Date,
-  ) {
-    if (cacheOrNow instanceof InMemoryCache) {
-      this.cache = cacheOrNow;
-      this.now = maybeNow ?? (() => new Date());
-      this.includeCacheMetadata = true;
-    } else {
-      this.cache = new InMemoryCache<Slot[]>({ ttlMs: SLOT_LIST_CACHE_TTL_MS });
-      this.now = cacheOrNow;
-      this.includeCacheMetadata = false;
-    }
-  }
-
-  private cloneSlots(slots: Slot[]): Slot[] {
-    return slots.map((slot) => ({ ...slot }));
-  }
-
-  private validateTimes(startTime: number, endTime: number): void {
-    if (!Number.isFinite(startTime) || !Number.isFinite(endTime)) {
-      throw new SlotValidationError("startTime and endTime must be finite numbers");
-    }
-    if (endTime <= startTime) {
-      throw new SlotValidationError("endTime must be greater than startTime");
-    }
-  }
-
-  createSlot(input: CreateSlotInput): Slot {
-    if (typeof input.professional !== "string" || input.professional.trim().length === 0) {
-      throw new SlotValidationError("professional must be a non-empty string");
-    }
-    this.validateTimes(input.startTime, input.endTime);
-
-    const timestamp = this.now().toISOString();
-    const slot: Slot = {
-      id: this.nextId++,
-      professional: input.professional.trim(),
-      startTime: input.startTime,
-      endTime: input.endTime,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    };
-    this.slots.push(slot);
-    this.cache.invalidateByPrefix("slots:list:");
-    return { ...slot };
-  }
-
-  updateSlot(slotId: number, updates: UpdateSlotInput): Slot {
-    if (!updates || typeof updates !== "object") {
-      throw new SlotValidationError("update payload must include at least one field");
-    }
-    const slot = this.slots.find((entry) => entry.id === slotId);
-    if (!slot) {
-      throw new SlotNotFoundError(`Slot ${slotId} was not found`);
-    }
-
-    if (
-      typeof updates.professional === "undefined" &&
-      typeof updates.startTime === "undefined" &&
-      typeof updates.endTime === "undefined"
-    ) {
-      throw new SlotValidationError("update payload must include at least one field");
-    }
-
-    if (typeof updates.professional !== "undefined") {
-      if (typeof updates.professional !== "string") {
-        throw new SlotValidationError("professional must be a string");
-      }
-      const trimmed = updates.professional.trim();
-      if (!trimmed) {
-        throw new SlotValidationError("professional must be a non-empty string");
-      }
-      slot.professional = trimmed;
-    }
-
-    const startTime = updates.startTime ?? slot.startTime;
-    const endTime = updates.endTime ?? slot.endTime;
-    this.validateTimes(startTime, endTime);
-    slot.startTime = startTime;
-    slot.endTime = endTime;
-    slot.updatedAt = this.now().toISOString();
-    this.cache.invalidateByPrefix("slots:list:");
-    return { ...slot };
-  }
-
-  listSlots(): Slot[] | { slots: Slot[]; cache: "hit" | "miss" } {
-    const cached = this.cache.get(SLOT_LIST_CACHE_KEY);
-    if (cached) {
-      const slots = this.cloneSlots(cached);
-      return this.includeCacheMetadata ? { slots, cache: "hit" as const } : slots;
-    }
-    const fresh = this.cloneSlots(this.slots);
-    this.cache.set(SLOT_LIST_CACHE_KEY, fresh);
-    return this.includeCacheMetadata ? { slots: fresh, cache: "miss" as const } : fresh;
-  }
-
-  reset(): void {
-    this.slots.length = 0;
-    this.nextId = 1;
-    this.cache.clear();
-  }
-}
-
-export const slotService = new SlotService();

--- a/src/tracing/hooks.ts
+++ b/src/tracing/hooks.ts
@@ -1,4 +1,5 @@
 import { createChildContext, runWithTraceContext, getTraceContext } from "./context.js";
+import { emitSpan } from "./spanExporter.js";
 
 /**
  * Interface representing a tracing span.
@@ -12,21 +13,26 @@ export interface Span {
   startTime: number;
   endTime?: number;
   duration?: number;
-  attributes: Record<string, any>;
+  /** Stable, non-PII attributes: route, requestId, outcome, latency, error */
+  attributes: Record<string, string | number | boolean>;
 }
 
 /**
- * Hook to manually instrument a synchronous or asynchronous function with a new span.
- * This automatically handles span lifecycle and context propagation.
- * 
- * @param name - The name of the span (e.g., "db.query", "api.call").
- * @param attributes - Metadata associated with the span.
- * @param fn - The function to execute within this span.
- * @returns The result of the function execution.
+ * Wraps a synchronous or asynchronous function in a new child span.
+ *
+ * Stable attributes automatically recorded:
+ *   - outcome: "ok" | "error"
+ *   - latency: duration in ms (alias for duration)
+ *   - error: true (only on failure)
+ *   - error.message: sanitised message (only on failure)
+ *
+ * @param name       Span name, e.g. "slots.create"
+ * @param attributes Initial attributes — must NOT contain PII or secrets.
+ * @param fn         Work to execute inside the span.
  */
 export async function withSpan<T>(
   name: string,
-  attributes: Record<string, any>,
+  attributes: Record<string, string | number | boolean>,
   fn: (span: Span) => Promise<T> | T,
 ): Promise<T> {
   const childContext = createChildContext();
@@ -40,41 +46,35 @@ export async function withSpan<T>(
   };
 
   try {
-    // Run the function within the new child context
     const result = await runWithTraceContext(childContext, () => fn(span));
-    
+
     span.endTime = Date.now();
     span.duration = span.endTime - span.startTime;
-    
-    // In a real production system, we would export this span to a collector here
-    // For now, we'll log it for visibility if in development
-    if (process.env.DEBUG_TRACING === "true") {
-      console.log(`[TRACING] Span "${name}" completed:`, span);
-    }
+    span.attributes.outcome = "ok";
+    span.attributes.latency = span.duration;
 
+    emitSpan(span);
     return result;
   } catch (error) {
     span.endTime = Date.now();
     span.duration = span.endTime - span.startTime;
+    span.attributes.outcome = "error";
+    span.attributes.latency = span.duration;
     span.attributes.error = true;
-    span.attributes["error.message"] = error instanceof Error ? error.message : String(error);
+    span.attributes["error.message"] =
+      error instanceof Error ? error.message : String(error);
 
-    if (process.env.DEBUG_TRACING === "true") {
-      console.error(`[TRACING] Span "${name}" failed:`, span);
-    }
-    
+    emitSpan(span);
     throw error;
   }
 }
 
 /**
- * Retrieves the current span information from the active context.
- * Useful for adding attributes to the current span dynamically.
+ * Returns a snapshot of the current span from the active AsyncLocalStorage context.
  */
 export function getCurrentSpan(): Partial<Span> | undefined {
   const context = getTraceContext();
   if (!context) return undefined;
-
   return {
     traceId: context.traceId,
     spanId: context.spanId,

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -1,0 +1,7 @@
+export { getTraceContext, runWithTraceContext, generateId, createChildContext } from "./context.js";
+export type { TraceContext } from "./context.js";
+export { tracingMiddleware, getPropagationHeaders, TRACE_HEADERS } from "./middleware.js";
+export { withSpan, getCurrentSpan } from "./hooks.js";
+export type { Span } from "./hooks.js";
+export { addSpanExporter, removeSpanExporter, emitSpan } from "./spanExporter.js";
+export type { SpanExporter } from "./spanExporter.js";

--- a/src/tracing/spanExporter.ts
+++ b/src/tracing/spanExporter.ts
@@ -1,0 +1,36 @@
+import type { Span } from "./hooks.js";
+
+export type SpanExporter = (span: Span) => void;
+
+const exporters: SpanExporter[] = [];
+
+/** Register a span exporter (e.g. for tests or a real collector). */
+export function addSpanExporter(fn: SpanExporter): void {
+  exporters.push(fn);
+}
+
+/** Remove a previously registered exporter. */
+export function removeSpanExporter(fn: SpanExporter): void {
+  const idx = exporters.indexOf(fn);
+  if (idx !== -1) exporters.splice(idx, 1);
+}
+
+/** Emit a completed span to all registered exporters. */
+export function emitSpan(span: Span): void {
+  if (process.env.DEBUG_TRACING === "true") {
+    const status = span.attributes.error ? "FAILED" : "OK";
+    console.log(`[TRACING] ${span.name} ${status} ${span.duration}ms`, {
+      traceId: span.traceId,
+      spanId: span.spanId,
+      parentSpanId: span.parentSpanId,
+      attributes: span.attributes,
+    });
+  }
+  for (const fn of exporters) {
+    try {
+      fn(span);
+    } catch {
+      // exporters must not crash the request
+    }
+  }
+}


### PR DESCRIPTION
Closes #131 

- Add spanExporter.ts: pluggable sink (addSpanExporter/removeSpanExporter/emitSpan)
- Update hooks.ts: emit spans via exporter; record outcome, latency, error attrs
- Add index.ts barrel export for src/tracing/
- Add traced wrappers to SlotService (create/update/list)
- Add traced wrappers to CheckoutSessionService (create/get/complete/cancel)
- Add createIntentTraced to BookingIntentService
- Fix duplicate declarations in slotService.ts (pre-existing concatenation bug)
- Add 25 tests covering: exporter lifecycle, ok/error paths, async propagation, context isolation, nested spans, no-PII assertions
- Add docs/tracing.md with conventions, security rules, and usage examples

Closes #131