### PR TITLE
test: cover content negotiation middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import { featureFlagContextMiddleware, initializeFeatureFlagsFromEnv } from "./m
 import { createBookingIntentsRouter } from "./routes/booking-intents.js";
 import { AmountUtils } from "./utils/amount.js";
 import checkoutRouter from "./routes/checkout.js";
+import { configService } from "./config/config.service.js";
 import { createContentNegotiationMiddleware } from "./middleware/contentNegotiation.js";
 import { createRequestLogger } from "./middleware/requestLogger.js";
 

--- a/src/middleware/__tests__/contentNegotiation.test.ts
+++ b/src/middleware/__tests__/contentNegotiation.test.ts
@@ -1,6 +1,23 @@
+import { jest } from "@jest/globals";
 import express from "express";
 import request from "supertest";
 import { createContentNegotiationMiddleware } from "../contentNegotiation.js";
+
+jest.unstable_mockModule("../rateLimitStore.js", () => ({
+  rateLimitRedisStore: {
+    async incr() {
+      return 1;
+    },
+    async decrement() {},
+    async resetKey() {},
+  },
+}));
+
+let createApp: typeof import("../../app.js").createApp;
+
+beforeAll(async () => {
+  ({ createApp } = await import("../../app.js"));
+});
 
 function createHarness(options?: { excludePaths?: string[] }) {
   const app = express();
@@ -123,5 +140,30 @@ describe("content negotiation middleware", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ bypassed: true });
+  });
+
+  it("is wired before JSON parsing in the real app factory", async () => {
+    const rejected = await request(createApp({ enableDocs: false }))
+      .post("/api/v1/slots")
+      .set("Content-Type", "text/plain")
+      .set("Accept", "application/json")
+      .send("not json");
+
+    expect(rejected.status).toBe(415);
+    expect(rejected.body.code).toBe("UNSUPPORTED_MEDIA_TYPE");
+
+    const excluded = await request(
+      createApp({
+        enableDocs: false,
+        contentNegotiationExcludePaths: ["/api/v1/slots"],
+      }),
+    )
+      .post("/api/v1/slots")
+      .set("Content-Type", "text/plain")
+      .set("Accept", "text/html")
+      .send("not json");
+
+    expect(excluded.status).toBe(400);
+    expect(excluded.body.code).toBe("MISSING_REQUIRED_FIELD");
   });
 });

--- a/src/middleware/__tests__/contentNegotiation.test.ts
+++ b/src/middleware/__tests__/contentNegotiation.test.ts
@@ -1,0 +1,127 @@
+import express from "express";
+import request from "supertest";
+import { createContentNegotiationMiddleware } from "../contentNegotiation.js";
+
+function createHarness(options?: { excludePaths?: string[] }) {
+  const app = express();
+
+  app.use(createContentNegotiationMiddleware(options));
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  app.post("/echo", (req, res) => {
+    res.status(200).json({ body: req.body ?? null });
+  });
+
+  app.post("/webhooks/stripe/events", (_req, res) => {
+    res.status(200).json({ bypassed: true });
+  });
+
+  app.use(
+    (
+      err: unknown,
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      const error = err as {
+        statusCode?: number;
+        code?: string;
+        message?: string;
+      };
+      res.status(error.statusCode ?? 500).json({
+        success: false,
+        code: error.code,
+        error: error.message,
+      });
+    },
+  );
+
+  return app;
+}
+
+describe("content negotiation middleware", () => {
+  it("rejects POST requests with unsupported content types before JSON parsing", async () => {
+    const res = await request(createHarness())
+      .post("/echo")
+      .set("Content-Type", "text/plain")
+      .set("Accept", "application/json")
+      .send("not json");
+
+    expect(res.status).toBe(415);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: "UNSUPPORTED_MEDIA_TYPE",
+      error: "Content-Type must be application/json",
+    });
+  });
+
+  it("rejects POST requests that omit Content-Type", async () => {
+    const res = await request(createHarness())
+      .post("/echo")
+      .set("Accept", "application/json");
+
+    expect(res.status).toBe(415);
+    expect(res.body.code).toBe("UNSUPPORTED_MEDIA_TYPE");
+  });
+
+  it("allows JSON content types with charset parameters", async () => {
+    const res = await request(createHarness())
+      .post("/echo")
+      .set("Content-Type", "application/json; charset=utf-8")
+      .set("Accept", "application/json")
+      .send(JSON.stringify({ invoiceId: "inv_123" }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ body: { invoiceId: "inv_123" } });
+  });
+
+  it("allows wildcard Accept headers", async () => {
+    const res = await request(createHarness())
+      .post("/echo")
+      .set("Content-Type", "application/json")
+      .set("Accept", "*/*")
+      .send({ ok: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ body: { ok: true } });
+  });
+
+  it("rejects body requests that do not accept JSON responses", async () => {
+    const res = await request(createHarness())
+      .post("/echo")
+      .set("Content-Type", "application/json")
+      .set("Accept", "text/html")
+      .send({ ok: true });
+
+    expect(res.status).toBe(406);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: "NOT_ACCEPTABLE",
+      error: "Accept header must include application/json",
+    });
+  });
+
+  it("does not require JSON Accept headers for GET requests", async () => {
+    const res = await request(createHarness())
+      .get("/health")
+      .set("Accept", "text/html");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("bypasses configured excluded path prefixes", async () => {
+    const res = await request(createHarness({ excludePaths: ["/webhooks"] }))
+      .post("/webhooks/stripe/events")
+      .set("Content-Type", "text/plain")
+      .set("Accept", "text/html")
+      .send("raw webhook body");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bypassed: true });
+  });
+});


### PR DESCRIPTION
Fixes #229.

## Summary
- add focused middleware coverage for unsupported and missing Content-Type handling
- cover JSON charset handling, wildcard and non-JSON Accept headers, GET bypass behavior, and configured excluded path prefixes
- verify real createApp() wiring rejects non-JSON content before express.json() and honors contentNegotiationExcludePaths through the app factory
- keep the focused harness tests for edge cases while adding the app-factory regression check for src/app.ts

## Validation
- npm test -- src/middleware/__tests__/contentNegotiation.test.ts --runInBand (8 passed)
- npm test (9 passed)
- npm run build
- git diff --check
- hosted CI build-test passed on 0f1f5b88b2deca06d8b58acb98ea6cc13dbaf6fd