### PR TITLE
feat: add /health/ready readiness probe with DB and Redis checks

### DIFF
--- a/src/__tests__/booking-intents-idempotency.test.ts
+++ b/src/__tests__/booking-intents-idempotency.test.ts
@@ -65,6 +65,10 @@ class InMemoryRedisMock implements RedisClient {
     return Array.from(this.store.keys()).filter((k) => k.startsWith(prefix));
   }
 
+  async ping(): Promise<string> {
+    return "PONG";
+  }
+
   async quit(): Promise<unknown> {
     this.store.clear();
     return "OK";

--- a/src/__tests__/health-readiness.test.ts
+++ b/src/__tests__/health-readiness.test.ts
@@ -1,0 +1,186 @@
+import { jest } from "@jest/globals";
+import request from "supertest";
+import { checkReadiness, checkDb, checkRedis } from "../health/readiness.js";
+
+jest.mock("../middleware/rateLimiter.js", () => ({
+  createAuthAwareRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../middleware/featureFlags.js", () => ({
+  featureFlagContextMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  initializeFeatureFlagsFromEnv: () => {},
+}));
+
+jest.mock("../routes/booking-intents.js", () => ({
+  createBookingIntentsRouter: () => {
+    const { Router } = require("express");
+    return Router();
+  },
+}));
+
+jest.mock("../routes/checkout.js", () => {
+  const { Router } = require("express");
+  return { default: Router() };
+});
+
+function mockPool(ok: boolean) {
+  return {
+    query: jest.fn<() => Promise<unknown>>().mockImplementation(() =>
+      ok ? Promise.resolve({ rowCount: 1 }) : Promise.reject(new Error("DB down")),
+    ),
+  };
+}
+
+function mockRedis(ok: boolean) {
+  return {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    keys: jest.fn(),
+    ping: jest.fn<() => Promise<string>>().mockImplementation(() =>
+      ok ? Promise.resolve("PONG") : Promise.reject(new Error("Redis down")),
+    ),
+    quit: jest.fn(),
+  };
+}
+
+describe("checkReadiness", () => {
+  it("returns both ok when DB and Redis are up", async () => {
+    const result = await checkReadiness({
+      pingDb: () => checkDb(mockPool(true)),
+      pingRedis: () => checkRedis(mockRedis(true)),
+    });
+    expect(result).toEqual({ db: "ok", redis: "ok" });
+  });
+
+  it("returns db down when DB query fails", async () => {
+    const result = await checkReadiness({
+      pingDb: () => checkDb(mockPool(false)),
+      pingRedis: () => checkRedis(mockRedis(true)),
+    });
+    expect(result).toEqual({ db: "down", redis: "ok" });
+  });
+
+  it("returns redis down when Redis ping fails", async () => {
+    const result = await checkReadiness({
+      pingDb: () => checkDb(mockPool(true)),
+      pingRedis: () => checkRedis(mockRedis(false)),
+    });
+    expect(result).toEqual({ db: "ok", redis: "down" });
+  });
+
+  it("returns both down when both fail", async () => {
+    const result = await checkReadiness({
+      pingDb: () => checkDb(mockPool(false)),
+      pingRedis: () => checkRedis(mockRedis(false)),
+    });
+    expect(result).toEqual({ db: "down", redis: "down" });
+  });
+
+  it("does not short-circuit when one fails — both checks run", async () => {
+    const dbSpy = jest.fn(() => checkDb(mockPool(false)));
+    const redisSpy = jest.fn(() => checkRedis(mockRedis(true)));
+    const result = await checkReadiness({ pingDb: dbSpy, pingRedis: redisSpy });
+    expect(result).toEqual({ db: "down", redis: "ok" });
+    expect(dbSpy).toHaveBeenCalledTimes(1);
+    expect(redisSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GET /health/ready", () => {
+  it("returns 200 when DB and Redis are up", async () => {
+    const { createApp } = await import("../app.js");
+    const app = createApp({
+      enableDocs: false,
+      dbPool: mockPool(true),
+      redisClient: mockRedis(true),
+    });
+    const res = await request(app).get("/health/ready");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ db: "ok", redis: "ok" });
+  });
+
+  it("returns 503 when DB is down", async () => {
+    const { createApp } = await import("../app.js");
+    const app = createApp({
+      enableDocs: false,
+      dbPool: mockPool(false),
+      redisClient: mockRedis(true),
+    });
+    const res = await request(app).get("/health/ready");
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ db: "down", redis: "ok" });
+  });
+
+  it("returns 503 when Redis is down", async () => {
+    const { createApp } = await import("../app.js");
+    const app = createApp({
+      enableDocs: false,
+      dbPool: mockPool(true),
+      redisClient: mockRedis(false),
+    });
+    const res = await request(app).get("/health/ready");
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ db: "ok", redis: "down" });
+  });
+
+  it("returns 503 when both are down", async () => {
+    const { createApp } = await import("../app.js");
+    const app = createApp({
+      enableDocs: false,
+      dbPool: mockPool(false),
+      redisClient: mockRedis(false),
+    });
+    const res = await request(app).get("/health/ready");
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ db: "down", redis: "down" });
+  });
+
+  it("falls back to down when dbPool is null", async () => {
+    const { createApp } = await import("../app.js");
+    const app = createApp({
+      enableDocs: false,
+      dbPool: null,
+      redisClient: mockRedis(true),
+    });
+    const res = await request(app).get("/health/ready");
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ db: "down", redis: "ok" });
+  });
+
+  it("falls back to down when redisClient is null", async () => {
+    const { createApp } = await import("../app.js");
+    const app = createApp({
+      enableDocs: false,
+      dbPool: mockPool(true),
+      redisClient: null,
+    });
+    const res = await request(app).get("/health/ready");
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ db: "ok", redis: "down" });
+  });
+});
+
+describe("checkDb", () => {
+  it("returns true on successful query", async () => {
+    const result = await checkDb(mockPool(true));
+    expect(result).toBe(true);
+  });
+
+  it("returns false on query failure", async () => {
+    const result = await checkDb(mockPool(false));
+    expect(result).toBe(false);
+  });
+});
+
+describe("checkRedis", () => {
+  it("returns true on successful ping", async () => {
+    const result = await checkRedis(mockRedis(true));
+    expect(result).toBe(true);
+  });
+
+  it("returns false on ping failure", async () => {
+    const result = await checkRedis(mockRedis(false));
+    expect(result).toBe(false);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,7 @@
 import { createRequire } from "node:module";
 import { randomUUID } from "node:crypto";
 import cors from "cors";
-<<<<<<< HEAD
 import express, { type Request, type Response } from "express";
-=======
-import express, { type Request, type Response } from "express";
->>>>>>> upstream/main
 import { configService } from "./config/config.service.js";
 import { requireApiKey } from "./middleware/apiKeyAuth.js";
 import { createAuthAwareRateLimiter } from "./middleware/rateLimiter.js";
@@ -22,6 +18,9 @@ import { featureFlagContextMiddleware, requireFeatureFlag } from "./middleware/f
 import { register, metricsMiddleware } from "./metrics.js";
 import { createContentNegotiationMiddleware } from "./middleware/contentNegotiation.js";
 import { createRequestLogger } from "./middleware/requestLogger.js";
+import type { Pool } from "pg";
+import type { RedisClient } from "./cache/redisClient.js";
+import { checkReadiness, checkDb, checkRedis } from "./health/readiness.js";
 
 // Import routers
 import checkoutRouter from "./routes/checkout.js";
@@ -40,6 +39,8 @@ export interface AppFactoryOptions {
   contentNegotiationExcludePaths?: string[];
   slotRepository?: any;
   bookingIntentService?: any;
+  dbPool?: Pick<Pool, "query"> | null;
+  redisClient?: RedisClient | null;
 }
 
 function registerSwaggerDocs(app: express.Express) {
@@ -218,7 +219,7 @@ export function createApp(options: AppFactoryOptions = {}) {
     registerSwaggerDocs(app);
   }
 
-  // Health check
+  // Health check (liveness — cheap, no deps)
   app.get("/health", (_req, res) => {
     const health = { status: "ok", service: "chronopay-backend" };
     // Only include timestamp/version if not in a strict test environment that expects exactly two fields
@@ -234,6 +235,24 @@ export function createApp(options: AppFactoryOptions = {}) {
 
   app.get("/live", (_req, res) => {
     res.json({ status: "alive", service: "chronopay-backend", timestamp: new Date().toISOString() });
+  });
+
+  // Readiness probe — checks DB and Redis connectivity
+  app.get("/health/ready", async (_req, res) => {
+    const result = await checkReadiness({
+      pingDb: async () => {
+        if (options.dbPool !== undefined) return checkDb(options.dbPool ?? null);
+        const pool = await tryGetPool();
+        return pool ? checkDb(pool) : false;
+      },
+      pingRedis: async () => {
+        if (options.redisClient !== undefined) return options.redisClient ? checkRedis(options.redisClient) : false;
+        const client = await tryGetRedisClient();
+        return client ? checkRedis(client) : false;
+      },
+    });
+    const httpStatus = result.db === "ok" && result.redis === "ok" ? 200 : 503;
+    res.status(httpStatus).json(result);
   });
 
   // Metrics
@@ -387,6 +406,24 @@ export function createApp(options: AppFactoryOptions = {}) {
     app.get("/__test__/explode", () => {
       throw new Error("Intentional test fault");
     });
+  }
+
+  async function tryGetPool(): Promise<Pick<Pool, "query"> | null> {
+    try {
+      const mod = await import("./db/pool.js");
+      return (mod.default || mod) as Pick<Pool, "query">;
+    } catch {
+      return null;
+    }
+  }
+
+  async function tryGetRedisClient(): Promise<RedisClient | null> {
+    try {
+      const { getRedisClient } = await import("./cache/redisClient.js");
+      return getRedisClient();
+    } catch {
+      return null;
+    }
   }
 
   // Error Handlers

--- a/src/cache/__tests__/slotCache.test.ts
+++ b/src/cache/__tests__/slotCache.test.ts
@@ -6,13 +6,13 @@
  * HIT/MISS behavior, TTL from env, and graceful error degradation.
  *
  * Coverage targets:
- *  - getCachedSlotsPage  — HIT, MISS, error fallback
- *  - setCachedSlotsPage  — write-through, error fallback
- *  - getOrFetchSlots     — single-flight, cache HIT, cache MISS
- *  - getCachedSlots      — legacy path
- *  - setCachedSlots      — legacy path
- *  - invalidateSlotsCache — clears page keys and legacy key
- *  - Redis unavailable    — all functions return safe defaults
+ *  - getCachedSlotsPage  ï¿½ HIT, MISS, error fallback
+ *  - setCachedSlotsPage  ï¿½ write-through, error fallback
+ *  - getOrFetchSlots     ï¿½ single-flight, cache HIT, cache MISS
+ *  - getCachedSlots      ï¿½ legacy path
+ *  - setCachedSlots      ï¿½ legacy path
+ *  - invalidateSlotsCache ï¿½ clears page keys and legacy key
+ *  - Redis unavailable    ï¿½ all functions return safe defaults
  */
 
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
@@ -58,6 +58,9 @@ function createMockRedisClient(): RedisClient & { _store: Map<string, string> } 
       // Simple glob: "slots:page:*" matches anything starting with "slots:page:"
       const prefix = pattern.replace(/\*$/, "");
       return Array.from(store.keys()).filter((k) => k.startsWith(prefix));
+    },
+    async ping(): Promise<string> {
+      return "PONG";
     },
     async quit(): Promise<"OK"> {
       return "OK";
@@ -243,7 +246,7 @@ describe("invalidateSlotsCache", () => {
     });
     setRedisClient(redis);
 
-    // Should not throw — error is caught internally
+    // Should not throw ï¿½ error is caught internally
     await expect(invalidateSlotsCache()).resolves.toBeUndefined();
 
     // slots:page:2 should still have been deleted (Promise.all continues)
@@ -374,7 +377,7 @@ describe("SLOT_CACHE_TTL_SECONDS", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Redis unavailable — all paths return safe defaults
+// Redis unavailable ï¿½ all paths return safe defaults
 // ---------------------------------------------------------------------------
 
 describe("Redis unavailable", () => {
@@ -409,7 +412,7 @@ describe("Redis unavailable", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Cache invalidation after write — integration scenario
+// Cache invalidation after write ï¿½ integration scenario
 // ---------------------------------------------------------------------------
 
 describe("Cache lifecycle: set ? get (HIT) ? invalidate ? get (MISS)", () => {
@@ -422,7 +425,7 @@ describe("Cache lifecycle: set ? get (HIT) ? invalidate ? get (MISS)", () => {
     // Set cache
     await setCachedSlotsPage(1, paginated);
 
-    // Get — should be HIT
+    // Get ï¿½ should be HIT
     const hit = await getCachedSlotsPage(1);
     expect(hit).not.toBeNull();
     expect(hit!.slots).toHaveLength(2);
@@ -430,7 +433,7 @@ describe("Cache lifecycle: set ? get (HIT) ? invalidate ? get (MISS)", () => {
     // Invalidate
     await invalidateSlotsCache();
 
-    // Get — should be MISS
+    // Get ï¿½ should be MISS
     const miss = await getCachedSlotsPage(1);
     expect(miss).toBeNull();
   });

--- a/src/cache/redisClient.ts
+++ b/src/cache/redisClient.ts
@@ -32,6 +32,7 @@ export interface RedisClient {
   set(key: string, value: string, exMode: "EX", ttl: number, condition?: "NX"): Promise<unknown>;
   del(key: string): Promise<unknown>;
   keys(pattern: string): Promise<string[]>;
+  ping(): Promise<string>;
   quit(): Promise<unknown>;
 }
 

--- a/src/health/readiness.ts
+++ b/src/health/readiness.ts
@@ -1,0 +1,35 @@
+import type { Pool } from "pg";
+import type { RedisClient } from "../cache/redisClient.js";
+
+export interface ReadinessResult {
+  db: "ok" | "down";
+  redis: "ok" | "down";
+}
+
+export interface ReadinessPingers {
+  pingDb: () => Promise<boolean>;
+  pingRedis: () => Promise<boolean>;
+}
+
+export async function checkReadiness(pingers: ReadinessPingers): Promise<ReadinessResult> {
+  const [dbOk, redisOk] = await Promise.all([pingers.pingDb(), pingers.pingRedis()]);
+  return {
+    db: dbOk ? "ok" : "down",
+    redis: redisOk ? "ok" : "down",
+  };
+}
+
+export function checkDb(pool: Pick<Pool, "query"> | null | undefined): Promise<boolean> {
+  if (!pool) return Promise.resolve(false);
+  return pool
+    .query("SELECT 1")
+    .then(() => true)
+    .catch(() => false);
+}
+
+export function checkRedis(client: RedisClient): Promise<boolean> {
+  return client
+    .ping()
+    .then(() => true)
+    .catch(() => false);
+}


### PR DESCRIPTION
Closes #214

---

Implements issue #214 - a readiness probe at GET /health/ready that verifies PostgreSQL and Redis connectivity before reporting ready.

- Adds GET /health/ready returning { db, redis } with 200 (both ok) or 503 (any down)
- Adds src/health/readiness.ts with checkReadiness, checkDb, checkRedis
- Adds ping() to RedisClient interface for readiness checks
- Wires deps through AppFactoryOptions (dbPool, redisClient) for test DI
- 15 tests covering all states (both up, DB down, Redis down, both down, null deps)
- Fixes leftover merge conflict in app.ts
- Keeps /health as cheap liveness probe unchanged