### PR TITLE
feat: enforce coverage threshold in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,16 @@ jobs:
       - name: Validate migrations
         run: npm run migrate validate
 
-      - name: Run tests
+      - name: Run tests with coverage
         env:
           NODE_ENV: test
           REDIS_URL: redis://localhost:6379
-        run: npm test
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -23,4 +23,21 @@ module.exports = {
   transform: { "^.+\\.tsx?$": ["ts-jest", { useESM: true }] },
   testMatch: ["**/__tests__/**/*.test.ts"],
   clearMocks: true,
+  coverageDirectory: "coverage",
+  coverageReporters: ["lcov", "text-summary"],
+  collectCoverageFrom: [
+    "src/**/*.ts",
+    "!src/index.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.spec.ts",
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,js,cjs,mjs}\" \".github/workflows/*.{yml,yaml}\" \"eslint.config.js\" \"package.json\" \"tsconfig.json\" \"README.md\" \".prettierrc\"",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand",
+    "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --coverage",
     "migrate": "tsx src/scripts/migrate.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #257

---

Implements issue #257 — adds code coverage gates to the CI pipeline.

- Adds coverageThreshold (80% branches, functions, lines, statements) to jest.config.cjs
- Adds collectCoverageFrom including src/**/*.ts but excluding entry points and test files
- Adds test:coverage script to package.json (jest --runInBand --coverage)
- Updates CI workflow to run test:coverage and upload lcov report as an artifact
- CI fails when coverage drops below threshold