### PR TITLE
feat: recurring booking expansion with RRULE

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "pino-http": "^10.4.0",
     "pino-pretty": "^13.0.0",
     "prom-client": "^15.1.3",
+    "rrule": "^2.7.1",
     "swagger-jsdoc": "^6.3.0",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^14.0.0"

--- a/src/modules/booking-intents/__tests__/recurring-booking.test.ts
+++ b/src/modules/booking-intents/__tests__/recurring-booking.test.ts
@@ -1,0 +1,40 @@
+import { jest } from "@jest/globals";
+import { BookingIntentService } from "../booking-intent-service.js";
+
+describe("BookingIntentService recurring", () => {
+  let service: BookingIntentService;
+  let mockRepo: any;
+  let mockSlotRepo: any;
+
+  beforeEach(() => {
+    mockRepo = {
+      create: jest.fn().mockImplementation(async (rec) => ({ id: `intent-${Math.random()}`, ...rec })),
+      findById: jest.fn(),
+      findBySlotId: jest.fn().mockReturnValue(undefined),
+      findBySlotIdAndCustomer: jest.fn().mockReturnValue(undefined),
+      updateTokenInfo: jest.fn(),
+    };
+
+    // One slot matching the DTSTART
+    const dt = new Date("2026-01-05T10:00:00.000Z").getTime();
+    mockSlotRepo = {
+      list: jest.fn().mockReturnValue([
+        { id: "slot-1", professional: "alice", startTime: dt, endTime: dt + 3600000, bookable: true },
+      ]),
+      findById: jest.fn(),
+      hasConflict: jest.fn(),
+      updateBookable: jest.fn(),
+    };
+
+    service = new BookingIntentService(mockRepo, mockSlotRepo, () => "2026-01-01T00:00:00.000Z");
+  });
+
+  it("creates intents for bounded rrule occurrences", async () => {
+    const rrule = "DTSTART:20260105T100000Z\nRRULE:FREQ=WEEKLY;COUNT=1;BYDAY=MO";
+    const actor = { userId: "buyer-1", role: "customer", claims: {} };
+
+    const report = await service.createRecurringIntents({ rrule }, actor as any);
+    expect(report.successes.length).toBe(1);
+    expect(report.failures.length).toBe(0);
+  });
+});

--- a/src/modules/booking-intents/booking-intent-service.ts
+++ b/src/modules/booking-intents/booking-intent-service.ts
@@ -15,6 +15,11 @@ export interface CreateBookingIntentInput {
   note?: string;
 }
 
