### PR TITLE
feat: add Stellar Horizon contract client (#197)

### DIFF
--- a/src/clients/__tests__/horizon-contract-client.test.ts
+++ b/src/clients/__tests__/horizon-contract-client.test.ts
@@ -1,0 +1,319 @@
+import { jest } from "@jest/globals";
+import { HorizonContractClient, HorizonHttpError } from "../../clients/horizon-contract-client.js";
+import { ContractService } from "../../services/contract.service.js";
+import { RetryPolicy } from "../../utils/retry-policy.js";
+import {
+  ContractExecutionError,
+  ContractInvalidRequestError,
+  ContractProviderUnavailableError,
+  ContractRateLimitError,
+} from "../../errors/contractErrors.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const BASE_URL = "https://horizon-testnet.stellar.org";
+const PASSPHRASE = "Test SDF Network ; September 2015";
+const ACCOUNT_ID = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+const TX_HASH = "abc123";
+const XDR = "AAAAAQAAAA==";
+
+function makeService(): ContractService {
+  return new ContractService(
+    new RetryPolicy({ maxRetries: 0, initialDelay: 0, backoffFactor: 1, maxDelay: 0, useJitter: false }),
+  );
+}
+
+function makeClient(url = BASE_URL): HorizonContractClient {
+  return new HorizonContractClient(url, PASSPHRASE, makeService());
+}
+
+function args(method: string, ...methodArgs: any[]) {
+  return { address: ACCOUNT_ID, abi: null, method, args: methodArgs };
+}
+
+// ─── fetch mock ───────────────────────────────────────────────────────────────
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function mockOk(body: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response);
+}
+
+function mockHttpError(status: number, body = "") {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    text: async () => body,
+  } as unknown as Response);
+}
+
+function mockNetworkError(message = "network failure") {
+  mockFetch.mockRejectedValueOnce(new Error(message));
+}
+
+function mockMalformedJson() {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => { throw new SyntaxError("Unexpected token"); },
+    text: async () => "not-json",
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+// ─── HorizonHttpError ─────────────────────────────────────────────────────────
+
+describe("HorizonHttpError", () => {
+  it("stores statusCode and truncates long body", () => {
+    const body = "x".repeat(300);
+    const err = new HorizonHttpError(503, body);
+    expect(err.statusCode).toBe(503);
+    expect(err.message.length).toBeLessThan(300);
+    expect(err.name).toBe("HorizonHttpError");
+  });
+
+  it("5xx message contains 'service unavailable'", () => {
+    expect(new HorizonHttpError(500, "err").message).toContain("service unavailable");
+    expect(new HorizonHttpError(503, "err").message).toContain("service unavailable");
+  });
+
+  it("429 message contains 'rate limit'", () => {
+    expect(new HorizonHttpError(429, "err").message).toContain("rate limit");
+  });
+
+  it("4xx message contains 'invalid argument'", () => {
+    expect(new HorizonHttpError(400, "err").message).toContain("invalid argument");
+    expect(new HorizonHttpError(404, "err").message).toContain("invalid argument");
+  });
+});
+
+// ─── call() ───────────────────────────────────────────────────────────────────
+
+describe("HorizonContractClient.call()", () => {
+  it("getAccount fetches /accounts/:id and returns data with blockNumber 0", async () => {
+    const account = { id: ACCOUNT_ID, sequence: "1" };
+    mockOk(account);
+
+    const client = makeClient();
+    const result = await client.call(args("getAccount", ACCOUNT_ID));
+
+    expect(result.data).toEqual(account);
+    expect(result.blockNumber).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE_URL}/accounts/${ACCOUNT_ID}`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("getTransactions fetches /accounts/:id/transactions", async () => {
+    const txList = { _embedded: { records: [] } };
+    mockOk(txList);
+
+    const client = makeClient();
+    await client.call(args("getTransactions", ACCOUNT_ID));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE_URL}/accounts/${ACCOUNT_ID}/transactions`,
+      expect.anything(),
+    );
+  });
+
+  it("getTransaction fetches /transactions/:hash", async () => {
+    const tx = { hash: TX_HASH };
+    mockOk(tx);
+
+    const client = makeClient();
+    await client.call(args("getTransaction", TX_HASH));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE_URL}/transactions/${TX_HASH}`,
+      expect.anything(),
+    );
+  });
+
+  it("strips trailing slash from base URL", async () => {
+    mockOk({ id: ACCOUNT_ID });
+    const client = makeClient(`${BASE_URL}/`);
+    await client.call(args("getAccount", ACCOUNT_ID));
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE_URL}/accounts/${ACCOUNT_ID}`,
+      expect.anything(),
+    );
+  });
+
+  it("throws ContractInvalidRequestError for unknown method", async () => {
+    const client = makeClient();
+    await expect(client.call(args("unknownMethod", ACCOUNT_ID))).rejects.toBeInstanceOf(
+      ContractInvalidRequestError,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("maps 404 to ContractInvalidRequestError", async () => {
+    mockHttpError(404, "not found");
+    const client = makeClient();
+    await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toBeInstanceOf(
+      ContractInvalidRequestError,
+    );
+  });
+
+  it("maps 429 to ContractRateLimitError", async () => {
+    mockHttpError(429, "rate limit");
+    const client = makeClient();
+    await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toBeInstanceOf(
+      ContractRateLimitError,
+    );
+  });
+
+  it("maps 503 to ContractProviderUnavailableError", async () => {
+    mockHttpError(503, "service unavailable");
+    const client = makeClient();
+    await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toBeInstanceOf(
+      ContractProviderUnavailableError,
+    );
+  });
+
+  it("maps 500 to ContractProviderUnavailableError", async () => {
+    mockHttpError(500, "internal server error");
+    const client = makeClient();
+    await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toBeInstanceOf(
+      ContractProviderUnavailableError,
+    );
+  });
+
+  it("maps 502 to ContractProviderUnavailableError", async () => {
+    mockHttpError(502, "bad gateway");
+    const client = makeClient();
+    await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toBeInstanceOf(
+      ContractProviderUnavailableError,
+    );
+  });
+
+  it("maps network error to AppError", async () => {
+    mockNetworkError("ECONNRESET");
+    const client = makeClient();
+    await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toBeInstanceOf(Error);
+  });
+
+  it("maps malformed JSON to ContractExecutionError", async () => {
+    mockMalformedJson();
+    const client = makeClient();
+    await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toBeInstanceOf(
+      ContractExecutionError,
+    );
+  });
+
+  it("URL-encodes special characters in account id", async () => {
+    mockOk({});
+    const client = makeClient();
+    const specialId = "GA+TEST/ID";
+    await client.call(args("getAccount", specialId));
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent(specialId)),
+      expect.anything(),
+    );
+  });
+});
+
+// ─── sendTransaction() ────────────────────────────────────────────────────────
+
+describe("HorizonContractClient.sendTransaction()", () => {
+  it("POSTs XDR to /transactions and returns hash", async () => {
+    mockOk({ hash: TX_HASH });
+
+    const client = makeClient();
+    const result = await client.sendTransaction(args("submitTransaction", XDR));
+
+    expect(result.hash).toBe(TX_HASH);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE_URL}/transactions`,
+      expect.objectContaining({
+        method: "POST",
+        body: `tx=${encodeURIComponent(XDR)}`,
+      }),
+    );
+  });
+
+  it("sets Content-Type to application/x-www-form-urlencoded", async () => {
+    mockOk({ hash: TX_HASH });
+    const client = makeClient();
+    await client.sendTransaction(args("submitTransaction", XDR));
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+      }),
+    );
+  });
+
+  it("wait() fetches /transactions/:hash", async () => {
+    mockOk({ hash: TX_HASH });
+    const txDetail = { hash: TX_HASH, ledger: 42 };
+    mockOk(txDetail);
+
+    const client = makeClient();
+    const result = await client.sendTransaction(args("submitTransaction", XDR));
+    const detail = await result.wait();
+
+    expect(detail).toEqual(txDetail);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE_URL}/transactions/${TX_HASH}`,
+      expect.anything(),
+    );
+  });
+
+  it("maps 400 submission error to ContractInvalidRequestError", async () => {
+    mockHttpError(400, "Transaction malformed");
+    const client = makeClient();
+    await expect(client.sendTransaction(args("submitTransaction", XDR))).rejects.toBeInstanceOf(
+      ContractInvalidRequestError,
+    );
+  });
+
+  it("maps 503 submission error to ContractProviderUnavailableError", async () => {
+    mockHttpError(503, "service unavailable");
+    const client = makeClient();
+    await expect(client.sendTransaction(args("submitTransaction", XDR))).rejects.toBeInstanceOf(
+      ContractProviderUnavailableError,
+    );
+  });
+
+  it("maps network error during submission to AppError", async () => {
+    mockNetworkError("ETIMEDOUT");
+    const client = makeClient();
+    await expect(client.sendTransaction(args("submitTransaction", XDR))).rejects.toBeInstanceOf(Error);
+  });
+});
+
+// ─── Circuit breaker integration ─────────────────────────────────────────────
+
+describe("circuit breaker integration", () => {
+  it("opens circuit after 5 consecutive 5xx failures", async () => {
+    // Use real ContractService with fast retry policy (0 retries)
+    const service = new ContractService(
+      new RetryPolicy({ maxRetries: 0, initialDelay: 0, backoffFactor: 1, maxDelay: 0, useJitter: false }),
+    );
+    const client = new HorizonContractClient(BASE_URL, PASSPHRASE, service);
+
+    for (let i = 0; i < 5; i++) {
+      mockHttpError(503, "service unavailable");
+      await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toThrow();
+    }
+
+    // 6th call should be blocked by circuit breaker (no fetch call)
+    await expect(client.call(args("getAccount", ACCOUNT_ID))).rejects.toBeInstanceOf(
+      ContractProviderUnavailableError,
+    );
+    // fetch was called exactly 5 times (circuit blocked the 6th)
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+  });
+});

