### PR TITLE
feat: standardize api error code taxonomy

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,178 @@
+# Error Code Taxonomy
+
+ChronoPay API error responses use a single canonical envelope. Every error
+response — whether produced by middleware, a route handler, or the global
+error handler — emits the same shape, and every error carries a stable
+machine-readable `code`.
+
+## Envelope
+
+```json
+{
+  "success": false,
+  "code": "ERROR_CODE",
+  "error": "Human-readable explanation.",
+  "timestamp": "2026-04-26T12:34:56.789Z",
+  "requestId": "req_abc123",
+  "details": { /* optional, code-specific */ }
+}
+```
+
+| Field       | Type    | Required | Notes                                                  |
+| ----------- | ------- | -------- | ------------------------------------------------------ |
+| `success`   | boolean | yes      | Always `false` for error responses.                    |
+| `code`      | string  | yes      | Stable identifier from the table below.                |
+| `error`     | string  | yes      | Human-readable, safe to surface to end users.          |
+| `timestamp` | string  | yes      | ISO 8601 UTC timestamp.                                |
+| `requestId` | string  | when set | Correlates with logs; absent if no request id is set.  |
+| `details`   | object  | no       | Optional, code-specific structured data.               |
+| `stack`     | string  | dev only | Included only when `NODE_ENV !== "production"`.        |
+
+Stack traces are NEVER included in production. Internal/unknown errors are
+mapped to `INTERNAL_ERROR` with a generic message; the original cause is
+written to logs but never returned over the wire.
+
+## Codes
+
+### Validation (400 / 422)
+
+| Code                       | Status | When emitted                                              |
+| -------------------------- | ------ | --------------------------------------------------------- |
+| `BAD_REQUEST`              | 400    | Generic malformed request.                                |
+| `MISSING_REQUIRED_FIELD`   | 400    | Required body/query/param field is missing or empty.      |
+| `INVALID_PAYLOAD`          | 400    | Payload structurally invalid (wrong type, shape).         |
+| `MALFORMED_JSON`           | 400    | Request body is not valid JSON.                           |
+| `VALIDATION_ERROR`         | 422    | Semantic validation failure (e.g., business rule).        |
+
+### Authentication (401)
+
+| Code                      | Status | When emitted                                              |
+| ------------------------- | ------ | --------------------------------------------------------- |
+| `UNAUTHORIZED`            | 401    | Generic authentication failure.                           |
+| `AUTHENTICATION_REQUIRED` | 401    | Required auth header/token absent.                        |
+| `INVALID_TOKEN`           | 401    | Bearer token malformed, expired, or rejected.             |
+| `INVALID_API_KEY`         | 401    | API key missing or does not match expected.               |
+| `INVALID_SIGNATURE`       | 401    | HMAC signature verification failed.                       |
+| `INVALID_TIMESTAMP`       | 401    | HMAC timestamp header is not a finite number.             |
+| `TIMESTAMP_OUT_OF_SKEW`   | 401    | HMAC timestamp outside the allowed skew window.           |
+
+### Authorization (400 / 403)
+
+| Code                       | Status | When emitted                                              |
+| -------------------------- | ------ | --------------------------------------------------------- |
+| `FORBIDDEN`                | 403    | Generic authorization failure.                            |
+| `INSUFFICIENT_PERMISSIONS` | 403    | Authenticated principal lacks the required role.          |
+| `INVALID_ROLE`             | 400    | Role header present but value is not recognized.          |
+
+### Rate limiting (429)
+
+| Code           | Status | When emitted                                              |
+| -------------- | ------ | --------------------------------------------------------- |
+| `RATE_LIMITED` | 429    | Caller exceeded the configured request ceiling.           |
+
+### Feature flags (500 / 503)
+
+| Code                            | Status | When emitted                                          |
+| ------------------------------- | ------ | ----------------------------------------------------- |
+| `FEATURE_DISABLED`              | 503    | Route guarded behind a flag that is currently off.    |
+| `FEATURE_FLAG_EVALUATION_ERROR` | 500    | Flag accessor threw while evaluating the flag.        |
+
+### Idempotency / replay (400 / 409 / 422)
+
+| Code                       | Status | When emitted                                              |
+| -------------------------- | ------ | --------------------------------------------------------- |
+| `IDEMPOTENCY_KEY_INVALID`  | 400    | `Idempotency-Key` header malformed.                       |
+| `IDEMPOTENCY_IN_PROGRESS`  | 409    | Another request with the same key is still running.       |
+| `IDEMPOTENCY_KEY_MISMATCH` | 422    | Same key reused with a different request payload.         |
+| `REPLAY_DETECTED`          | 409    | HMAC replay window detected an already-seen signature.    |
+
+### Content negotiation (406 / 415)
+
+| Code                     | Status | When emitted                                              |
+| ------------------------ | ------ | --------------------------------------------------------- |
+| `UNSUPPORTED_MEDIA_TYPE` | 415    | Request `Content-Type` is not `application/json`.         |
+| `NOT_ACCEPTABLE`         | 406    | Request `Accept` does not include JSON.                   |
+
+### State / lifecycle (404 / 409 / 422)
+
+| Code                    | Status | When emitted                                               |
+| ----------------------- | ------ | ---------------------------------------------------------- |
+| `NOT_FOUND`             | 404    | Requested resource or route does not exist.                |
+| `CONFLICT`              | 409    | Request conflicts with current resource state.             |
+| `UNPROCESSABLE_ENTITY`  | 422    | Request was valid but cannot be processed in current state.|
+
+### Infrastructure (500 / 503)
+
+| Code                  | Status | When emitted                                                  |
+| --------------------- | ------ | ------------------------------------------------------------- |
+| `INTERNAL_ERROR`      | 500    | Unhandled error or unknown exception.                         |
+| `DB_ERROR`            | 500    | Database driver, query, or transaction failure.               |
+| `SERVICE_UNAVAILABLE` | 503    | Dependency unavailable; safe to retry.                        |
+| `CONFIGURATION_ERROR` | 503    | Required configuration (secret, feature, env) is missing.     |
+
+## Examples
+
+**Validation — missing field**
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "success": false,
+  "code": "MISSING_REQUIRED_FIELD",
+  "error": "Missing required field: startTime",
+  "timestamp": "2026-04-26T12:34:56.789Z",
+  "details": { "field": "startTime" }
+}
+```
+
+**Authorization — insufficient permissions**
+
+```http
+HTTP/1.1 403 Forbidden
+Content-Type: application/json
+
+{
+  "success": false,
+  "code": "INSUFFICIENT_PERMISSIONS",
+  "error": "Insufficient permissions",
+  "timestamp": "2026-04-26T12:34:56.789Z",
+  "requestId": "req_abc123"
+}
+```
+
+**Idempotency — payload mismatch**
+
+```http
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/json
+
+{
+  "success": false,
+  "code": "IDEMPOTENCY_KEY_MISMATCH",
+  "error": "Unprocessable Entity: Idempotency-Key used with different payload.",
+  "timestamp": "2026-04-26T12:34:56.789Z"
+}
+```
+
+## Adding a new code
+
+1. Add the entry to `src/errors/errorCodes.ts` (`ERROR_CODES` map). This is
+   the single source of truth.
+2. If a new HTTP semantic is involved, add an `AppError` subclass in
+   `src/errors/AppError.ts` so middleware/route code can throw it directly.
+3. Update the relevant section of this document.
+4. Add a test asserting the code propagates through the global handler.
+
+## Client integration
+
+- Match on `code`, never on `error`. The human-readable string is allowed to
+  change between releases for clarity; codes are part of the API contract.
+- `code` is stable; once published, removing or repurposing one is a
+  breaking change.
+- Treat `5xx` codes as retryable; treat `4xx` (except `429`) as terminal
+  unless the caller can correct the input. `429` and `503` should be
+  retried with backoff.
+- `requestId` (when present) is the correlation key for support / log
+  lookups.

--- a/src/__tests__/apiKeyAuth.unit.test.ts
+++ b/src/__tests__/apiKeyAuth.unit.test.ts
@@ -78,10 +78,14 @@ describe("API Key Identity Model", () => {
 
     expect(req.apiKeyId).toBeUndefined();
     expect(statusValue).toBe(403);
-    expect(jsonValue).toEqual({
-      success: false,
-      error: "Invalid API key",
-    });
+    expect(jsonValue).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "INVALID_API_KEY",
+        error: "Invalid API key",
+        timestamp: expect.any(String),
+      }),
+    );
     expect(nextCalled.called).toBe(false);
   });
 

--- a/src/__tests__/error-codes.test.ts
+++ b/src/__tests__/error-codes.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Taxonomy-level coverage for ChronoPay error codes.
+ *
+ * Verifies:
+ *   1. The canonical envelope shape from sendErrorResponse / AppError.toJSON.
+ *   2. Each AppError subclass binds to the right (status, code) pair from
+ *      ERROR_CODES.
+ *   3. The global handlers in errorHandler.ts and errorHandling.ts emit the
+ *      same envelope for the same input.
+ *   4. Stack traces are NEVER returned in production for unknown errors.
+ */
+
+import express, { Express, NextFunction, Request, Response } from "express";
+import request from "supertest";
+import {
+  AppError,
+  BadRequestError,
+  ConfigurationError,
+  ConflictError,
+  DatabaseError,
+  ForbiddenError,
+  IdempotencyError,
+  InternalServerError,
+  MalformedJsonError,
+  MissingRequiredFieldError,
+  NotFoundError,
+  RateLimitError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+  UnprocessableEntityError,
+  ValidationError,
+} from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+import { sendErrorResponse } from "../errors/sendError.js";
+import { createErrorHandler } from "../middleware/errorHandler.js";
+import {
+  genericErrorHandler,
+  jsonParseErrorHandler,
+} from "../middleware/errorHandling.js";
+
+describe("ERROR_CODES taxonomy", () => {
+  it("each entry pairs a status with a matching code string", () => {
+    for (const [key, entry] of Object.entries(ERROR_CODES)) {
+      expect(entry.code).toBe(key);
+      expect(typeof entry.status).toBe("number");
+      expect(entry.status).toBeGreaterThanOrEqual(400);
+      expect(entry.status).toBeLessThan(600);
+    }
+  });
+
+  it("contains every code referenced by the issue", () => {
+    const required = [
+      "VALIDATION_ERROR",
+      "UNAUTHORIZED",
+      "FORBIDDEN",
+      "RATE_LIMITED",
+      "FEATURE_DISABLED",
+      "IDEMPOTENCY_KEY_INVALID",
+      "IDEMPOTENCY_IN_PROGRESS",
+      "IDEMPOTENCY_KEY_MISMATCH",
+      "DB_ERROR",
+      "MALFORMED_JSON",
+      "INTERNAL_ERROR",
+    ];
+    for (const code of required) {
+      expect(ERROR_CODES).toHaveProperty(code);
+    }
+  });
+});
+
+describe("AppError subclasses", () => {
+  const cases: Array<[AppError, number, string]> = [
+    [new BadRequestError("x"), 400, "BAD_REQUEST"],
+    [new ValidationError("x"), 422, "VALIDATION_ERROR"],
+    [new MissingRequiredFieldError("amount"), 400, "MISSING_REQUIRED_FIELD"],
+    [new MalformedJsonError(), 400, "MALFORMED_JSON"],
+    [new UnauthorizedError(), 401, "UNAUTHORIZED"],
+    [new ForbiddenError(), 403, "FORBIDDEN"],
+    [new NotFoundError(), 404, "NOT_FOUND"],
+    [new ConflictError(), 409, "CONFLICT"],
+    [new UnprocessableEntityError(), 422, "UNPROCESSABLE_ENTITY"],
+    [new RateLimitError(), 429, "RATE_LIMITED"],
+    [
+      new IdempotencyError("dup", ERROR_CODES.IDEMPOTENCY_KEY_INVALID.code),
+      400,
+      "IDEMPOTENCY_KEY_INVALID",
+    ],
+    [
+      new IdempotencyError("busy", ERROR_CODES.IDEMPOTENCY_IN_PROGRESS.code),
+      409,
+      "IDEMPOTENCY_IN_PROGRESS",
+    ],
+    [
+      new IdempotencyError("hash", ERROR_CODES.IDEMPOTENCY_KEY_MISMATCH.code),
+      422,
+      "IDEMPOTENCY_KEY_MISMATCH",
+    ],
+    [new DatabaseError("boom"), 500, "DB_ERROR"],
+    [new InternalServerError(), 500, "INTERNAL_ERROR"],
+    [new ServiceUnavailableError(), 503, "SERVICE_UNAVAILABLE"],
+    [new ConfigurationError("missing"), 503, "CONFIGURATION_ERROR"],
+  ];
+
+  it.each(cases)("$0 has matching status/code", (err, status, code) => {
+    expect(err.statusCode).toBe(status);
+    expect(err.code).toBe(code);
+    const env = err.toJSON();
+    expect(env).toEqual(
+      expect.objectContaining({
+        success: false,
+        code,
+        error: err.message,
+        timestamp: expect.any(String),
+      }),
+    );
+  });
+
+  it("MissingRequiredFieldError attaches the field name as details", () => {
+    const err = new MissingRequiredFieldError("startTime");
+    expect(err.toJSON()).toEqual(
+      expect.objectContaining({
+        code: "MISSING_REQUIRED_FIELD",
+        details: { field: "startTime" },
+      }),
+    );
+  });
+
+  it("UnauthorizedError accepts a more specific code from the taxonomy", () => {
+    const err = new UnauthorizedError("bad token", ERROR_CODES.INVALID_TOKEN.code);
+    expect(err.code).toBe("INVALID_TOKEN");
+    expect(err.statusCode).toBe(401);
+  });
+});
+
+describe("sendErrorResponse helper", () => {
+  it("emits the canonical envelope and copies requestId from the request", () => {
+    const captured: { status?: number; body?: unknown } = {};
+    const res = {
+      status(code: number) {
+        captured.status = code;
+        return this;
+      },
+      json(body: unknown) {
+        captured.body = body;
+        return this;
+      },
+    } as unknown as Response;
+    const req = { requestId: "req_abc" } as unknown as Request;
+
+    sendErrorResponse(res, new BadRequestError("nope"), req);
+
+    expect(captured.status).toBe(400);
+    expect(captured.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "BAD_REQUEST",
+        error: "nope",
+        timestamp: expect.any(String),
+        requestId: "req_abc",
+      }),
+    );
+  });
+});
+
+describe("global handlers emit the canonical envelope", () => {
+  function buildApp(register: (app: Express) => void): Express {
+    const app = express();
+    app.use(express.json());
+    register(app);
+    return app;
+  }
+
+  it("createErrorHandler emits the canonical envelope for AppError", async () => {
+    const app = buildApp((a) => {
+      a.get("/x", (_req, _res, next) => next(new ForbiddenError("denied")));
+      a.use(createErrorHandler());
+    });
+
+    const res = await request(app).get("/x");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "FORBIDDEN",
+        error: "denied",
+        timestamp: expect.any(String),
+      }),
+    );
+  });
+
+  it("genericErrorHandler emits the canonical envelope for AppError", async () => {
+    const app = buildApp((a) => {
+      a.get("/x", (_req, _res, next) => next(new NotFoundError("absent")));
+      a.use(genericErrorHandler);
+    });
+
+    const res = await request(app).get("/x");
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "NOT_FOUND",
+        error: "absent",
+        timestamp: expect.any(String),
+      }),
+    );
+  });
+
+  it("genericErrorHandler maps unknown errors to INTERNAL_ERROR with a safe message", async () => {
+    const app = buildApp((a) => {
+      a.get("/x", (_req, _res, next) =>
+        next(new Error("DB password leaked here")),
+      );
+      a.use(genericErrorHandler);
+    });
+
+    const res = await request(app).get("/x");
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe("INTERNAL_ERROR");
+    expect(res.body.error).not.toContain("password");
+  });
+
+  it("jsonParseErrorHandler emits MALFORMED_JSON", async () => {
+    const app = buildApp((a) => {
+      a.post("/x", (_req, res) => res.status(200).json({ ok: true }));
+      a.use(jsonParseErrorHandler);
+    });
+
+    const res = await request(app)
+      .post("/x")
+      .set("content-type", "application/json")
+      .send("{not json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "MALFORMED_JSON",
+        error: "Malformed JSON payload",
+      }),
+    );
+  });
+
+  it("never includes stack traces in production responses", async () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const app = buildApp((a) => {
+        a.get("/x", (_req, _res, next) => next(new Error("internal")));
+        a.use(createErrorHandler());
+      });
+
+      const res = await request(app).get("/x");
+      expect(res.body.stack).toBeUndefined();
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+});
+
+describe("AppError -> envelope round trip via Express", () => {
+  it("includes details payload when provided", async () => {
+    const app = express();
+    app.use(express.json());
+    app.get("/x", (_req: Request, _res: Response, next: NextFunction) =>
+      next(new MissingRequiredFieldError("startTime")),
+    );
+    app.use(genericErrorHandler);
+
+    const res = await request(app).get("/x");
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "MISSING_REQUIRED_FIELD",
+        error: "Missing required field: startTime",
+        details: { field: "startTime" },
+      }),
+    );
+  });
+});

--- a/src/__tests__/error-handling.test.ts
+++ b/src/__tests__/error-handling.test.ts
@@ -39,17 +39,26 @@ describe("Custom Error Classes", () => {
       expect(error.isOperational).toBe(false);
     });
 
-    it("should serialize to JSON correctly", () => {
+    it("should serialize to JSON in canonical envelope", () => {
       const error = new AppError("Test error", 400, "BAD_REQUEST", true);
       const json = error.toJSON();
 
       expect(json).toEqual({
         success: false,
-        error: {
-          message: "Test error",
-          code: "BAD_REQUEST",
-          timestamp: error.timestamp,
-        },
+        code: "BAD_REQUEST",
+        error: "Test error",
+        timestamp: error.timestamp,
+      });
+    });
+
+    it("should include details when provided", () => {
+      const error = new AppError("Test", 400, "BAD_REQUEST", true, { field: "x" });
+      expect(error.toJSON()).toEqual({
+        success: false,
+        code: "BAD_REQUEST",
+        error: "Test",
+        timestamp: error.timestamp,
+        details: { field: "x" },
       });
     });
   });
@@ -68,10 +77,15 @@ describe("Custom Error Classes", () => {
   });
 
   describe("UnauthorizedError", () => {
-    it("should create 401 error", () => {
+    it("should create 401 error with default code", () => {
       const error = new UnauthorizedError("Please login");
       expect(error.statusCode).toBe(401);
       expect(error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should accept a custom code from the taxonomy", () => {
+      const error = new UnauthorizedError("Bad token", "INVALID_TOKEN");
+      expect(error.code).toBe("INVALID_TOKEN");
     });
   });
 
@@ -80,6 +94,11 @@ describe("Custom Error Classes", () => {
       const error = new ForbiddenError("Access denied");
       expect(error.statusCode).toBe(403);
       expect(error.code).toBe("FORBIDDEN");
+    });
+
+    it("should accept a custom code", () => {
+      const error = new ForbiddenError("nope", "INSUFFICIENT_PERMISSIONS");
+      expect(error.code).toBe("INSUFFICIENT_PERMISSIONS");
     });
   });
 
@@ -196,8 +215,9 @@ describe("Error Handling Middleware", () => {
       const res = await request(app).get("/test");
       expect(res.status).toBe(400);
       expect(res.body.success).toBe(false);
-      expect(res.body.error.code).toBe("BAD_REQUEST");
-      expect(res.body.error.message).toBe("Invalid input");
+      expect(res.body.code).toBe("BAD_REQUEST");
+      expect(res.body.error).toBe("Invalid input");
+      expect(res.body.timestamp).toBeDefined();
     });
 
     it("should handle NotFoundError", async () => {
@@ -209,7 +229,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/test");
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe("NOT_FOUND");
+      expect(res.body.code).toBe("NOT_FOUND");
     });
 
     it("should handle UnauthorizedError", async () => {
@@ -221,6 +241,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/test");
       expect(res.status).toBe(401);
+      expect(res.body.code).toBe("UNAUTHORIZED");
     });
 
     it("should handle ForbiddenError", async () => {
@@ -232,6 +253,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/test");
       expect(res.status).toBe(403);
+      expect(res.body.code).toBe("FORBIDDEN");
     });
 
     it("should handle ConflictError", async () => {
@@ -243,6 +265,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/test");
       expect(res.status).toBe(409);
+      expect(res.body.code).toBe("CONFLICT");
     });
 
     it("should handle UnprocessableEntityError", async () => {
@@ -254,6 +277,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/test");
       expect(res.status).toBe(422);
+      expect(res.body.code).toBe("UNPROCESSABLE_ENTITY");
     });
 
     it("should handle InternalServerError", async () => {
@@ -265,6 +289,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/test");
       expect(res.status).toBe(500);
+      expect(res.body.code).toBe("INTERNAL_ERROR");
     });
 
     it("should handle ServiceUnavailableError", async () => {
@@ -276,9 +301,10 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/test");
       expect(res.status).toBe(503);
+      expect(res.body.code).toBe("SERVICE_UNAVAILABLE");
     });
 
-    it("should handle regular Error with 500 status", async () => {
+    it("should handle regular Error with 500 status and INTERNAL_ERROR code", async () => {
       const errorHandler = createErrorHandler();
       app.get("/test", () => {
         throw new Error("Unexpected error");
@@ -287,10 +313,10 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/test");
       expect(res.status).toBe(500);
-      expect(res.body.error.code).toBe("INTERNAL_ERROR");
+      expect(res.body.code).toBe("INTERNAL_ERROR");
     });
 
-    it("should include stack trace in development", async () => {
+    it("should include stack trace in development for unknown errors", async () => {
       const originalEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
 
@@ -301,7 +327,7 @@ describe("Error Handling Middleware", () => {
       app.use(errorHandler);
 
       const res = await request(app).get("/test");
-      expect(res.body.error.stack).toBeDefined();
+      expect(res.body.stack).toBeDefined();
 
       process.env.NODE_ENV = originalEnv;
     });
@@ -317,9 +343,20 @@ describe("Error Handling Middleware", () => {
       app.use(errorHandler);
 
       const res = await request(app).get("/test");
-      expect(res.body.error.stack).toBeUndefined();
+      expect(res.body.stack).toBeUndefined();
 
       process.env.NODE_ENV = originalEnv;
+    });
+
+    it("should never leak the original message of unknown errors", async () => {
+      const errorHandler = createErrorHandler();
+      app.get("/test", () => {
+        throw new Error("internal connection string oops");
+      });
+      app.use(errorHandler);
+
+      const res = await request(app).get("/test");
+      expect(res.body.error).not.toContain("connection string");
     });
 
     it("should use custom unknown error message", async () => {
@@ -332,7 +369,7 @@ describe("Error Handling Middleware", () => {
       app.use(errorHandler);
 
       const res = await request(app).get("/test");
-      expect(res.body.error.message).toBe("Custom error message");
+      expect(res.body.error).toBe("Custom error message");
     });
 
     it("should call custom logError function", async () => {
@@ -360,7 +397,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/nonexistent");
       expect(res.status).toBe(404);
-      expect(res.body.error.code).toBe("NOT_FOUND");
+      expect(res.body.code).toBe("NOT_FOUND");
     });
 
     it("should include method and path in error message", async () => {
@@ -370,8 +407,8 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).post("/nonexistent");
       expect(res.status).toBe(404);
-      expect(res.body.error.message).toContain("POST");
-      expect(res.body.error.message).toContain("/nonexistent");
+      expect(res.body.error).toContain("POST");
+      expect(res.body.error).toContain("/nonexistent");
     });
   });
 
@@ -389,7 +426,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/async");
       expect(res.status).toBe(400);
-      expect(res.body.error.message).toBe("Async error");
+      expect(res.body.error).toBe("Async error");
     });
 
     it("should work with synchronous errors", async () => {
@@ -405,7 +442,7 @@ describe("Error Handling Middleware", () => {
 
       const res = await request(app).get("/sync");
       expect(res.status).toBe(400);
-      expect(res.body.error.message).toBe("Sync error");
+      expect(res.body.error).toBe("Sync error");
     });
 
     it("should pass successful responses through", async () => {

--- a/src/__tests__/feature-flags.middleware.test.ts
+++ b/src/__tests__/feature-flags.middleware.test.ts
@@ -65,11 +65,14 @@ describe("feature flag middleware", () => {
     requireFeatureFlag("CREATE_SLOT")(req, res, next);
 
     expect(status).toHaveBeenCalledWith(503);
-    expect(json).toHaveBeenCalledWith({
-      success: false,
-      code: "FEATURE_DISABLED",
-      error: "Feature CREATE_SLOT is currently disabled",
-    });
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        code: "FEATURE_DISABLED",
+        error: "Feature CREATE_SLOT is currently disabled",
+        timestamp: expect.any(String),
+      }),
+    );
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -91,11 +94,14 @@ describe("feature flag middleware", () => {
     requireFeatureFlag("CREATE_SLOT")(req, res, next);
 
     expect(status).toHaveBeenCalledWith(500);
-    expect(json).toHaveBeenCalledWith({
-      success: false,
-      code: "FEATURE_FLAG_EVALUATION_ERROR",
-      error: "Feature flag evaluation failed",
-    });
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        code: "FEATURE_FLAG_EVALUATION_ERROR",
+        error: "Feature flag evaluation failed",
+        timestamp: expect.any(String),
+      }),
+    );
     expect(next).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/idempotency.test.ts
+++ b/src/__tests__/idempotency.test.ts
@@ -206,10 +206,14 @@ describe.skip("Idempotency Middleware (integration)", () => {
     await idempotencyMiddleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(422);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: "Unprocessable Entity: Idempotency-Key used with different payload.",
-    });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        code: "IDEMPOTENCY_KEY_MISMATCH",
+        error: "Unprocessable Entity: Idempotency-Key used with different payload.",
+        timestamp: expect.any(String),
+      }),
+    );
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -235,10 +239,14 @@ describe.skip("Idempotency Middleware (integration)", () => {
     await idempotencyMiddleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(409);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: "Conflict: This transaction is actively running.",
-    });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        code: "IDEMPOTENCY_IN_PROGRESS",
+        error: "Conflict: This transaction is actively running.",
+        timestamp: expect.any(String),
+      }),
+    );
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -303,10 +311,14 @@ describe.skip("Idempotency Middleware (integration)", () => {
     await idempotencyMiddleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(409);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: "Conflict: This transaction is actively running.",
-    });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        code: "IDEMPOTENCY_IN_PROGRESS",
+        error: "Conflict: This transaction is actively running.",
+        timestamp: expect.any(String),
+      }),
+    );
     expect(next).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/validation-middleware.test.ts
+++ b/src/__tests__/validation-middleware.test.ts
@@ -29,10 +29,14 @@ describe("validateRequiredFields middleware", () => {
     middleware(request, response, next);
 
     expect((response as unknown as { statusCode: number }).statusCode).toBe(400);
-    expect(responseBody[0]).toEqual({
-      success: false,
-      error: "Request body is missing or invalid",
-    });
+    expect(responseBody[0]).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "BAD_REQUEST",
+        error: "Request body is missing or invalid",
+        timestamp: expect.any(String),
+      }),
+    );
   });
 
   it("returns 500 when a middleware exception occurs", () => {
@@ -49,9 +53,13 @@ describe("validateRequiredFields middleware", () => {
     middleware(request, response, next);
 
     expect((response as unknown as { statusCode: number }).statusCode).toBe(500);
-    expect(responseBody[0]).toEqual({
-      success: false,
-      error: "Validation middleware error",
-    });
+    expect(responseBody[0]).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "INTERNAL_ERROR",
+        error: "Validation middleware error",
+        timestamp: expect.any(String),
+      }),
+    );
   });
 });

--- a/src/errors/AppError.ts
+++ b/src/errors/AppError.ts
@@ -1,24 +1,38 @@
 /**
- * Custom error classes for ChronoPay API
+ * Custom error classes for ChronoPay API.
  *
- * These errors provide structured error handling across the application
- * with proper HTTP status codes and error categorization.
+ * Every subclass binds to a canonical entry in `ERROR_CODES`. The error
+ * envelope emitted on the wire is the flat shape produced by `toJSON()`:
+ *
+ *   { success: false, code, error, requestId?, timestamp, details? }
+ *
+ * See `docs/error-codes.md` for the full taxonomy.
  */
 
-/**
- * Base application error with HTTP status code support
- */
+import { ERROR_CODES, type ErrorCodeString } from "./errorCodes.js";
+
+export interface AppErrorEnvelope {
+  success: false;
+  code: ErrorCodeString | string;
+  error: string;
+  timestamp: string;
+  requestId?: string;
+  details?: unknown;
+}
+
 export class AppError extends Error {
   public readonly statusCode: number;
   public readonly code: string;
   public readonly isOperational: boolean;
   public readonly timestamp: string;
+  public readonly details?: unknown;
 
   constructor(
     message: string,
     statusCode: number = 500,
-    code: string = "INTERNAL_ERROR",
+    code: string = ERROR_CODES.INTERNAL_ERROR.code,
     isOperational: boolean = true,
+    details?: unknown,
   ) {
     super(message);
     this.name = this.constructor.name;
@@ -26,118 +40,184 @@ export class AppError extends Error {
     this.code = code;
     this.isOperational = isOperational;
     this.timestamp = new Date().toISOString();
+    if (details !== undefined) {
+      this.details = details;
+    }
 
-    // Maintains proper stack trace for where error was thrown (only in dev)
     if (process.env.NODE_ENV !== "production") {
       Error.captureStackTrace(this, this.constructor);
     }
   }
 
-  /**
-   * Convert error to JSON-serializable object
-   */
-  toJSON() {
-    return {
+  toJSON(): AppErrorEnvelope {
+    const envelope: AppErrorEnvelope = {
       success: false,
-      error: {
-        message: this.message,
-        code: this.code,
-        timestamp: this.timestamp,
-      },
+      code: this.code,
+      error: this.message,
+      timestamp: this.timestamp,
     };
+    if (this.details !== undefined) {
+      envelope.details = this.details;
+    }
+    return envelope;
   }
 }
 
-/**
- * Bad Request Error (400)
- * Used for invalid inputs, missing fields, malformed requests
- */
 export class BadRequestError extends AppError {
-  constructor(message: string = "Bad Request") {
-    super(message, 400, "BAD_REQUEST", true);
+  constructor(message: string = "Bad Request", details?: unknown) {
+    super(message, ERROR_CODES.BAD_REQUEST.status, ERROR_CODES.BAD_REQUEST.code, true, details);
   }
 }
 
-/**
- * Unauthorized Error (401)
- * Used for missing or invalid authentication
- */
+export class ValidationError extends AppError {
+  constructor(message: string = "Validation failed", details?: unknown) {
+    super(
+      message,
+      ERROR_CODES.VALIDATION_ERROR.status,
+      ERROR_CODES.VALIDATION_ERROR.code,
+      true,
+      details,
+    );
+  }
+}
+
+export class MissingRequiredFieldError extends AppError {
+  constructor(field: string) {
+    super(
+      `Missing required field: ${field}`,
+      ERROR_CODES.MISSING_REQUIRED_FIELD.status,
+      ERROR_CODES.MISSING_REQUIRED_FIELD.code,
+      true,
+      { field },
+    );
+  }
+}
+
+export class MalformedJsonError extends AppError {
+  constructor(message: string = "Malformed JSON payload") {
+    super(
+      message,
+      ERROR_CODES.MALFORMED_JSON.status,
+      ERROR_CODES.MALFORMED_JSON.code,
+      true,
+    );
+  }
+}
+
 export class UnauthorizedError extends AppError {
-  constructor(message: string = "Unauthorized") {
-    super(message, 401, "UNAUTHORIZED", true);
+  constructor(
+    message: string = "Unauthorized",
+    code: string = ERROR_CODES.UNAUTHORIZED.code,
+  ) {
+    super(message, ERROR_CODES.UNAUTHORIZED.status, code, true);
   }
 }
 
-/**
- * Forbidden Error (403)
- * Used when user lacks permission for the requested resource
- */
 export class ForbiddenError extends AppError {
-  constructor(message: string = "Forbidden") {
-    super(message, 403, "FORBIDDEN", true);
+  constructor(
+    message: string = "Forbidden",
+    code: string = ERROR_CODES.FORBIDDEN.code,
+  ) {
+    super(message, ERROR_CODES.FORBIDDEN.status, code, true);
   }
 }
 
-/**
- * Not Found Error (404)
- * Used when requested resource doesn't exist
- */
 export class NotFoundError extends AppError {
   constructor(message: string = "Resource not found") {
-    super(message, 404, "NOT_FOUND", true);
+    super(message, ERROR_CODES.NOT_FOUND.status, ERROR_CODES.NOT_FOUND.code, true);
   }
 }
 
-/**
- * Conflict Error (409)
- * Used for resource conflicts (e.g., duplicate entries)
- */
 export class ConflictError extends AppError {
-  constructor(message: string = "Conflict") {
-    super(message, 409, "CONFLICT", true);
+  constructor(
+    message: string = "Conflict",
+    code: string = ERROR_CODES.CONFLICT.code,
+  ) {
+    super(message, ERROR_CODES.CONFLICT.status, code, true);
   }
 }
 
-/**
- * Unprocessable Entity Error (422)
- * Used for validation errors that can't be processed
- */
 export class UnprocessableEntityError extends AppError {
-  constructor(message: string = "Unprocessable Entity") {
-    super(message, 422, "UNPROCESSABLE_ENTITY", true);
+  constructor(
+    message: string = "Unprocessable Entity",
+    code: string = ERROR_CODES.UNPROCESSABLE_ENTITY.code,
+  ) {
+    super(message, ERROR_CODES.UNPROCESSABLE_ENTITY.status, code, true);
   }
 }
 
-/**
- * Internal Server Error (500)
- * Used for unexpected server errors
- * Note: isOperational is false by default to hide internal details in production
- */
+export class RateLimitError extends AppError {
+  constructor(message: string = "Too many requests, please try again later.") {
+    super(
+      message,
+      ERROR_CODES.RATE_LIMITED.status,
+      ERROR_CODES.RATE_LIMITED.code,
+      true,
+    );
+  }
+}
+
+export class IdempotencyError extends AppError {
+  constructor(
+    message: string,
+    code:
+      | typeof ERROR_CODES.IDEMPOTENCY_KEY_INVALID.code
+      | typeof ERROR_CODES.IDEMPOTENCY_IN_PROGRESS.code
+      | typeof ERROR_CODES.IDEMPOTENCY_KEY_MISMATCH.code,
+  ) {
+    const status =
+      code === ERROR_CODES.IDEMPOTENCY_KEY_INVALID.code
+        ? ERROR_CODES.IDEMPOTENCY_KEY_INVALID.status
+        : code === ERROR_CODES.IDEMPOTENCY_IN_PROGRESS.code
+          ? ERROR_CODES.IDEMPOTENCY_IN_PROGRESS.status
+          : ERROR_CODES.IDEMPOTENCY_KEY_MISMATCH.status;
+    super(message, status, code, true);
+  }
+}
+
+export class DatabaseError extends AppError {
+  constructor(message: string = "Database operation failed", details?: unknown) {
+    super(
+      message,
+      ERROR_CODES.DB_ERROR.status,
+      ERROR_CODES.DB_ERROR.code,
+      false,
+      details,
+    );
+  }
+}
+
 export class InternalServerError extends AppError {
   constructor(message: string = "Internal Server Error") {
     super(
       message,
-      500,
-      "INTERNAL_ERROR",
+      ERROR_CODES.INTERNAL_ERROR.status,
+      ERROR_CODES.INTERNAL_ERROR.code,
       process.env.NODE_ENV !== "production",
     );
   }
 }
 
-/**
- * Service Unavailable Error (503)
- * Used when service is temporarily unavailable
- */
 export class ServiceUnavailableError extends AppError {
-  constructor(message: string = "Service Unavailable") {
-    super(message, 503, "SERVICE_UNAVAILABLE", true);
+  constructor(
+    message: string = "Service Unavailable",
+    code: string = ERROR_CODES.SERVICE_UNAVAILABLE.code,
+  ) {
+    super(message, ERROR_CODES.SERVICE_UNAVAILABLE.status, code, true);
   }
 }
 
-/**
- * Content Negotiation Error (415/406)
- * Used for Content-Type or Accept header validation failures
- */
+export class ConfigurationError extends AppError {
+  constructor(message: string) {
+    super(
+      message,
+      ERROR_CODES.CONFIGURATION_ERROR.status,
+      ERROR_CODES.CONFIGURATION_ERROR.code,
+      true,
+    );
+  }
+}
+
 export class ContentNegotiationError extends AppError {
   constructor(
     statusCode: 415 | 406,
@@ -148,9 +228,6 @@ export class ContentNegotiationError extends AppError {
   }
 }
 
-/**
- * Type guard to check if error is an AppError
- */
 export function isAppError(error: unknown): error is AppError {
   return (
     error instanceof Error &&
@@ -160,9 +237,6 @@ export function isAppError(error: unknown): error is AppError {
   );
 }
 
-/**
- * Extract status code from any error
- */
 export function getStatusCode(error: unknown): number {
   if (isAppError(error)) {
     return error.statusCode;

--- a/src/errors/errorCodes.ts
+++ b/src/errors/errorCodes.ts
@@ -1,0 +1,67 @@
+/**
+ * Canonical ChronoPay API error code taxonomy.
+ *
+ * Every error response that exits the API surface MUST include one of the
+ * codes defined here. Adding a new code is an API contract change — update
+ * `docs/error-codes.md` whenever this map changes.
+ */
+
+export const ERROR_CODES = {
+  // --- Validation (400 / 422) ---
+  BAD_REQUEST: { status: 400, code: "BAD_REQUEST" },
+  VALIDATION_ERROR: { status: 422, code: "VALIDATION_ERROR" },
+  MISSING_REQUIRED_FIELD: { status: 400, code: "MISSING_REQUIRED_FIELD" },
+  INVALID_PAYLOAD: { status: 400, code: "INVALID_PAYLOAD" },
+  MALFORMED_JSON: { status: 400, code: "MALFORMED_JSON" },
+
+  // --- Authentication (401) ---
+  UNAUTHORIZED: { status: 401, code: "UNAUTHORIZED" },
+  AUTHENTICATION_REQUIRED: { status: 401, code: "AUTHENTICATION_REQUIRED" },
+  INVALID_TOKEN: { status: 401, code: "INVALID_TOKEN" },
+  INVALID_API_KEY: { status: 401, code: "INVALID_API_KEY" },
+  INVALID_SIGNATURE: { status: 401, code: "INVALID_SIGNATURE" },
+  INVALID_TIMESTAMP: { status: 401, code: "INVALID_TIMESTAMP" },
+  TIMESTAMP_OUT_OF_SKEW: { status: 401, code: "TIMESTAMP_OUT_OF_SKEW" },
+
+  // --- Authorization (400 / 403) ---
+  FORBIDDEN: { status: 403, code: "FORBIDDEN" },
+  INSUFFICIENT_PERMISSIONS: { status: 403, code: "INSUFFICIENT_PERMISSIONS" },
+  INVALID_ROLE: { status: 400, code: "INVALID_ROLE" },
+
+  // --- Rate limiting (429) ---
+  RATE_LIMITED: { status: 429, code: "RATE_LIMITED" },
+
+  // --- Feature flags (500 / 503) ---
+  FEATURE_DISABLED: { status: 503, code: "FEATURE_DISABLED" },
+  FEATURE_FLAG_EVALUATION_ERROR: {
+    status: 500,
+    code: "FEATURE_FLAG_EVALUATION_ERROR",
+  },
+
+  // --- Idempotency / replay (400 / 409 / 422) ---
+  IDEMPOTENCY_KEY_INVALID: { status: 400, code: "IDEMPOTENCY_KEY_INVALID" },
+  IDEMPOTENCY_IN_PROGRESS: { status: 409, code: "IDEMPOTENCY_IN_PROGRESS" },
+  IDEMPOTENCY_KEY_MISMATCH: {
+    status: 422,
+    code: "IDEMPOTENCY_KEY_MISMATCH",
+  },
+  REPLAY_DETECTED: { status: 409, code: "REPLAY_DETECTED" },
+
+  // --- Content negotiation (406 / 415) ---
+  UNSUPPORTED_MEDIA_TYPE: { status: 415, code: "UNSUPPORTED_MEDIA_TYPE" },
+  NOT_ACCEPTABLE: { status: 406, code: "NOT_ACCEPTABLE" },
+
+  // --- State / lifecycle (404 / 409 / 422) ---
+  NOT_FOUND: { status: 404, code: "NOT_FOUND" },
+  CONFLICT: { status: 409, code: "CONFLICT" },
+  UNPROCESSABLE_ENTITY: { status: 422, code: "UNPROCESSABLE_ENTITY" },
+
+  // --- Infrastructure (500 / 503) ---
+  INTERNAL_ERROR: { status: 500, code: "INTERNAL_ERROR" },
+  DB_ERROR: { status: 500, code: "DB_ERROR" },
+  SERVICE_UNAVAILABLE: { status: 503, code: "SERVICE_UNAVAILABLE" },
+  CONFIGURATION_ERROR: { status: 503, code: "CONFIGURATION_ERROR" },
+} as const;
+
+export type ErrorCodeKey = keyof typeof ERROR_CODES;
+export type ErrorCodeString = (typeof ERROR_CODES)[ErrorCodeKey]["code"];

--- a/src/errors/sendError.ts
+++ b/src/errors/sendError.ts
@@ -1,0 +1,24 @@
+import type { Request, Response } from "express";
+import type { AppError } from "./AppError.js";
+
+/**
+ * Emit the canonical error envelope from a middleware/route directly.
+ *
+ * Use this when calling `next(err)` is not appropriate (e.g., handlers passed
+ * to third-party libraries, or unit tests that mock `res`). The shape matches
+ * what the global error handler emits.
+ */
+export function sendErrorResponse(
+  res: Response,
+  err: AppError,
+  req?: Request,
+): Response {
+  const envelope = err.toJSON();
+  if (req) {
+    const requestId = req.requestId ?? req.id;
+    if (requestId !== undefined) {
+      envelope.requestId = requestId;
+    }
+  }
+  return res.status(err.statusCode).json(envelope);
+}

--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
 import { Request, Response, NextFunction } from "express";
+import { ForbiddenError, UnauthorizedError } from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 const API_KEY_HEADER = "x-api-key";
 const API_KEY_ID_PREFIX = "apiKey_";
@@ -28,17 +31,19 @@ export function requireApiKey(expectedApiKey?: string) {
     const provided = req.header(API_KEY_HEADER);
 
     if (!provided) {
-      return res.status(401).json({
-        success: false,
-        error: "Missing API key",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError("Missing API key", ERROR_CODES.INVALID_API_KEY.code),
+        req,
+      );
     }
 
     if (provided !== expectedApiKey) {
-      return res.status(403).json({
-        success: false,
-        error: "Invalid API key",
-      });
+      return sendErrorResponse(
+        res,
+        new ForbiddenError("Invalid API key", ERROR_CODES.INVALID_API_KEY.code),
+        req,
+      );
     }
 
     req.apiKeyId = deriveApiKeyId(provided);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,12 @@
 import type { NextFunction, Request, Response } from "express";
 import { jwtVerify } from "jose";
+import {
+  ForbiddenError,
+  InternalServerError,
+  UnauthorizedError,
+} from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 export type ChronoPayRole = "customer" | "admin" | "professional";
 
@@ -28,42 +35,59 @@ export async function authenticateToken(
         return next();
       }
 
-      return res.status(401).json({
-        success: false,
-        error: "Authorization header is required",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError(
+          "Authorization header is required",
+          ERROR_CODES.AUTHENTICATION_REQUIRED.code,
+        ),
+        req,
+      );
     }
 
     if (!authHeader.startsWith("Bearer ")) {
-      return res.status(401).json({
-        success: false,
-        error: "Authorization header must use Bearer scheme",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError(
+          "Authorization header must use Bearer scheme",
+          ERROR_CODES.INVALID_TOKEN.code,
+        ),
+        req,
+      );
     }
 
     const token = authHeader.slice("Bearer ".length).trim();
     if (!token) {
-      return res.status(401).json({
-        success: false,
-        error: "Bearer token is missing",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError(
+          "Bearer token is missing",
+          ERROR_CODES.INVALID_TOKEN.code,
+        ),
+        req,
+      );
     }
 
     if (!jwtSecret) {
-      return res.status(500).json({
-        success: false,
-        error: "Authentication middleware error",
-      });
+      return sendErrorResponse(
+        res,
+        new InternalServerError("Authentication middleware error"),
+        req,
+      );
     }
 
     const { payload } = await jwtVerify(token, new TextEncoder().encode(jwtSecret));
     req.user = payload as Request["user"];
     next();
   } catch {
-    return res.status(401).json({
-      success: false,
-      error: "Invalid or expired token",
-    });
+    return sendErrorResponse(
+      res,
+      new UnauthorizedError(
+        "Invalid or expired token",
+        ERROR_CODES.INVALID_TOKEN.code,
+      ),
+      req,
+    );
   }
 }
 
@@ -79,20 +103,28 @@ export function requireAuthenticatedActor(
 
     if (!rawUserId || rawUserId.trim().length === 0) {
       emitAuthAudit(req, "AUTH_MISSING", 401);
-      return res.status(401).json({
-        success: false,
-        error: "Authentication required.",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError(
+          "Authentication required.",
+          ERROR_CODES.AUTHENTICATION_REQUIRED.code,
+        ),
+        req,
+      );
     }
 
     const role = parseRole(rawRole);
     if (!allowedRoles.includes(role)) {
       // Safe to log the resolved role — it is a controlled enum value, not a raw header.
       emitAuthAudit(req, "AUTH_FORBIDDEN", 403, { role });
-      return res.status(403).json({
-        success: false,
-        error: "Role is not authorized for this action.",
-      });
+      return sendErrorResponse(
+        res,
+        new ForbiddenError(
+          "Role is not authorized for this action.",
+          ERROR_CODES.INSUFFICIENT_PERMISSIONS.code,
+        ),
+        req,
+      );
     }
 
     req.auth = {

--- a/src/middleware/authorization.ts
+++ b/src/middleware/authorization.ts
@@ -1,4 +1,10 @@
 import { NextFunction, Request, Response } from "express";
+import {
+  ConfigurationError,
+  ForbiddenError,
+  UnauthorizedError,
+} from "../errors/AppError.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 const ADMIN_TOKEN_HEADER = "x-chronopay-admin-token";
 
@@ -6,26 +12,25 @@ export function requireAdminToken(req: Request, res: Response, next: NextFunctio
   const configuredToken = process.env.CHRONOPAY_ADMIN_TOKEN;
 
   if (!configuredToken) {
-    return res.status(503).json({
-      success: false,
-      error: "Update slot authorization is not configured",
-    });
+    return sendErrorResponse(
+      res,
+      new ConfigurationError("Update slot authorization is not configured"),
+      req,
+    );
   }
 
   const providedToken = req.header(ADMIN_TOKEN_HEADER);
 
   if (!providedToken) {
-    return res.status(401).json({
-      success: false,
-      error: `Missing required header: ${ADMIN_TOKEN_HEADER}`,
-    });
+    return sendErrorResponse(
+      res,
+      new UnauthorizedError(`Missing required header: ${ADMIN_TOKEN_HEADER}`),
+      req,
+    );
   }
 
   if (providedToken !== configuredToken) {
-    return res.status(403).json({
-      success: false,
-      error: "Invalid admin token",
-    });
+    return sendErrorResponse(res, new ForbiddenError("Invalid admin token"), req);
   }
 
   return next();

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,15 +1,10 @@
 /**
- * Global Error Handling Middleware for ChronoPay API
+ * Global error handling middleware for ChronoPay API.
  *
- * This middleware provides centralized error handling across the application.
- * It catches all errors thrown in the application and returns appropriate
- * HTTP responses based on the error type.
+ * Emits the canonical flat error envelope:
+ *   { success: false, code, error, requestId?, timestamp, details?, stack? }
  *
- * Features:
- * - Structured error responses
- * - Security: Hides internal error details in production
- * - Logging: Supports external logging integration
- * - Type-safe error handling
+ * `stack` is included only when NODE_ENV !== "production".
  */
 
 import {
@@ -19,35 +14,20 @@ import {
   ErrorRequestHandler,
   RequestHandler,
 } from "express";
-import { AppError, isAppError, getStatusCode, ContentNegotiationError } from "../errors/AppError.js";
+import {
+  AppError,
+  isAppError,
+  getStatusCode,
+  type AppErrorEnvelope,
+} from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
 
-/**
- * Configuration options for error handling middleware
- */
 export interface ErrorHandlerOptions {
-  /**
-   * Function to handle error logging
-   * @param error - The error that occurred
-   * @param req - The incoming request
-   */
   logError?: (error: Error, req: Request) => void;
-
-  /**
-   * Whether to include stack trace in response (development only)
-   * @default process.env.NODE_ENV !== "production"
-   */
   includeStackTrace?: boolean;
-
-  /**
-   * Custom error message for unknown errors
-   * @default "An unexpected error occurred"
-   */
   unknownErrorMessage?: string;
 }
 
-/**
- * Default logging function
- */
 function defaultLogError(error: Error, req: Request): void {
   const timestamp = new Date().toISOString();
   const method = req.method;
@@ -61,21 +41,6 @@ function defaultLogError(error: Error, req: Request): void {
   );
 }
 
-/**
- * Global error handling middleware factory
- *
- * @param options - Configuration options for the middleware
- * @returns Express error handling middleware
- *
- * @example
- * ```typescript
- * const errorHandler = createErrorHandler({
- *   logError: (err, req) => logger.error(err, req),
- *   includeStackTrace: false
- * });
- * app.use(errorHandler);
- * ```
- */
 export function createErrorHandler(
   options: ErrorHandlerOptions = {},
 ): ErrorRequestHandler {
@@ -85,123 +50,62 @@ export function createErrorHandler(
     unknownErrorMessage = "An unexpected error occurred",
   } = options;
 
-  // Express error handler with 4 parameters
   return (
     err: Error,
     req: Request,
     res: Response,
     _next: NextFunction,
   ): void => {
-    // Log the error
     logError(err, req);
 
-    // Handle ContentNegotiationError with flat error envelope
-    if (err instanceof ContentNegotiationError) {
-      res.status(err.statusCode).json({
-        success: false,
-        code: err.code,
-        error: err.message,
-      });
-      return;
-    }
-
-    // Determine if this is an operational error (expected)
-    const isOperational = isAppError(err) && err.isOperational;
-
-    // Get appropriate status code
-    const statusCode = getStatusCode(err);
     const requestId = req.requestId ?? req.id;
+    const statusCode = getStatusCode(err);
 
-    // Build error response
-    let errorResponse: Record<string, unknown>;
+    let envelope: AppErrorEnvelope & { stack?: string };
 
     if (isAppError(err)) {
-      // Use the structured error from our custom error classes
-      errorResponse = err.toJSON();
-      if (
-        typeof errorResponse === "object" &&
-        errorResponse !== null &&
-        "error" in errorResponse &&
-        typeof (errorResponse as { error?: unknown }).error === "object" &&
-        (errorResponse as { error?: unknown }).error !== null
-      ) {
-        ((errorResponse as { error: Record<string, unknown> }).error).requestId = requestId;
-      }
+      envelope = (err as AppError).toJSON();
     } else {
-      // Handle unknown/unexpected errors
-      const errorObj: Record<string, unknown> = {
-        message: unknownErrorMessage,
-        code: "INTERNAL_ERROR",
-        timestamp: new Date().toISOString(),
-        requestId,
-      };
-
-      // Add stack trace in development only
-      if (includeStackTrace && err.stack) {
-        errorObj.stack = err.stack;
-      }
-
-      errorResponse = {
+      envelope = {
         success: false,
-        error: errorObj,
+        code: ERROR_CODES.INTERNAL_ERROR.code,
+        error: unknownErrorMessage,
+        timestamp: new Date().toISOString(),
       };
     }
 
-    // Send error response
-    res.status(statusCode).json(errorResponse);
+    if (requestId !== undefined) {
+      envelope.requestId = requestId;
+    }
+
+    if (!isAppError(err) && includeStackTrace && err.stack) {
+      envelope.stack = err.stack;
+    }
+
+    res.status(statusCode).json(envelope);
   };
 }
 
-/**
- * Async route handler wrapper
- *
- * Wraps async route handlers to automatically catch errors and pass them
- * to the error handling middleware.
- *
- * @param fn - Async route handler function
- * @returns Wrapped function with error handling
- *
- * @example
- * ```typescript
- * app.get('/api/users', asyncErrorHandler(async (req, res) => {
- *   const users = await getUsers();
- *   res.json(users);
- * }));
- * ```
- */
 export function asyncErrorHandler<T extends RequestHandler>(fn: T): T {
-  // Return a new function that wraps the original
   return ((req: Request, res: Response, next: NextFunction) => {
-    // Promise.resolve ensures fn can return either sync or async result
     Promise.resolve(fn(req, res, next)).catch(next);
   }) as T;
 }
 
-/**
- * Not Found handler for unmatched routes
- *
- * @param req - The incoming request
- * @param res - The response object
- * @param next - The next middleware function
- */
 export function notFoundHandler(
   req: Request,
-  res: Response,
+  _res: Response,
   next: NextFunction,
 ): void {
   const error = new AppError(
     `Route ${req.method} ${req.originalUrl} not found`,
-    404,
-    "NOT_FOUND",
+    ERROR_CODES.NOT_FOUND.status,
+    ERROR_CODES.NOT_FOUND.code,
     true,
   );
   next(error);
 }
 
-/**
- * 404 Handler middleware for unmatched routes
- */
 export const notFoundMiddleware: RequestHandler = notFoundHandler;
 
-// Default error handler instance
 export const errorHandler = createErrorHandler();

--- a/src/middleware/errorHandling.ts
+++ b/src/middleware/errorHandling.ts
@@ -1,15 +1,36 @@
 import { NextFunction, Request, Response } from "express";
+import {
+  AppError,
+  MalformedJsonError,
+  isAppError,
+  type AppErrorEnvelope,
+} from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+
+function withRequestContext(
+  envelope: AppErrorEnvelope,
+  req: Request,
+): AppErrorEnvelope {
+  const requestId = req.requestId ?? req.id;
+  if (requestId !== undefined) {
+    envelope.requestId = requestId;
+  }
+  return envelope;
+}
 
 export function notFoundHandler(req: Request, res: Response) {
-  return res.status(404).json({
-    success: false,
-    error: `Route not found: ${req.method} ${req.path}`,
-  });
+  const err = new AppError(
+    `Route not found: ${req.method} ${req.path}`,
+    ERROR_CODES.NOT_FOUND.status,
+    ERROR_CODES.NOT_FOUND.code,
+    true,
+  );
+  return res.status(err.statusCode).json(withRequestContext(err.toJSON(), req));
 }
 
 export function jsonParseErrorHandler(
   err: Error & { status?: number; type?: string },
-  _req: Request,
+  req: Request,
   res: Response,
   next: NextFunction,
 ) {
@@ -17,38 +38,29 @@ export function jsonParseErrorHandler(
     return next(err);
   }
 
-  return res.status(400).json({
-    success: false,
-    error: "Malformed JSON payload",
-  });
+  const wrapped = new MalformedJsonError();
+  return res
+    .status(wrapped.statusCode)
+    .json(withRequestContext(wrapped.toJSON(), req));
 }
 
 export function genericErrorHandler(
   err: unknown,
-  _req: Request,
+  req: Request,
   res: Response,
   _next: NextFunction,
 ) {
-  if (
-    err instanceof Error &&
-    "statusCode" in err &&
-    "code" in err
-  ) {
-    const e = err as any;
-    if (
-      (e.statusCode === 415 || e.statusCode === 406) &&
-      (e.code === "UNSUPPORTED_MEDIA_TYPE" || e.code === "NOT_ACCEPTABLE")
-    ) {
-      return res.status(e.statusCode).json({
-        success: false,
-        code: e.code,
-        error: e.message,
-      });
-    }
+  if (isAppError(err)) {
+    return res
+      .status(err.statusCode)
+      .json(withRequestContext(err.toJSON(), req));
   }
 
-  return res.status(500).json({
+  const fallback: AppErrorEnvelope = {
     success: false,
+    code: ERROR_CODES.INTERNAL_ERROR.code,
     error: "Internal server error",
-  });
+    timestamp: new Date().toISOString(),
+  };
+  return res.status(500).json(withRequestContext(fallback, req));
 }

--- a/src/middleware/featureFlags.ts
+++ b/src/middleware/featureFlags.ts
@@ -5,6 +5,9 @@ import {
   setFeatureFlagsFromEnv,
 } from "../flags/index.js";
 import type { FeatureFlagName } from "../flags/index.js";
+import { AppError, ServiceUnavailableError } from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 // Extend Express Request to include flags
 declare global {
@@ -40,20 +43,28 @@ export function requireFeatureFlag(flag: FeatureFlagName) {
   return (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.flags!.isEnabled(flag)) {
-        return res.status(503).json({
-          success: false,
-          code: "FEATURE_DISABLED",
-          error: `Feature ${flag} is currently disabled`,
-        });
+        return sendErrorResponse(
+          res,
+          new ServiceUnavailableError(
+            `Feature ${flag} is currently disabled`,
+            ERROR_CODES.FEATURE_DISABLED.code,
+          ),
+          req,
+        );
       }
 
       next();
     } catch {
-      return res.status(500).json({
-        success: false,
-        code: "FEATURE_FLAG_EVALUATION_ERROR",
-        error: "Feature flag evaluation failed",
-      });
+      return sendErrorResponse(
+        res,
+        new AppError(
+          "Feature flag evaluation failed",
+          ERROR_CODES.FEATURE_FLAG_EVALUATION_ERROR.status,
+          ERROR_CODES.FEATURE_FLAG_EVALUATION_ERROR.code,
+          true,
+        ),
+        req,
+      );
     }
   };
 }

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -2,6 +2,9 @@ import type { NextFunction, Request, Response } from "express";
 import { getRedisClient } from "../cache/redisClient.js";
 import { generateRequestHash } from "../utils/hash.js";
 import { getIdempotencyPayloadCodec } from "../utils/idempotencyPayloadCodec.js";
+import { IdempotencyError } from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 const IDEMPOTENCY_EXPIRATION_SECONDS = 86400;
 
@@ -40,10 +43,14 @@ export const idempotencyMiddleware = async (
   // --- Header validation: reject malformed keys before touching Redis ---
   const keyValidation = validateIdempotencyKey(idempotencyKey);
   if (!keyValidation.valid) {
-    res.status(400).json({
-      success: false,
-      error: keyValidation.reason,
-    });
+    sendErrorResponse(
+      res,
+      new IdempotencyError(
+        keyValidation.reason,
+        ERROR_CODES.IDEMPOTENCY_KEY_INVALID.code,
+      ),
+      req,
+    );
     return;
   }
 
@@ -57,18 +64,26 @@ export const idempotencyMiddleware = async (
       const parsedData = codec.deserialize<IdempotencyState>(existingData);
 
       if (parsedData.status === "processing") {
-        res.status(409).json({
-          success: false,
-          error: "Conflict: This transaction is actively running.",
-        });
+        sendErrorResponse(
+          res,
+          new IdempotencyError(
+            "Conflict: This transaction is actively running.",
+            ERROR_CODES.IDEMPOTENCY_IN_PROGRESS.code,
+          ),
+          req,
+        );
         return;
       }
 
       if (parsedData.requestHash !== incomingHash) {
-        res.status(422).json({
-          success: false,
-          error: "Unprocessable Entity: Idempotency-Key used with different payload.",
-        });
+        sendErrorResponse(
+          res,
+          new IdempotencyError(
+            "Unprocessable Entity: Idempotency-Key used with different payload.",
+            ERROR_CODES.IDEMPOTENCY_KEY_MISMATCH.code,
+          ),
+          req,
+        );
         return;
       }
 
@@ -92,10 +107,14 @@ export const idempotencyMiddleware = async (
     );
 
     if (lockAcquired !== "OK") {
-      res.status(409).json({
-        success: false,
-        error: "Conflict: This transaction is actively running.",
-      });
+      sendErrorResponse(
+        res,
+        new IdempotencyError(
+          "Conflict: This transaction is actively running.",
+          ERROR_CODES.IDEMPOTENCY_IN_PROGRESS.code,
+        ),
+        req,
+      );
       return;
     }
 

--- a/src/middleware/internalHmacAuth.ts
+++ b/src/middleware/internalHmacAuth.ts
@@ -1,6 +1,9 @@
 import crypto from "node:crypto";
 import type { NextFunction, Request, Response } from "express";
 import { getRedisClient } from "../utils/redis.js";
+import { ConflictError, UnauthorizedError } from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 const TIMESTAMP_HEADER = "x-chronopay-timestamp";
 const SIGNATURE_HEADER = "x-chronopay-signature";
@@ -74,26 +77,38 @@ export function requireInternalHmacAuth(options: InternalHmacOptions = {}) {
     const signatureHeader = req.header(SIGNATURE_HEADER);
 
     if (!timestampHeader || !signatureHeader) {
-      return res.status(401).json({
-        success: false,
-        error: "Missing internal authentication headers",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError(
+          "Missing internal authentication headers",
+          ERROR_CODES.AUTHENTICATION_REQUIRED.code,
+        ),
+        req,
+      );
     }
 
     const timestampMs = Number(timestampHeader);
     if (!Number.isFinite(timestampMs)) {
-      return res.status(401).json({
-        success: false,
-        error: "Invalid internal timestamp",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError(
+          "Invalid internal timestamp",
+          ERROR_CODES.INVALID_TIMESTAMP.code,
+        ),
+        req,
+      );
     }
 
     const ageSeconds = Math.abs(Date.now() - timestampMs) / 1000;
     if (ageSeconds > maxSkewSeconds) {
-      return res.status(401).json({
-        success: false,
-        error: "Internal request timestamp outside allowed skew window",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError(
+          "Internal request timestamp outside allowed skew window",
+          ERROR_CODES.TIMESTAMP_OUT_OF_SKEW.code,
+        ),
+        req,
+      );
     }
 
     const method = req.method.toUpperCase();
@@ -106,19 +121,27 @@ export function requireInternalHmacAuth(options: InternalHmacOptions = {}) {
       .digest("hex");
 
     if (!safeEqualHex(expectedSignature, signatureHeader)) {
-      return res.status(401).json({
-        success: false,
-        error: "Invalid internal request signature",
-      });
+      return sendErrorResponse(
+        res,
+        new UnauthorizedError(
+          "Invalid internal request signature",
+          ERROR_CODES.INVALID_SIGNATURE.code,
+        ),
+        req,
+      );
     }
 
     const replayKey = `${timestampHeader}:${signatureHeader}`;
     const isReplay = await detectReplay(replayKey, replayTtlSeconds);
     if (isReplay) {
-      return res.status(409).json({
-        success: false,
-        error: "Replay detected for internal request",
-      });
+      return sendErrorResponse(
+        res,
+        new ConflictError(
+          "Replay detected for internal request",
+          ERROR_CODES.REPLAY_DETECTED.code,
+        ),
+        req,
+      );
     }
 
     next();

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -4,6 +4,8 @@ import rateLimit, {
 } from "express-rate-limit";
 import { type Request, type Response } from "express";
 import { configService } from "../config/config.service.js";
+import { RateLimitError } from "../errors/AppError.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 /**
  * Creates a rate limiter middleware with configurable window and request ceiling.
@@ -20,11 +22,8 @@ export function createRateLimiter(
     limit: resolvedMax,
     standardHeaders: "draft-7",
     legacyHeaders: false,
-    handler: (_req: Request, res: Response) => {
-      res.status(429).json({
-        success: false,
-        error: "Too many requests, please try again later.",
-      });
+    handler: (req: Request, res: Response) => {
+      sendErrorResponse(res, new RateLimitError(), req);
     },
   };
 

--- a/src/middleware/rbac.ts
+++ b/src/middleware/rbac.ts
@@ -1,5 +1,13 @@
 import { Request, Response, NextFunction } from "express";
 import { defaultAuditLogger } from "../services/auditLogger.js";
+import {
+  BadRequestError,
+  ForbiddenError,
+  InternalServerError,
+  UnauthorizedError,
+} from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 const ROLE_HEADER = "x-user-role";
 const VALID_ROLES = ["admin", "professional", "customer"] as const;
@@ -43,35 +51,45 @@ export function requireRole(allowedRoles: UserRole[]) {
 
       if (!parsedRole) {
         emitRbacAudit(req, "RBAC_MISSING", 401);
-        return res.status(401).json({
-          success: false,
-          error: `Missing required authentication header: ${ROLE_HEADER}`,
-        });
+        return sendErrorResponse(
+          res,
+          new UnauthorizedError(
+            `Missing required authentication header: ${ROLE_HEADER}`,
+            ERROR_CODES.AUTHENTICATION_REQUIRED.code,
+          ),
+          req,
+        );
       }
 
       if (!isValidRole(parsedRole)) {
         // parsedRole is a normalized string — safe to log as it is not a raw header value.
         emitRbacAudit(req, "RBAC_INVALID_ROLE", 400, { role: parsedRole });
-        return res.status(400).json({
-          success: false,
-          error: "Invalid user role",
-        });
+        return sendErrorResponse(
+          res,
+          new BadRequestError("Invalid user role"),
+          req,
+        );
       }
 
       if (!allowedRoleSet.has(parsedRole)) {
         emitRbacAudit(req, "RBAC_FORBIDDEN", 403, { role: parsedRole });
-        return res.status(403).json({
-          success: false,
-          error: "Insufficient permissions",
-        });
+        return sendErrorResponse(
+          res,
+          new ForbiddenError(
+            "Insufficient permissions",
+            ERROR_CODES.INSUFFICIENT_PERMISSIONS.code,
+          ),
+          req,
+        );
       }
 
       return next();
     } catch {
-      return res.status(500).json({
-        success: false,
-        error: "Authorization middleware error",
-      });
+      return sendErrorResponse(
+        res,
+        new InternalServerError("Authorization middleware error"),
+        req,
+      );
     }
   };
 }

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,4 +1,10 @@
 import { Request, Response, NextFunction } from "express";
+import {
+  BadRequestError,
+  InternalServerError,
+  MissingRequiredFieldError,
+} from "../errors/AppError.js";
+import { sendErrorResponse } from "../errors/sendError.js";
 
 type ValidationTarget = "body" | "query" | "params";
 
@@ -11,29 +17,28 @@ export function validateRequiredFields(
       const data = req[target];
 
       if (!data || typeof data !== "object") {
-        return res.status(400).json({
-          success: false,
-          error: `Request ${target} is missing or invalid`,
-        });
+        return sendErrorResponse(
+          res,
+          new BadRequestError(`Request ${target} is missing or invalid`),
+          req,
+        );
       }
 
       for (const field of requiredFields) {
         const value = data[field];
 
         if (value === undefined || value === null || value === "") {
-          return res.status(400).json({
-            success: false,
-            error: `Missing required field: ${field}`,
-          });
+          return sendErrorResponse(res, new MissingRequiredFieldError(field), req);
         }
       }
 
       next();
     } catch {
-      return res.status(500).json({
-        success: false,
-        error: "Validation middleware error",
-      });
+      return sendErrorResponse(
+        res,
+        new InternalServerError("Validation middleware error"),
+        req,
+      );
     }
   };
 }


### PR DESCRIPTION
Closes #93

## Summary
- Adds a single source of truth for API error codes (`src/errors/errorCodes.ts`) and aligns every middleware response with one canonical flat envelope: `{ success: false, code, error, requestId?, timestamp, details? }`.
- Migrates 9 middleware (`validation`, `auth`, `authorization`, `apiKeyAuth`, `rbac`, `idempotency`, `rateLimiter`, `internalHmacAuth`, `featureFlags`) to emit stable codes (`VALIDATION_ERROR`, `RATE_LIMITED`, `IDEMPOTENCY_*`, `INVALID_API_KEY`, `INVALID_SIGNATURE`, etc.) via shared `AppError` subclasses.
- Reconciles `errorHandler.ts` and `errorHandling.ts` so both global handlers emit the same envelope. Stack traces are never returned in production.
- Documents the full taxonomy in `docs/error-codes.md` (codes, status, when emitted, example payloads, client integration).

## Envelope
```json
{
  "success": false,
  "code": "ERROR_CODE",
  "error": "Human-readable message.",
  "timestamp": "2026-04-26T...Z",
  "requestId": "req_abc123",
  "details": { /* optional */ }
}
```

## Codes added/centralized
Validation: `BAD_REQUEST`, `VALIDATION_ERROR`, `MISSING_REQUIRED_FIELD`, `INVALID_PAYLOAD`, `MALFORMED_JSON`
Auth: `UNAUTHORIZED`, `AUTHENTICATION_REQUIRED`, `INVALID_TOKEN`, `INVALID_API_KEY`, `INVALID_SIGNATURE`, `INVALID_TIMESTAMP`, `TIMESTAMP_OUT_OF_SKEW`
Authz: `FORBIDDEN`, `INSUFFICIENT_PERMISSIONS`, `INVALID_ROLE`
Rate / flags: `RATE_LIMITED`, `FEATURE_DISABLED`, `FEATURE_FLAG_EVALUATION_ERROR`
Idempotency: `IDEMPOTENCY_KEY_INVALID`, `IDEMPOTENCY_IN_PROGRESS`, `IDEMPOTENCY_KEY_MISMATCH`, `REPLAY_DETECTED`
Content: `UNSUPPORTED_MEDIA_TYPE`, `NOT_ACCEPTABLE`
State: `NOT_FOUND`, `CONFLICT`, `UNPROCESSABLE_ENTITY`
Infra: `INTERNAL_ERROR`, `DB_ERROR`, `SERVICE_UNAVAILABLE`, `CONFIGURATION_ERROR`

## Security
- `includeStackTrace` defaults to off in production for both `createErrorHandler` and `genericErrorHandler`. Verified via test that asserts `body.stack` is undefined under `NODE_ENV=production`.
- Unknown errors are mapped to `INTERNAL_ERROR` with a generic message; the original cause is logged but never serialized to the wire. New regression test asserts the original message does not leak.

## Test plan
- [x] New `src/__tests__/error-codes.test.ts` covers the taxonomy, every `AppError` subclass, sendErrorResponse helper, both global handlers, JSON parse error path, production stack-trace suppression, and details-payload round-trip.
- [x] Updated `error-handling.test.ts` to assert the canonical envelope.
- [x] Updated `feature-flags.middleware.test.ts`, `idempotency.test.ts`, `apiKeyAuth.unit.test.ts`, `validation-middleware.test.ts` to expect the new shape (`code` + `timestamp`).
- [x] Full `npm test` run shows zero regressions vs `main` (50 failed suites / 39 failed tests on both branches; +32 new passing tests). All remaining failures are pre-existing infrastructure issues (`jose` package not installed, `parseBoolean` not defined, `src/index.ts` parse error, duplicate identifier in `auth.ts`) unrelated to this issue.

## Out of scope
~189 direct `res.status().json({...})` call sites in route handlers still emit the legacy shape. The issue's "ensure middleware emit the envelope consistently" requirement is satisfied; route-level migration is the natural follow-up and intentionally not bundled here to keep the PR reviewable.