+export interface CreateRecurringBookingInput {
+  rrule: string;
+  note?: string;
+}
+
 export class BookingIntentError extends AppError {
   constructor(
     readonly status: number,
@@ -91,6 +96,69 @@ export class BookingIntentService {
     return intent;
   }
 
+  async createRecurringIntents(input: CreateRecurringBookingInput, actor: AuthContext): Promise<{ successes: BookingIntentRecord[]; failures: { date: string; reason: string }[] }> {
+    const { expandRRule, RecurrenceError } = await import("../../services/recurrenceService.js");
+
+    let occurrences: Date[];
+    try {
+      occurrences = expandRRule(input.rrule);
+    } catch (err) {
+      if (err instanceof RecurrenceError) {
+        throw new BookingIntentError(400, err.message);
+      }
+      throw err;
+    }
+
+    const successes: BookingIntentRecord[] = [];
+    const failures: { date: string; reason: string }[] = [];
+
+    // For each occurrence, attempt to find a matching slot and create intent
+    for (const occ of occurrences) {
+      const startEpoch = occ.getTime();
+      const slot = this.slotRepository.list().find((s) => s.startTime === startEpoch && s.bookable);
+      if (!slot) {
+        failures.push({ date: occ.toISOString(), reason: "No available slot at this time" });
+        continue;
+      }
+
+      // Basic conflicts and checks similar to single-create
+      if (slot.professional === actor.userId) {
+        failures.push({ date: occ.toISOString(), reason: "Cannot book your own slot" });
+        continue;
+      }
+
+      const existingForCustomer = await this.bookingIntentRepository.findBySlotIdAndCustomer(slot.id, actor.userId);
+      if (existingForCustomer) {
+        failures.push({ date: occ.toISOString(), reason: "Customer already has an intent for this slot" });
+        continue;
+      }
+
+      const existingForSlot = await this.bookingIntentRepository.findBySlotId(slot.id);
+      if (existingForSlot) {
+        failures.push({ date: occ.toISOString(), reason: "Slot already has active booking intent" });
+        continue;
+      }
+
+      const intent = await this.bookingIntentRepository.create({
+        slotId: slot.id,
+        professional: slot.professional,
+        customerId: actor.userId,
+        startTime: slot.startTime,
+        endTime: slot.endTime,
+        status: "pending",
+        note: input.note,
+        createdAt: this.now(),
+      });
+
+      // Reserve slot
+      this.schedulingService.reserveSlot(slot.id);
+
+      successes.push(intent);
+    }
+
+    return { successes, failures };
+  }
+
   confirmIntent(intentId: string, actor: AuthContext): BookingIntentRecord {
     const intent = this.bookingIntentRepository.findById(intentId);
     if (!intent) {
@@ -157,12 +225,40 @@ export class BookingIntentService {
 
 export const SLOT_ID_PATTERN = /^slot-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export function parseCreateBookingIntentBody(body: unknown): CreateBookingIntentInput {
+export function parseCreateBookingIntentBody(body: unknown): CreateBookingIntentInput | CreateRecurringBookingInput {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new BookingIntentError(400, "Booking intent payload must be a JSON object.");
   }
 
-  const { slotId, note } = body as { slotId?: unknown; note?: unknown };
+  const { slotId, note, rrule } = body as { slotId?: unknown; note?: unknown; rrule?: unknown };
+
+
+  // If an RRULE is provided, treat this as a recurring booking request
+  if (rrule !== undefined) {
+    if (typeof rrule !== "string" || rrule.trim().length === 0) {
+      throw new BookingIntentError(400, "rrule must be a non-empty string.");
+    }
+    const normalizedRRule = rrule.trim();
+
+    if (note === undefined) {
+      return { rrule: normalizedRRule };
+    }
+
+    if (typeof note !== "string") {
+      throw new BookingIntentError(400, "note must be a string when provided.");
+    }
+
+    const sanitizedNote = sanitizeNote(note);
+    if (sanitizedNote === null) {
+      throw new BookingIntentError(400, "note cannot be empty when provided.");
+    }
+
+    if (sanitizedNote.length > 500) {
+      throw new BookingIntentError(400, "note must be 500 characters or fewer.");
+    }
+
+    return { rrule: normalizedRRule, note: sanitizedNote };
+  }
 
   if (typeof slotId !== "string" || slotId.trim().length === 0) {
     throw new BookingIntentError(400, "slotId is required.");
@@ -171,10 +267,6 @@ export function parseCreateBookingIntentBody(body: unknown): CreateBookingIntent
   const normalizedSlotId = slotId.trim();
   if (!SLOT_ID_PATTERN.test(normalizedSlotId)) {
     throw new BookingIntentError(400, "slotId format is invalid.");
-  }
-
-  if (note === undefined) {
-    return { slotId: normalizedSlotId };
   }
 
   if (typeof note !== "string") {

--- a/src/routes/booking-intents.ts
+++ b/src/routes/booking-intents.ts
@@ -56,7 +56,7 @@ export function createBookingIntentsRouter() {
     idempotencyMiddleware,
     createAuthAwareRateLimiter(),
     auditMiddleware("CREATE_BOOKING_INTENT"),
-    (req: Request, res: Response): void => {
+    async (req: Request, res: Response): Promise<void> => {
       try {
         const input = parseCreateBookingIntentBody(req.body);
         // Evaluate fraud risk
@@ -84,11 +84,19 @@ export function createBookingIntentsRouter() {
             });
           }
         }
-        const intent = bookingIntentService.createIntent(input, req.auth!);
-        res.status(201).json({
-          success: true,
-          intent,
-        });
+        if ((input as any).rrule) {
+          const report = await bookingIntentService.createRecurringIntents(input as any, req.auth!);
+          res.status(201).json({
+            success: true,
+            report,
+          });
+        } else {
+          const intent = await bookingIntentService.createIntent(input as any, req.auth!);
+          res.status(201).json({
+            success: true,
+            intent,
+          });
+        }
       } catch (error) {
         handleServiceError(error, res);
       }

--- a/src/services/__tests__/recurrenceService.test.ts
+++ b/src/services/__tests__/recurrenceService.test.ts
@@ -1,0 +1,15 @@
+import { expandRRule, RecurrenceError } from "../recurrenceService.js";
+
+describe("RecurrenceService", () => {
+  it("rejects unbounded rrule", () => {
+    const rrule = "FREQ=WEEKLY;BYDAY=MO"; // no COUNT or UNTIL
+    expect(() => expandRRule(rrule)).toThrow(RecurrenceError);
+  });
+
+  it("expands bounded rrule", () => {
+    const rrule = "DTSTART:20260101T100000Z\nRRULE:FREQ=WEEKLY;COUNT=2;BYDAY=MO";
+    const occ = expandRRule(rrule);
+    expect(occ.length).toBe(2);
+    expect(occ[0].toISOString()).toContain("2026");
+  });
+});

--- a/src/services/recurrenceService.ts
+++ b/src/services/recurrenceService.ts
@@ -1,0 +1,38 @@
+import { RRule, rrulestr } from "rrule";
+
+export const MAX_OCCURRENCES = 200;
+
+export class RecurrenceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RecurrenceError";
+  }
+}
+
+export function expandRRule(rruleText: string, dtstartIso?: string): Date[] {
+  if (typeof rruleText !== "string" || rruleText.trim().length === 0) {
+    throw new RecurrenceError("rrule must be a non-empty string");
+  }
+
+  // rrulestr accepts DTSTART inline or we can supply it via options
+  let rule: RRule;
+  try {
+    rule = rrulestr(rruleText, { forceset: false }) as unknown as RRule;
+  } catch (err) {
+    throw new RecurrenceError("Invalid RRULE format");
+  }
+
+  // Ensure RRULE is bounded (COUNT or UNTIL)
+  const options = rule.options;
+  if ((options.count ?? 0) <= 0 && !options.until) {
+    throw new RecurrenceError("Unbounded RRULE is not allowed; include COUNT or UNTIL");
+  }
+
+  // Limit occurrences to a safe maximum
+  const occurrences = rule.all((occurrence, i) => i < MAX_OCCURRENCES + 1);
+  if (occurrences.length > MAX_OCCURRENCES) {
+    throw new RecurrenceError(`RRULE expands to more than ${MAX_OCCURRENCES} occurrences`);
+  }
+
+  return occurrences;
+}


### PR DESCRIPTION
closes #327 


Title
feat(recurring-booking): add RRULE expansion and recurring booking creation

Summary

What: Add RRULE-based recurring booking expansion, validation (no unbounded RRULEs), capped expansion, and materialization of booking intents with partial-success reporting.
Why: Allow buyers to create repeat booking intents (e.g., "every weekday at 10am for 4 weeks") while preventing unbounded or unsafe expansions.
What I changed

New service: recurrenceService.ts — RRULE parsing, bounding, and safe expansion.
Booking logic: booking-intent-service.ts — createRecurringIntents() and CreateRecurringBookingInput; parser extended to accept rrule.
Route: booking-intents.ts — route now accepts rrule payloads and returns a report of successes/failures.
Deps: package.json — added rrule.
Tests: added recurrence and recurring-intent tests under __tests__ and __tests__.
Behavior & constraints

Bounded only: RRULEs without COUNT or UNTIL are rejected (400).
Safe cap: Expansion capped at MAX_OCCURRENCES (200) to avoid huge expansions.
Slot matching: Each occurrence attempts to match an available slot by startTime and bookable === true; matched slots are reserved.
Response: Recurring create returns { successes: BookingIntentRecord[], failures: { date, reason }[] } so callers can see partial results.
Testing

Unit tests added: recurrenceService.test.ts, recurring-booking.test.ts
Run locally:

npm cinpm test
Notes / Follow-ups

Current slot matching uses exact startTime equality — consider nearest/more flexible matching (by professional/time window) if desired.
DST-sensitive tests and additional conflict-handling (transactional DB implementation) recommended before production rollout.
Docs to update: booking-intent API docs to show rrule payload schema and example responses.
Files changed

package.json
recurrenceService.ts
booking-intent-service.ts
booking-intents.ts
recurrenceService.test.ts
recurring-booking.test.ts
Checklist before merging:

CI: pass (install, build, tests)
Docs: update Booking Intent API docs with rrule schema and examples
Review: confirm slot-matching logic meets product expectations