--- a/src/clients/horizon-contract-client.ts
+++ b/src/clients/horizon-contract-client.ts
@@ -1,0 +1,156 @@
+import { IContractClient } from "./contract-client.interface.js";
+import { ContractInteractionArgs, ContractCallResult, TransactionResult } from "./types.js";
+import { ContractService } from "../services/contract.service.js";
+import { ContractInvalidRequestError } from "../errors/contractErrors.js";
+import { withTimeout } from "../utils/outbound-helper.js";
+import { timeoutConfig } from "../config/timeouts.js";
+
+/**
+ * Stellar Horizon HTTP API client implementing IContractClient.
+ *
+ * Maps Horizon REST endpoints onto the generic contract interface:
+ *   - call()            → GET  /accounts/:address  (read-only queries)
+ *   - sendTransaction() → POST /transactions        (XDR envelope submission)
+ *
+ * The `method` field in ContractInteractionArgs selects the Horizon operation:
+ *   call:            "getAccount" | "getTransactions" | "getTransaction"
+ *   sendTransaction: "submitTransaction"
+ *
+ * `args[0]` carries the primary resource identifier (account id, tx hash, or XDR).
+ */
+export class HorizonContractClient implements IContractClient {
+  private readonly horizonUrl: string;
+  private readonly networkPassphrase: string;
+  private readonly contractService: ContractService;
+
+  constructor(horizonUrl: string, networkPassphrase: string, contractService: ContractService) {
+    this.horizonUrl = horizonUrl.replace(/\/$/, "");
+    this.networkPassphrase = networkPassphrase;
+    this.contractService = contractService;
+  }
+
+  /**
+   * Executes a read-only Horizon query.
+   *
+   * Supported methods:
+   *   - "getAccount"      → GET /accounts/{args[0]}
+   *   - "getTransactions" → GET /accounts/{args[0]}/transactions
+   *   - "getTransaction"  → GET /transactions/{args[0]}
+   */
+  async call<T>(args: ContractInteractionArgs): Promise<ContractCallResult<T>> {
+    const url = this.buildReadUrl(args.method, args.args);
+
+    const data = await this.contractService.call<T>(
+      `horizon:${args.method}`,
+      () =>
+        withTimeout(
+          async (signal) => this.fetchJson<T>(url, { signal }),
+          timeoutConfig.http.contractMs,
+          "horizon",
+        ),
+    );
+
+    return { data, blockNumber: 0 };
+  }
+
+  /**
+   * Submits a signed Stellar transaction XDR envelope to Horizon.
+   *
+   * args.args[0] must be the base64-encoded XDR transaction envelope.
+   */
+  async sendTransaction(args: ContractInteractionArgs): Promise<TransactionResult> {
+    const xdr = args.args[0] as string;
+    const url = `${this.horizonUrl}/transactions`;
+
+    const response = await this.contractService.sendTransaction<{ hash: string }>(
+      "horizon:submitTransaction",
+      () =>
+        withTimeout(
+          async (signal) =>
+            this.fetchJson<{ hash: string }>(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+              },
+              body: `tx=${encodeURIComponent(xdr)}`,
+              signal,
+            }),
+          timeoutConfig.http.contractMs,
+          "horizon",
+        ),
+    );
+
+    return {
+      hash: response.hash,
+      wait: async () => {
+        const txUrl = `${this.horizonUrl}/transactions/${response.hash}`;
+        return withTimeout(
+          async (signal) => this.fetchJson(txUrl, { signal }),
+          timeoutConfig.http.contractMs,
+          "horizon",
+        );
+      },
+    };
+  }
+
+  private buildReadUrl(method: string, methodArgs: any[]): string {
+    const id = methodArgs[0] as string;
+    switch (method) {
+      case "getAccount":
+        return `${this.horizonUrl}/accounts/${encodeURIComponent(id)}`;
+      case "getTransactions":
+        return `${this.horizonUrl}/accounts/${encodeURIComponent(id)}/transactions`;
+      case "getTransaction":
+        return `${this.horizonUrl}/transactions/${encodeURIComponent(id)}`;
+      default:
+        throw new ContractInvalidRequestError(`Unknown Horizon method: ${method}`);
+    }
+  }
+
+  private async fetchJson<T>(url: string, init: RequestInit = {}): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetch(url, init);
+    } catch (err) {
+      // Network-level error (ECONNRESET, ETIMEDOUT, etc.) — rethrow raw so
+      // mapContractError in ContractService can classify it correctly.
+      throw err;
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new HorizonHttpError(response.status, body);
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch {
+      // "malformed" doesn't match any mapContractError pattern → ContractExecutionError
+      throw new Error("Horizon returned malformed JSON response");
+    }
+  }
+}
+
+/**
+ * Represents an HTTP error from the Horizon API.
+ * The message is crafted to match patterns in mapContractError:
+ *   - 5xx → "service unavailable" → ContractProviderUnavailableError
+ *   - 429 → "rate limit"          → ContractRateLimitError
+ *   - 4xx → "invalid argument"    → ContractInvalidRequestError
+ */
+export class HorizonHttpError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    body: string,
+  ) {
+    super(HorizonHttpError.buildMessage(statusCode, body));
+    this.name = "HorizonHttpError";
+  }
+
+  private static buildMessage(status: number, body: string): string {
+    const detail = body.slice(0, 200);
+    if (status >= 500) return `service unavailable: Horizon HTTP ${status}: ${detail}`;
+    if (status === 429) return `rate limit exceeded: Horizon HTTP ${status}: ${detail}`;
+    return `invalid argument: Horizon HTTP ${status}: ${detail}`;
+  }
+}

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -264,3 +264,51 @@ describe("EnvValidationError", () => {
     }
   });
 });
