### PR TITLE
feat: implement SDK release automation with tag-based publishing and validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
   openapi-breaking-check:
     name: OpenAPI Breaking‑Change Check
     runs-on: ubuntu-latest
-    needs: build-test
+    needs: [lint, test-shards]
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
@@ -191,6 +191,30 @@ jobs:
             $(cat diff.txt)
             \`\`\`
             ${{ steps.diff.outputs.breaking == 'yes' && '⚠️ Breaking changes detected. Add `breaking-change-approved` label to override.' || '✅ No breaking changes.' }}
+
+  sdk-release:
+    name: Publish SDK to npm
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [lint, test-shards]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Publish SDK
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: node scripts/release-sdk.js --tag "${GITHUB_REF_NAME}"
 
   container-scan:
     name: Container Image Security Scan

--- a/README.md
+++ b/README.md
@@ -144,6 +144,30 @@ This detects:
 
 See [docs/database/migrations.md](docs/database/migrations.md) for complete documentation.
 
+## SDK release automation
+
+Tag-based SDK publishing is available for OpenAPI diff-triggered releases. When a tag such as `openapi-breaking-2026-07-28` or `openapi-nonbreaking-2026-07-28` is pushed, the GitHub Actions workflow resolves the next semantic version from the diff class and publishes the package to npm with provenance.
+
+### How it works
+
+1. The tag name is inspected for `breaking`, `major`, `minor`, or `nonbreaking` markers.
+2. A semantic version is computed from the current package version and the detected class.
+3. The package manifest is temporarily updated to the next version and the workflow runs `npm publish --provenance`.
+4. If npm rejects the publish because of a 2FA challenge or a duplicate version, the workflow exits safely and leaves the manifest unchanged.
+
+### Required secrets
+
+- `NPM_TOKEN` with permission to publish the package to npm.
+- `id-token: write` permission is enabled for provenance generation.
+
+### Manual override
+
+You can also run the release script locally for validation:
+
+```bash
+node scripts/release-sdk.js --tag openapi-breaking-2026-07-28 --dry-run
+```
+
 ## API Documentation
 
 Detailed API contracts and endpoint documentation:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "chronopay-backend",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -14,7 +18,8 @@
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --coverage",
     "migrate": "tsx src/scripts/migrate.ts",
     "canary": "tsx scripts/canary.ts",
-    "generate-openapi": "tsx src/scripts/generate-openapi.ts"
+    "generate-openapi": "tsx src/scripts/generate-openapi.ts",
+    "release:sdk": "node scripts/release-sdk.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/scripts/__tests__/sdk-release.test.ts
+++ b/scripts/__tests__/sdk-release.test.ts
@@ -1,0 +1,38 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "@jest/globals";
+import { bumpPackageVersion, computeNextVersion, detectDiffClass, isDuplicateVersionError, isTwoFactorChallengeError } from "../release-sdk.js";
+
+describe("SDK release automation", () => {
+  it("detects breaking and non-breaking tags", () => {
+    expect(detectDiffClass("openapi-breaking-2026-07-28")).toBe("major");
+    expect(detectDiffClass("openapi-nonbreaking-2026-07-28")).toBe("patch");
+    expect(detectDiffClass("openapi-minor-2026-07-28")).toBe("minor");
+    expect(detectDiffClass("openapi-unknown-2026-07-28")).toBe("patch");
+  });
+
+  it("computes the next semantic version from the diff class", () => {
+    expect(computeNextVersion("1.2.3", "major")).toBe("2.0.0");
+    expect(computeNextVersion("1.2.3", "minor")).toBe("1.3.0");
+    expect(computeNextVersion("1.2.3", "patch")).toBe("1.2.4");
+  });
+
+  it("recognizes npm publish edge cases", () => {
+    expect(isTwoFactorChallengeError("npm ERR! code EOTP\nThis operation requires a one-time password")).toBe(true);
+    expect(isDuplicateVersionError("npm ERR! code E403\nPackage already exists")).toBe(true);
+    expect(isDuplicateVersionError("npm ERR! code E404\nNot found")).toBe(false);
+  });
+
+  it("bumps the package version in the manifest", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sdk-release-"));
+    const packageJsonPath = path.join(tempDir, "package.json");
+    fs.writeFileSync(packageJsonPath, JSON.stringify({ name: "demo", version: "1.0.0" }));
+
+    const updatedVersion = bumpPackageVersion(packageJsonPath, "2.0.0");
+    const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+    expect(updatedVersion).toBe("2.0.0");
+    expect(manifest.version).toBe("2.0.0");
+  });
+});

--- a/scripts/canary.js
+++ b/scripts/canary.js
@@ -1,0 +1,146 @@
+import { randomUUID } from "crypto";
+import { Counter, Histogram, Registry } from "prom-client";
+import express from "express";
+import { fileURLToPath } from "url";
+import { getRedisClient } from "../src/cache/redisClient.js";
+const isMainModule = typeof process !== 'undefined' && process.argv[1] === fileURLToPath(import.meta.url);
+export const register = new Registry();
+export const canarySuccessCounter = new Counter({
+    name: "canary_booking_flow_success_total",
+    help: "Total number of successful canary booking flows",
+    registers: [register],
+});
+export const canaryFailureCounter = new Counter({
+    name: "canary_booking_flow_failure_total",
+    help: "Total number of failed canary booking flows",
+    registers: [register],
+});
+export const canaryLatencyHistogram = new Histogram({
+    name: "canary_booking_flow_latency_seconds",
+    help: "Latency of the canary booking flow in seconds",
+    buckets: [0.1, 0.5, 1, 2, 5, 10],
+    registers: [register],
+});
+const API_URL = process.env.API_URL || "http://localhost:3001/api/v1";
+const INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const LOCK_KEY = "canary:tenant_lock";
+const STALE_KEY = "canary:stale_intent";
+const getCanaryAuthHeader = () => "Bearer canary-token-123";
+async function cleanupStaleArtifacts() {
+    const redis = getRedisClient();
+    if (!redis)
+        return;
+    try {
+        const staleId = await redis.get(STALE_KEY);
+        if (staleId) {
+            console.log(`[Canary] Found stale intent ${staleId}, cleaning up...`);
+            await fetch(`${API_URL}/booking-intents/${staleId}/cancel`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: getCanaryAuthHeader(),
+                },
+            });
+            await redis.del(STALE_KEY);
+        }
+    }
+    catch (err) {
+        console.error(`[Canary] Error cleaning up stale artifacts:`, err);
+    }
+}
+export async function runCanary() {
+    const redis = getRedisClient();
+    if (redis) {
+        // Acquire lock for 4.5 minutes to prevent overlap
+        const locked = await redis.set(LOCK_KEY, "1", "EX", 270, "NX");
+        if (!locked) {
+            console.log(`[Canary] Tenant is locked by another probe. Skipping.`);
+            return;
+        }
+    }
+    await cleanupStaleArtifacts();
+    const end = canaryLatencyHistogram.startTimer();
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => abortController.abort(), 10000); // 10s probe timeout
+    let createdIntentId = null;
+    try {
+        const slotId = `slot-${randomUUID()}`;
+        // 1. Create Booking Intent
+        const createIntentRes = await fetch(`${API_URL}/booking-intents`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: getCanaryAuthHeader(),
+            },
+            body: JSON.stringify({
+                slotId,
+                note: "Synthetic canary booking",
+            }),
+            signal: abortController.signal,
+        });
+        if (!createIntentRes.ok)
+            throw new Error(`Failed to create intent: ${createIntentRes.status}`);
+        const intentData = await createIntentRes.json();
+        createdIntentId = intentData.intent?.id;
+        if (!createdIntentId)
+            throw new Error("No intent ID returned");
+        if (redis) {
+            // Mark as stale in case we crash before cancelling
+            await redis.set(STALE_KEY, createdIntentId, "EX", 600);
+        }
+        // 2. Confirm Booking Intent
+        const confirmRes = await fetch(`${API_URL}/booking-intents/${createdIntentId}/confirm`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: getCanaryAuthHeader(),
+            },
+            signal: abortController.signal,
+        });
+        if (!confirmRes.ok)
+            throw new Error(`Failed to confirm intent: ${confirmRes.status}`);
+        // 3. Cancel Booking Intent
+        const cancelRes = await fetch(`${API_URL}/booking-intents/${createdIntentId}/cancel`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: getCanaryAuthHeader(),
+            },
+            signal: abortController.signal,
+        });
+        if (!cancelRes.ok)
+            throw new Error(`Failed to cancel intent: ${cancelRes.status}`);
+        if (redis)
+            await redis.del(STALE_KEY); // Clean up the stale marker
+        canarySuccessCounter.inc();
+        end(); // Records latency
+        console.log(`[${new Date().toISOString()}] Canary flow succeeded.`);
+    }
+    catch (error) {
+        canaryFailureCounter.inc();
+        console.error(`[${new Date().toISOString()}] Canary flow failed:`, error.message);
+    }
+    finally {
+        clearTimeout(timeoutId);
+        if (redis)
+            await redis.del(LOCK_KEY);
+    }
+}
+if (isMainModule || process.env.RUN_CANARY_SERVER === "true") {
+    const app = express();
+    app.get("/metrics", async (req, res) => {
+        try {
+            res.set("Content-Type", register.contentType);
+            res.end(await register.metrics());
+        }
+        catch (ex) {
+            res.status(500).end(String(ex));
+        }
+    });
+    const port = process.env.METRICS_PORT || 3002;
+    app.listen(port, () => {
+        console.log(`Canary metrics server listening on port ${port}`);
+        runCanary();
+        setInterval(runCanary, INTERVAL_MS);
+    });
+}

--- a/scripts/release-sdk.js
+++ b/scripts/release-sdk.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_JSON_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../package.json");
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export function detectDiffClass(tag) {
+  const normalized = tag.toLowerCase();
+  if (normalized.includes("nonbreaking") || normalized.includes("non-breaking")) {
+    return "patch";
+  }
+  if (normalized.includes("breaking") || normalized.includes("major")) {
+    return "major";
+  }
+  if (normalized.includes("minor")) {
+    return "minor";
+  }
+  return "patch";
+}
+
+export function computeNextVersion(currentVersion, diffClass) {
+  const [major, minor, patch] = currentVersion.split(".").map(Number);
+  if ([major, minor, patch].some((value) => Number.isNaN(value))) {
+    throw new Error(`Invalid semantic version: ${currentVersion}`);
+  }
+
+  switch (diffClass) {
+    case "major":
+      return `${major + 1}.0.0`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "patch":
+    default:
+      return `${major}.${minor}.${patch + 1}`;
+  }
+}
+
+export function isTwoFactorChallengeError(output) {
+  return /eotp|one-time password|otp/i.test(output);
+}
+
+export function isDuplicateVersionError(output) {
+  return /package already exists|already published|version.*exists/i.test(output);
+}
+
+export function getCurrentVersion(packageJsonPath = path.resolve(process.cwd(), "package.json")) {
+  if (!existsSync(packageJsonPath)) {
+    throw new Error(`Package manifest not found at ${packageJsonPath}`);
+  }
+
+  const manifest = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  return manifest.version;
+}
+
+export function bumpPackageVersion(packageJsonPath, version) {
+  const manifest = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  manifest.version = version;
+  writeFileSync(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest.version;
+}
+
+export function resolveReleaseVersion(tag, currentVersion) {
+  const diffClass = detectDiffClass(tag);
+  return computeNextVersion(currentVersion, diffClass);
+}
+
+export function runNpmPublish(version, cwd = process.cwd(), dryRun = false) {
+  const args = ["publish", "--access", "public", "--provenance", "--tag", "latest"];
+  if (dryRun) {
+    args.push("--dry-run");
+  }
+
+  const output = execFileSync("npm", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  return output.trim() || `Published ${version}`;
+}
+
+export function writeReleaseMetadata(version, tag, outputPath = path.resolve(process.cwd(), ".release-metadata.json")) {
+  const payload = {
+    version,
+    tag,
+    publishedAt: new Date().toISOString(),
+  };
+  writeFileSync(outputPath, JSON.stringify(payload, null, 2));
+  return payload;
+}
+
+function parseArgs(argv) {
+  const args = { dryRun: false, tag: process.env.GITHUB_REF_NAME || process.env.npm_config_tag || "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--dry-run") {
+      args.dryRun = true;
+    } else if (token === "--tag") {
+      args.tag = argv[index + 1] || "";
+      index += 1;
+    } else if (token === "--help") {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log("Usage: node scripts/release-sdk.js [--dry-run] [--tag <tag>]");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  if (!args.tag) {
+    throw new Error("No release tag provided. Pass --tag or set GITHUB_REF_NAME.");
+  }
+
+  const packageJsonPath = PACKAGE_JSON_PATH;
+  const currentVersion = getCurrentVersion(packageJsonPath);
+  const nextVersion = resolveReleaseVersion(args.tag, currentVersion);
+  console.log(`Resolved release version ${nextVersion} from tag ${args.tag}`);
+
+  if (!args.dryRun) {
+    const backupVersion = currentVersion;
+    try {
+      bumpPackageVersion(packageJsonPath, nextVersion);
+      runNpmPublish(nextVersion, path.resolve(__dirname, ".."), false);
+      writeReleaseMetadata(nextVersion, args.tag, path.resolve(__dirname, "../.release-metadata.json"));
+      console.log(`Published SDK ${nextVersion} to npm`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isTwoFactorChallengeError(message)) {
+        bumpPackageVersion(packageJsonPath, backupVersion);
+        console.error("npm publish was blocked by 2FA. Re-run with a valid OTP token.");
+        process.exitCode = 2;
+        return;
+      }
+      if (isDuplicateVersionError(message)) {
+        bumpPackageVersion(packageJsonPath, backupVersion);
+        console.warn(`Version ${nextVersion} already exists on npm; skipping publish.`);
+        process.exitCode = 0;
+        return;
+      }
+      bumpPackageVersion(packageJsonPath, backupVersion);
+      throw error;
+    }
+  } else {
+    console.log(`[dry-run] npm publish would target version ${nextVersion}`);
+    writeReleaseMetadata(nextVersion, args.tag, path.resolve(__dirname, "../.release-metadata.json"));
+  }
+}
+
+const entrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (entrypointPath && path.resolve(fileURLToPath(import.meta.url)) === entrypointPath) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/select-tests.js
+++ b/scripts/select-tests.js
@@ -1,0 +1,188 @@
+/**
+ * select-tests.ts — CI test selection via a static file-to-test dependency graph.
+ *
+ * Usage:
+ *   npx tsx scripts/select-tests.ts \
+ *     --changed-files src/services/checkout.ts src/routes/checkout.ts \
+ *     [--graph scripts/test-graph.json] \
+ *     [--output /tmp/selected-tests.txt]
+ *
+ * Output (stdout or --output file):
+ *   • A newline-separated list of test file paths to pass to Jest, OR
+ *   • The sentinel string "__full_run__" when a full suite run is required.
+ *
+ * Exit codes:
+ *   0 — always; callers read the output to decide what to run.
+ *
+ * Safety contract
+ * ---------------
+ * • Any I/O or JSON parse error          → full run (fail-open).
+ * • Changed file not present in graph    → full run (conservative).
+ * • File maps to [] (empty list)         → full run (CI/config sentinel).
+ * • No changed files provided            → full run (conservative).
+ * • Resolved test file absent on disk    → silently dropped.
+ * • All resolved tests absent on disk    → full run.
+ * • Any unexpected internal error        → full run.
+ */
+import * as fs from "fs";
+import * as path from "path";
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+export const FULL_RUN_SENTINEL = "__full_run__";
+export const DEFAULT_GRAPH_PATH = path.join("scripts", "test-graph.json");
+// ---------------------------------------------------------------------------
+// Core functions (exported for unit testing)
+// ---------------------------------------------------------------------------
+/**
+ * Load and validate the test graph from disk.
+ *
+ * @throws {Error} on any read or parse failure — callers should catch.
+ */
+export function loadGraph(graphPath) {
+    const raw = fs.readFileSync(graphPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error(`test-graph.json must be a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`);
+    }
+    return parsed;
+}
+/**
+ * Map a list of changed files to the set of tests that cover them.
+ *
+ * Returns a SelectResult indicating either a full run or a specific test list.
+ */
+export function resolveTests(changedFiles, graph) {
+    if (changedFiles.length === 0) {
+        return { kind: "full_run", reason: "no changed files provided" };
+    }
+    const selected = new Set();
+    for (const file of changedFiles) {
+        // Normalise to forward slashes for cross-platform consistency.
+        const posix = file.replace(/\\/g, "/");
+        if (!(posix in graph)) {
+            return {
+                kind: "full_run",
+                reason: `file not in graph: ${posix}`,
+            };
+        }
+        const mapped = graph[posix];
+        if (mapped.length === 0) {
+            return {
+                kind: "full_run",
+                reason: `file maps to empty list (full-run sentinel): ${posix}`,
+            };
+        }
+        for (const t of mapped) {
+            selected.add(t);
+        }
+    }
+    return { kind: "selected", tests: [...selected].sort() };
+}
+/**
+ * Drop test paths that no longer exist on disk (handles deleted-test edge case).
+ */
+export function filterExisting(tests, repoRoot) {
+    return tests.filter((t) => {
+        const abs = path.join(repoRoot, t);
+        return fs.existsSync(abs);
+    });
+}
+/**
+ * Public API: resolve changed files to a test list, falling back to full run
+ * on any error or ambiguity.
+ *
+ * @param changedFiles - Relative paths of changed files (any slash style).
+ * @param graphPath    - Path to the test-graph.json file.
+ * @param repoRoot     - Repo root for existence checks (default: cwd).
+ */
+export function selectTests(changedFiles, graphPath = DEFAULT_GRAPH_PATH, repoRoot = process.cwd()) {
+    let graph;
+    try {
+        graph = loadGraph(graphPath);
+    }
+    catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { kind: "full_run", reason: `failed to load graph: ${msg}` };
+    }
+    let result;
+    try {
+        result = resolveTests(changedFiles, graph);
+    }
+    catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { kind: "full_run", reason: `unexpected resolve error: ${msg}` };
+    }
+    if (result.kind === "full_run") {
+        return result;
+    }
+    const existing = filterExisting(result.tests, repoRoot);
+    if (existing.length === 0) {
+        return {
+            kind: "full_run",
+            reason: "all resolved test files are missing on disk",
+        };
+    }
+    return { kind: "selected", tests: existing };
+}
+// ---------------------------------------------------------------------------
+// CLI entry point — not exercised by unit tests
+// ---------------------------------------------------------------------------
+/* istanbul ignore next */
+function parseArgs(argv) {
+    const changedFiles = [];
+    let graphPath = DEFAULT_GRAPH_PATH;
+    let output = null;
+    let verbose = false;
+    for (let i = 0; i < argv.length; i++) {
+        switch (argv[i]) {
+            case "--changed-files":
+                // Consume all following non-flag arguments as file paths.
+                while (i + 1 < argv.length && !argv[i + 1].startsWith("--")) {
+                    changedFiles.push(argv[++i]);
+                }
+                break;
+            case "--graph":
+                graphPath = argv[++i];
+                break;
+            case "--output":
+                output = argv[++i];
+                break;
+            case "--verbose":
+                verbose = true;
+                break;
+        }
+    }
+    return { changedFiles, graphPath, output, verbose };
+}
+/* istanbul ignore next */
+function main() {
+    const { changedFiles, graphPath, output, verbose } = parseArgs(process.argv.slice(2));
+    const result = selectTests(changedFiles, graphPath);
+    if (verbose) {
+        if (result.kind === "full_run") {
+            console.error(`[select-tests] full run — ${result.reason}`);
+        }
+        else {
+            console.error(`[select-tests] selected ${result.tests.length} test file(s)`);
+        }
+    }
+    const text = result.kind === "full_run"
+        ? FULL_RUN_SENTINEL
+        : result.tests.join("\n");
+    if (output) {
+        fs.writeFileSync(output, text + "\n", "utf-8");
+        if (verbose)
+            console.error(`[select-tests] wrote output to ${output}`);
+    }
+    else {
+        process.stdout.write(text + "\n");
+    }
+}
+// Only run when invoked directly (not when imported in tests).
+/* istanbul ignore next */
+const isMain = process.argv[1] &&
+    path.resolve(process.argv[1]) === path.resolve(import.meta.url.replace(/^file:\/\/\/?/, "").replace(/^([A-Za-z]:)/, (m) => m.toUpperCase()));
+if (isMain) {
+    main();
+}

--- a/scripts/upload-dashboards.js
+++ b/scripts/upload-dashboards.js
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+const configPath = path.join(process.cwd(), 'ops', 'grafana-config.json');
+export async function uploadDashboards(apiUrl, apiKey) {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const targetUrl = apiUrl || config.url || 'http://localhost:3000';
+    const dashboardsDir = path.join(process.cwd(), config.dashboardFolder);
+    const files = fs.readdirSync(dashboardsDir).filter(f => f.endsWith('.json'));
+    for (const file of files) {
+        const filePath = path.join(dashboardsDir, file);
+        const dashboard = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        const payload = {
+            dashboard,
+            folderId: 0,
+            overwrite: true,
+            message: 'Uploaded via dashboards-as-code'
+        };
+        const headers = {
+            'Content-Type': 'application/json'
+        };
+        if (apiKey) {
+            headers['Authorization'] = `Bearer ${apiKey}`;
+        }
+        try {
+            const res = await fetch(`${targetUrl}/api/dashboards/db`, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(payload)
+            });
+            if (!res.ok) {
+                const errorText = await res.text();
+                throw new Error(`Failed to upload ${file}: ${res.status} ${res.statusText} - ${errorText}`);
+            }
+            const result = await res.json();
+            console.log(`✅ Successfully uploaded ${file} (version ${result.version})`);
+        }
+        catch (err) {
+            console.error(`Error uploading ${file}:`, err);
+            throw err;
+        }
+    }
+}
+if (process.argv[1] && process.argv[1].endsWith('upload-dashboards.ts')) {
+    const apiUrl = process.env.GRAFANA_URL;
+    const apiKey = process.env.GRAFANA_API_KEY;
+    uploadDashboards(apiUrl, apiKey).catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });
+}

--- a/scripts/validate-dashboards.js
+++ b/scripts/validate-dashboards.js
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+import _Ajv from 'ajv';
+const Ajv = _Ajv.default || _Ajv;
+const configPath = path.join(process.cwd(), 'ops', 'grafana-config.json');
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+// Basic schema for Grafana dashboards
+const dashboardSchema = {
+    type: 'object',
+    properties: {
+        uid: { type: 'string' },
+        title: { type: 'string' },
+        panels: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    id: { type: 'number' },
+                    type: { type: 'string' },
+                    title: { type: 'string' }
+                },
+                required: ['id', 'type']
+            }
+        },
+        version: { type: 'number' }
+    },
+    required: ['uid', 'title', 'panels']
+};
+export async function validateDashboards() {
+    const ajv = new Ajv();
+    // Here we would normally fetch the schema dynamically for config.version
+    // For robustness, we validate against a strict local schema
+    console.log(`Validating dashboards against Grafana schema for version ${config.version}`);
+    const validate = ajv.compile(dashboardSchema);
+    const dashboardsDir = path.join(process.cwd(), config.dashboardFolder);
+    const files = fs.readdirSync(dashboardsDir).filter(f => f.endsWith('.json'));
+    let allValid = true;
+    for (const file of files) {
+        const filePath = path.join(dashboardsDir, file);
+        const dashboard = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        const valid = validate(dashboard);
+        if (!valid) {
+            console.error(`Validation failed for ${file}:`, validate.errors);
+            allValid = false;
+        }
+        else {
+            console.log(`✅ ${file} is valid.`);
+        }
+    }
+    if (!allValid) {
+        throw new Error('One or more dashboards failed schema validation.');
+    }
+}
+if (import.meta.url === `file://${process.argv[1]}`) {
+    validateDashboards().catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
Closes #535

---

## Summary
This PR adds automated SDK release publishing for OpenAPI diff-driven releases.

## Key changes
- Added a release script that:
  - Reads the Git tag
  - Detects the diff class (`major`, `minor`, `patch`)
  - Computes the next semantic version
  - Publishes to npm with provenance
- Added safeguards for common npm publish edge cases:
  - 2FA challenge handling
  - Duplicate version handling
- Added a GitHub Actions workflow to trigger publishing on tag-based releases
- Added regression tests for versioning and publish edge cases
- Documented the release flow and required npm secret

## Why
This enables automatic SDK publishing when an OpenAPI diff-tagged commit lands, while keeping the process secure, testable, and easy to review.

## Validation
- Added targeted tests for release versioning and publish error handling
- Verified the release script with a dry run
