### PR TITLE
feat: add postgres and redis services to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,38 @@ jobs:
 
   build-test:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://test:test@localhost:5432/testdb
+      POSTGRESQL_URL: postgres://test:test@localhost:5432/testdb
+      REDIS_URL: redis://localhost:6379
+      NODE_ENV: test
+
     steps:
       - uses: actions/checkout@v4
 
@@ -50,8 +82,8 @@ jobs:
       - name: Validate migrations
         run: npm run migrate validate
 
+      - name: Run migrations
+        run: npm run migrate up
+
       - name: Run tests
-        env:
-          NODE_ENV: test
-          REDIS_URL: redis://localhost:6379
         run: npm test


### PR DESCRIPTION
Closes #258

---

Implements issue #258 — adds Postgres and Redis service containers so DB-backed tests and migrations can run in the CI pipeline.

- Adds postgres:16 service container with health check (pg_isready), user/pass/db matching jest.config defaults
- Adds redis:7 service container with health check (redis-cli ping)
- Sets DATABASE_URL, POSTGRESQL_URL, REDIS_URL, NODE_ENV at the job level
- Adds npm run migrate up step before tests to apply pending migrations
- Services are health-gated by GH Actions before any step runs