+
+// ─── HORIZON_URL ──────────────────────────────────────────────────────────────
+
+describe("HORIZON_URL", () => {
+  it("returns undefined when omitted", () => {
+    expect(load().horizonUrl).toBeUndefined();
+  });
+
+  it("accepts https:// URL", () => {
+    expect(load({ HORIZON_URL: "https://horizon-testnet.stellar.org" }).horizonUrl).toBe(
+      "https://horizon-testnet.stellar.org",
+    );
+  });
+
+  it("accepts http:// URL", () => {
+    expect(load({ HORIZON_URL: "http://localhost:8000" }).horizonUrl).toBe("http://localhost:8000");
+  });
+
+  it("returns undefined for whitespace-only value", () => {
+    expect(load({ HORIZON_URL: "   " }).horizonUrl).toBeUndefined();
+  });
+
+  it("rejects non-http scheme", () => {
+    expectIssue({ ...VALID, HORIZON_URL: "ftp://horizon.example.com" }, "HORIZON_URL");
+  });
+
+  it("rejects invalid URL", () => {
+    expectIssue({ ...VALID, HORIZON_URL: "not-a-url" }, "HORIZON_URL");
+  });
+});
+
+// ─── STELLAR_NETWORK_PASSPHRASE ───────────────────────────────────────────────
+
+describe("STELLAR_NETWORK_PASSPHRASE", () => {
+  it("returns undefined when omitted", () => {
+    expect(load().networkPassphrase).toBeUndefined();
+  });
+
+  it("returns trimmed passphrase when provided", () => {
+    expect(
+      load({ STELLAR_NETWORK_PASSPHRASE: "  Test SDF Network ; September 2015  " }).networkPassphrase,
+    ).toBe("Test SDF Network ; September 2015");
+  });
+
+  it("returns undefined for whitespace-only value", () => {
+    expect(load({ STELLAR_NETWORK_PASSPHRASE: "   " }).networkPassphrase).toBeUndefined();
+  });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -31,6 +31,10 @@ export interface EnvConfig {
   jwtIssuer?: string;
   jwtAudience?: string;
   corsAllowedOrigins?: string[];
+  /** Stellar Horizon base URL (e.g. https://horizon-testnet.stellar.org) */
+  horizonUrl?: string;
+  /** Stellar network passphrase used to identify the target network */
+  networkPassphrase?: string;
 }
 
 export class EnvValidationError extends Error {
@@ -64,6 +68,8 @@ export function loadEnvConfig(env: NodeJS.ProcessEnv = process.env): EnvConfig {
   const jwtIssuer = parseOptionalString(env.JWT_ISSUER);
   const jwtAudience = parseOptionalString(env.JWT_AUDIENCE);
   const corsAllowedOrigins = parseStringList(env.CORS_ALLOWED_ORIGINS);
+  const horizonUrl = parseOptionalUrl(env.HORIZON_URL, "HORIZON_URL", issues);
+  const networkPassphrase = parseOptionalString(env.STELLAR_NETWORK_PASSPHRASE);
 
   if (issues.length > 0) {
     throw new EnvValidationError(issues);
@@ -81,6 +87,8 @@ export function loadEnvConfig(env: NodeJS.ProcessEnv = process.env): EnvConfig {
     jwtIssuer,
     jwtAudience,
     corsAllowedOrigins,
+    horizonUrl,
+    networkPassphrase,
   };
 }
 
@@ -209,4 +217,21 @@ function parseOptionalString(rawValue: string | undefined): string | undefined {
 function parseStringList(rawValue: string | undefined): string[] {
   if (rawValue === undefined) return [];
   return rawValue.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+function parseOptionalUrl(rawValue: string | undefined, key: string, issues: string[]): string | undefined {
+  if (rawValue === undefined) return undefined;
+  const value = rawValue.trim();
+  if (value.length === 0) return undefined;
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:"].includes(url.protocol)) {
+      issues.push(`${key} must use http or https scheme.`);
+      return undefined;
+    }
+    return value;
+  } catch {
+    issues.push(`${key} must be a valid URL.`);
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Summary

Implements `IContractClient` backed by the Stellar Horizon HTTP API, enabling account queries and transaction submission without adding the `stellar-sdk` dependency.

## Changes

### `src/clients/horizon-contract-client.ts` (new)
- `HorizonContractClient` implements `IContractClient` via native `fetch`
- `call()` supports `getAccount`, `getTransactions`, `getTransaction` → GET endpoints
- `sendTransaction()` submits XDR envelopes via POST `/transactions`
- `HorizonHttpError` maps HTTP status codes to messages `mapContractError` can classify:
  - 5xx → `ContractProviderUnavailableError`
  - 429 → `ContractRateLimitError`
  - 4xx → `ContractInvalidRequestError`
- Reuses `ContractService` circuit breaker (5 failures / 30 s) and `RetryPolicy`
- Reuses `withTimeout` with `timeoutConfig.http.contractMs`

### `src/config/env.ts` (modified)
- Adds `horizonUrl` (`HORIZON_URL`) — optional, validated as http/https URL
- Adds `networkPassphrase` (`STELLAR_NETWORK_PASSPHRASE`) — optional string

### Tests
- 24 tests in `horizon-contract-client.test.ts` covering all methods, error paths (4xx / 5xx / network / malformed JSON), URL encoding, trailing-slash normalisation, and circuit-breaker integration
- Env tests for `HORIZON_URL` and `STELLAR_NETWORK_PASSPHRASE`

## Test output
All new tests pass. Pre-existing failures in `inMemoryCache`, `slotService`, `scheduling`, and `hooks` are unrelated (merge conflicts and missing exports on `main`).

Closes #212