### PR TITLE
feat: implement co-occurrence detection for shared IP and device fing…

### DIFF
--- a/docs/fraud-detection.md
+++ b/docs/fraud-detection.md
@@ -1,0 +1,16 @@
+# Fraud detection notes
+
+The fraud scorer now performs lightweight co-occurrence checks for suspicious behavior patterns.
+
+## What is detected
+- Shared IP address across different actors within the in-memory tracker.
+- Shared device fingerprint across different actors, stored only as a SHA-256 hash.
+- A review case is created when both signals appear together for the same request pattern.
+
+## Privacy considerations
+- Raw device fingerprints are never persisted.
+- Only a one-way SHA-256 hash is used for comparison and case evidence.
+
+## Scoring
+- Each trigger adds to the fraud score.
+- Shared IP and shared fingerprint reasons contribute to the score, and a sockpuppet review case is emitted when both are present.

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,7 +154,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2621,7 +2620,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2975,7 +2973,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3918,7 +3915,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4597,7 +4593,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
       "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
@@ -7837,7 +7832,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -9354,7 +9348,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/services/__tests__/fraudScorer.test.ts
+++ b/src/services/__tests__/fraudScorer.test.ts
@@ -1,0 +1,50 @@
+import { FraudScorer } from "../fraudScorer";
+
+function createRequest(actorId: string, ip: string, fingerprint: string) {
+  return {
+    auth: {
+      userId: actorId,
+      fingerprint,
+    },
+    body: {},
+    headers: {
+      "x-device-fingerprint": fingerprint,
+    },
+    ip,
+  } as any;
+}
+
+describe("FraudScorer", () => {
+  it("does not flag unrelated requests", () => {
+    const scorer = new FraudScorer();
+
+    const result = scorer.evaluate("intent-1", createRequest("user-1", "203.0.113.10", "fp-unique"));
+
+    expect(result.score).toBe(0);
+    expect(result.reasons).toEqual([]);
+    expect(result.case).toBeUndefined();
+  });
+
+  it("detects shared IP and fingerprint co-occurrence and creates a review case", () => {
+    const scorer = new FraudScorer();
+
+    scorer.evaluate("intent-1", createRequest("user-1", "203.0.113.20", "fp-shared"));
+    const result = scorer.evaluate("intent-2", createRequest("user-2", "203.0.113.20", "fp-shared"));
+
+    expect(result.score).toBeGreaterThanOrEqual(5);
+    expect(result.reasons).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("shared_ip"),
+        expect.stringContaining("shared_fingerprint"),
+      ]),
+    );
+    expect(result.case).toEqual(
+      expect.objectContaining({
+        type: "sockpuppet_review",
+        actors: expect.arrayContaining(["user-1", "user-2"]),
+      }),
+    );
+    expect(result.case?.evidence.fingerprintHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.case?.evidence.fingerprint).toBeUndefined();
+  });
+});

--- a/src/services/fraudScorer.ts
+++ b/src/services/fraudScorer.ts
@@ -1,7 +1,27 @@
 // src/services/fraudScorer.ts
+import { createHash } from "crypto";
 import type { Request } from "express";
 
-/** Simple in‑memory tracker for request timestamps per actor */
+export interface FraudCase {
+  type: "sockpuppet_review";
+  score: number;
+  actors: string[];
+  reason: string;
+  evidence: {
+    ip: string;
+    fingerprintHash: string;
+    actors: string[];
+    observedAt: string;
+  };
+}
+
+export interface FraudEvaluationResult {
+  score: number;
+  reasons: string[];
+  case?: FraudCase;
+}
+
+/** Simple in-memory tracker for request timestamps per actor */
 class VelocityTracker {
   private readonly windows = new Map<string, number[]>();
   constructor(private readonly windowMs: number) {}
@@ -20,17 +40,24 @@ export class FraudScorer {
   private readonly maxIntents: number = Number(process.env.FRAUD_MAX_INTENTS) || 5;
   private readonly stepUpMode: "challenge" | "quarantine" = (process.env.FRAUD_STEP_UP_MODE as any) || "challenge";
   private readonly disposableList: Set<string> = new Set(
-    (process.env.FRAUD_DISPOSABLE_LIST || "mailinator.com,trashmail.com,tempmail.com").
-      split(",").
-      map((s) => s.trim().toLowerCase()).
-      filter(Boolean),
+    (process.env.FRAUD_DISPOSABLE_LIST || "mailinator.com,trashmail.com,tempmail.com")
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
   );
   private readonly threshold: number = Number(process.env.FRAUD_STEP_UP_THRESHOLD) || 2;
   private readonly velocityTracker = new VelocityTracker(this.velocityWindowMs);
+  private readonly ipIndex = new Map<string, Set<string>>();
+  private readonly fingerprintIndex = new Map<string, Set<string>>();
 
-  evaluate(intentId: string, req: Request): { score: number; reasons: string[] } {
+  evaluate(intentId: string, req: Request): FraudEvaluationResult {
     const reasons: string[] = [];
     const actorId = (req as any).auth?.userId || "anonymous";
+    const observedIp = req.ip ?? req.socket?.remoteAddress ?? "unknown";
+    const headerFp = req.headers["x-device-fingerprint"] as string | undefined;
+    const storedFp = (req as any).auth?.fingerprint as string | undefined;
+    const fingerprintValue = headerFp ?? storedFp ?? "";
+    const fingerprintHash = fingerprintValue ? this.hashFingerprint(fingerprintValue) : undefined;
 
     // Velocity check
     const count = this.velocityTracker.record(actorId);
@@ -38,9 +65,7 @@ export class FraudScorer {
       reasons.push("velocity_exceeded");
     }
 
-    // Fingerprint / User‑Agent mismatch (header vs stored)
-    const headerFp = req.headers["x-device-fingerprint"] as string | undefined;
-    const storedFp = (req as any).auth?.fingerprint as string | undefined;
+    // Fingerprint / User-agent mismatch (header vs stored)
     if (headerFp && storedFp && headerFp !== storedFp) {
       reasons.push("fingerprint_mismatch");
     }
@@ -54,10 +79,55 @@ export class FraudScorer {
       }
     }
 
-    const score = reasons.length;
-    return { score, reasons };
+    let caseDetails: FraudCase | undefined;
+
+    if (observedIp && fingerprintHash) {
+      const ipActors = this.ipIndex.get(observedIp) ?? new Set<string>();
+      const fingerprintActors = this.fingerprintIndex.get(fingerprintHash) ?? new Set<string>();
+      const sharedIp = Array.from(ipActors).some((existingActor) => existingActor !== actorId);
+      const sharedFingerprint = Array.from(fingerprintActors).some((existingActor) => existingActor !== actorId);
+
+      if (sharedIp) {
+        reasons.push("shared_ip");
+      }
+      if (sharedFingerprint) {
+        reasons.push("shared_fingerprint");
+      }
+
+      if (sharedIp && sharedFingerprint) {
+        const combinedActors = Array.from(new Set([actorId, ...ipActors, ...fingerprintActors]));
+        caseDetails = {
+          type: "sockpuppet_review",
+          score: 5,
+          actors: combinedActors,
+          reason: "shared_ip_and_fingerprint",
+          evidence: {
+            ip: observedIp,
+            fingerprintHash,
+            actors: combinedActors,
+            observedAt: new Date().toISOString(),
+          },
+        };
+      }
+
+      ipActors.add(actorId);
+      fingerprintActors.add(actorId);
+      this.ipIndex.set(observedIp, ipActors);
+      this.fingerprintIndex.set(fingerprintHash, fingerprintActors);
+    }
+
+    const score = reasons.length + (caseDetails ? 3 : 0);
+    return { score, reasons, case: caseDetails };
   }
 
-  getThreshold(): number { return this.threshold; }
-  getStepUpMode(): "challenge" | "quarantine" { return this.stepUpMode; }
+  private hashFingerprint(value: string): string {
+    return createHash("sha256").update(value.trim().toLowerCase()).digest("hex");
+  }
+
+  getThreshold(): number {
+    return this.threshold;
+  }
+  getStepUpMode(): "challenge" | "quarantine" {
+    return this.stepUpMode;
+  }
 }


### PR DESCRIPTION
Closes #554


I’m drafting a concise PR description you can paste directly, based on the fraud-scoring work we just completed.

## PR Title
Add co-occurrence-based sockpuppet review detection for shared IPs and device fingerprints

## Summary
This PR adds a lightweight fraud-scoring detector that flags suspicious account behavior when the same IP address and device fingerprint are observed across different actors. The goal is to help identify sockpuppet reviewers and surface a review case for human investigation.

## What changed
- Added shared-IP and shared-device-fingerprint detection to the fraud scorer
- Implemented a review-case payload for high-risk co-occurrence signals
- Stored device fingerprints only as SHA-256 hashes for privacy and security
- Added regression tests covering:
  - normal traffic not being flagged
  - shared IP + shared fingerprint triggering a review case

## Security and privacy
- Raw device fingerprints are not persisted
- Only hashed fingerprints are used for matching and evidence
- The detection is intentionally lightweight and easy to review

## Testing
- Added targeted unit tests for the new fraud scorer behavior
- Verified with:
  - `npm test -- --runTestsByPath src/services/__tests__/fraudScorer.test.ts`

## Notes
- The implementation is scoped to the existing fraud scorer and does not introduce heavier infrastructure dependencies

If you want, I can also turn this into a more polished GitHub-style PR body with “Problem / Solution / Testing” sections.