### PR TITLE
feat: quorum-voted escrow drift reconciler

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -369,6 +369,54 @@ export const slowQueryDuration = createBudgetedHistogram({
   registers: [register],
 });
 
+// ─── Escrow drift reconciler metrics ──────────────────────────────────────────
+
+/**
+ * Gauge set to 1 when drift is detected between chain escrow state and local DB.
+ */
+export const escrowDriftDetected = createBudgetedGauge({
+  name: "escrow_drift_detected",
+  help: "Whether escrow state drift has been detected (1 = drift, 0 = clean)",
+  labels: ["slot_id"],
+  budget: 128,
+  buckets: [],
+  registers: [register],
+});
+
+/**
+ * Counter incremented each time an escrow reader returns a result that
+ * disagrees with the quorum majority for any slot.
+ */
+export const escrowReaderDisagreementTotal = createBudgetedCounter({
+  name: "escrow_reader_disagreement_total",
+  help: "Total number of reader disagreements observed during escrow drift reconciliation",
+  labels: ["reader_id"],
+  budget: 8,
+  registers: [register],
+});
+
+/**
+ * Counter incremented on each drift reconciliation tick.
+ */
+export const escrowDriftReconciliationTicks = createBudgetedCounter({
+  name: "escrow_drift_reconciliation_ticks_total",
+  help: "Total number of escrow drift reconciliation ticks performed",
+  labels: [],
+  budget: 0,
+  registers: [register],
+});
+
+/**
+ * Counter incremented each time a drift override is applied.
+ */
+export const escrowDriftOverridesApplied = createBudgetedCounter({
+  name: "escrow_drift_overrides_applied_total",
+  help: "Total number of manual escrow drift overrides applied",
+  labels: ["slot_id"],
+  budget: 64,
+  registers: [register],
+});
+
 /**
  * Express middleware to track HTTP request duration.
  */

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,6 +5,7 @@ import { getImpersonationSessionStore } from "../services/impersonationSessionSt
 import type { SessionListOptions } from "../types/impersonation.types.js";
 import { defaultAuditLogger } from "../services/auditLogger.js";
 import { IMPERSONATION_AUDIT_ACTIONS } from "../types/auditEvent.js";
+import type { LocalIntentStatus } from "../services/escrowDriftReconciler.js";
 
 const router = Router();
 
@@ -243,6 +244,148 @@ router.post(
       return res.status(500).json({
         success: false,
         error: err.message ?? "Failed to close impersonation session",
+      });
+    }
+  },
+);
+
+// ─── Escrow Drift Override API ───────────────────────────────────────────────
+
+/**
+ * In-memory reference to the escrow drift reconciler, set by the app
+ * bootstrap when a reconciler is active. Tests can replace this with
+ * a mock reconciler.
+ */
+let _driftReconciler: {
+  manualOverride(
+    slotId: string,
+    targetStatus: LocalIntentStatus,
+    reason: string,
+    actorIp: string,
+  ): Promise<{ previousState: unknown; newState: unknown }>;
+} | null = null;
+
+export function setDriftReconciler(
+  reconciler: NonNullable<typeof _driftReconciler>,
+): void {
+  _driftReconciler = reconciler;
+}
+
+function getDriftReconciler() {
+  return _driftReconciler;
+}
+
+const VALID_INTENT_STATUSES: ReadonlySet<LocalIntentStatus> = new Set([
+  "pending",
+  "confirmed",
+  "cancelled",
+  "expired",
+]);
+
+/**
+ * @route POST /api/v1/admin/escrow/drift/override
+ * @desc Manually override a booking intent's escrow state to resolve drift.
+ *   This is a privileged operation that must only be used after careful
+ *   forensic investigation. Every override is audited.
+ *
+ *   Body:
+ *     slotId       – the slot to override (required)
+ *     targetStatus – new intent status (pending|confirmed|cancelled|expired)
+ *     reason       – forensic justification (required, min 20 chars)
+ *
+ * @access Private (admin token only)
+ */
+router.post(
+  "/escrow/drift/override",
+  requireAdminToken,
+  async (req: Request, res: Response) => {
+    try {
+      const reconciler = getDriftReconciler();
+      if (!reconciler) {
+        return res.status(503).json({
+          success: false,
+          error: "Escrow drift reconciler is not running",
+        });
+      }
+
+      const { slotId, targetStatus, reason } = req.body as {
+        slotId?: string;
+        targetStatus?: string;
+        reason?: string;
+      };
+
+      // Validate slotId
+      if (!slotId || typeof slotId !== "string" || slotId.trim() === "") {
+        return res.status(400).json({
+          success: false,
+          error: "slotId is required and must be a non-empty string",
+        });
+      }
+
+      // Validate targetStatus
+      if (!targetStatus || typeof targetStatus !== "string") {
+        return res.status(400).json({
+          success: false,
+          error: `targetStatus is required and must be one of: ${Array.from(VALID_INTENT_STATUSES).join(", ")}`,
+        });
+      }
+
+      if (!VALID_INTENT_STATUSES.has(targetStatus as LocalIntentStatus)) {
+        return res.status(400).json({
+          success: false,
+          error: `Invalid targetStatus "${targetStatus}". Must be one of: ${Array.from(VALID_INTENT_STATUSES).join(", ")}`,
+        });
+      }
+
+      // Validate reason (min 20 chars for forensic justification, max 2000 for abuse prevention)
+      if (!reason || typeof reason !== "string" || reason.trim().length < 20) {
+        return res.status(400).json({
+          success: false,
+          error: "reason is required and must be at least 20 characters (forensic justification)",
+        });
+      }
+
+      if (reason.trim().length > 2000) {
+        return res.status(400).json({
+          success: false,
+          error: "reason must be at most 2000 characters",
+        });
+      }
+
+      const actorIp = req.ip ?? "unknown";
+      const result = await reconciler.manualOverride(
+        slotId.trim(),
+        targetStatus as LocalIntentStatus,
+        reason.trim(),
+        actorIp,
+      );
+
+      // Audit the override
+      void defaultAuditLogger.log(
+        "escrow.drift.override.applied",
+        {
+          context: {
+            slotId: slotId.trim(),
+            targetStatus,
+            reason: reason.trim(),
+            previousStatus: (result.previousState as any)?.intentStatus ?? "unknown",
+            actorIp,
+          },
+          method: req.method,
+        },
+        { actorIp, resource: `slot:${slotId.trim()}`, status: 200 },
+      );
+
+      return res.status(200).json({
+        success: true,
+        slotId: slotId.trim(),
+        previousState: result.previousState,
+        newState: result.newState,
+      });
+    } catch (err: any) {
+      return res.status(500).json({
+        success: false,
+        error: err.message ?? "Manual override failed",
       });
     }
   },

--- a/src/services/__tests__/escrowDriftReconciler.test.ts
+++ b/src/services/__tests__/escrowDriftReconciler.test.ts
@@ -1,0 +1,696 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import {
+  EscrowDriftReconciler,
+  driftEvents,
+  mapChainEventToIntentStatus,
+  type LocalStateRepository,
+  type LocalSlotState,
+} from "../escrowDriftReconciler.js";
+import { EscrowReaderPool, readerPoolEvents } from "../escrowReaderPool.js";
+import type { IEscrowReader, SlotEscrowState, EscrowStateSnapshot, EscrowLedgerInfo } from "../escrowReader.js";
+import {
+  escrowDriftDetected,
+} from "../../metrics.js";
+
+// ── Fake Escrow Reader ───────────────────────────────────────────────────────
+
+class FakeEscrowReader implements IEscrowReader {
+  public id: string;
+  private snapshots: EscrowStateSnapshot[] = [];
+  private failNext = false;
+  private delayMs = 0;
+  private _ledgerSeq: number = 1000;
+
+  constructor(id: string) {
+    this.id = id;
+  }
+
+  scriptSnapshot(snapshot: EscrowStateSnapshot): void {
+    this.snapshots.push(snapshot);
+  }
+
+  failNextSnapshot(): void {
+    this.failNext = true;
+  }
+
+  setDelay(ms: number): void {
+    this.delayMs = ms;
+  }
+
+  setLatestLedgerSeq(seq: number): void {
+    this._ledgerSeq = seq;
+  }
+
+  async getSlotEvents(_slotId: string, _startLedger?: number): Promise<never[]> {
+    return [];
+  }
+
+  async getLatestLedger(): Promise<EscrowLedgerInfo> {
+    return {
+      latestLedgerSeq: this._ledgerSeq,
+      latestCloseTime: new Date().toISOString(),
+      protocolVersion: 21,
+    };
+  }
+
+  async snapshot(slotIds: string[], _startLedger?: number): Promise<EscrowStateSnapshot> {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error(`[${this.id}] Simulated transport failure`);
+    }
+
+    if (this.delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+    }
+
+    const scripted = this.snapshots.shift();
+    if (scripted) return scripted;
+
+    return {
+      slots: slotIds.map((slotId) => ({
+        slotId,
+        latestEventKind: null,
+        latestTxHash: null,
+        latestLedgerSeq: -1,
+        bookingIntentId: null,
+        eventCount: 0,
+      })),
+      ledgerInfo: await this.getLatestLedger(),
+      readAt: new Date().toISOString(),
+      readerId: this.id,
+    };
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSlotState(
+  slotId: string,
+  overrides: Partial<SlotEscrowState> = {},
+): SlotEscrowState {
+  return {
+    slotId,
+    latestEventKind: null,
+    latestTxHash: null,
+    latestLedgerSeq: -1,
+    bookingIntentId: null,
+    eventCount: 0,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(
+  readerId: string,
+  slots: SlotEscrowState[],
+): EscrowStateSnapshot {
+  return {
+    slots,
+    ledgerInfo: {
+      latestLedgerSeq: 1000,
+      latestCloseTime: new Date().toISOString(),
+    },
+    readAt: new Date().toISOString(),
+    readerId,
+  };
+}
+
+// ── Fake Local State Repository ──────────────────────────────────────────────
+
+class FakeLocalStateRepo implements LocalStateRepository {
+  private states = new Map<string, LocalSlotState>();
+  private activeSlotIds: string[] = [];
+
+  setActiveSlotIds(ids: string[]): void {
+    this.activeSlotIds = ids;
+  }
+
+  setSlotState(slotId: string, state: LocalSlotState): void {
+    this.states.set(slotId, state);
+  }
+
+  async getActiveSlotIds(): Promise<string[]> {
+    return [...this.activeSlotIds];
+  }
+
+  async getSlotState(slotId: string): Promise<LocalSlotState | null> {
+    return this.states.get(slotId) ?? null;
+  }
+
+  async applyOverride(
+    slotId: string,
+    targetStatus: "pending" | "confirmed" | "cancelled" | "expired",
+    _reason: string,
+  ): Promise<LocalSlotState> {
+    const existing = this.states.get(slotId);
+    const updated: LocalSlotState = {
+      slotId,
+      intentStatus: targetStatus,
+      lastKnownTxHash: existing?.lastKnownTxHash ?? null,
+      lastKnownEventKind: existing?.lastKnownEventKind ?? null,
+    };
+    this.states.set(slotId, updated);
+    return updated;
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("mapChainEventToIntentStatus", () => {
+  it("maps Held → confirmed", () => {
+    expect(mapChainEventToIntentStatus("Held")).toBe("confirmed");
+  });
+
+  it("maps Released → cancelled", () => {
+    expect(mapChainEventToIntentStatus("Released")).toBe("cancelled");
+  });
+
+  it("maps Refunded → cancelled", () => {
+    expect(mapChainEventToIntentStatus("Refunded")).toBe("cancelled");
+  });
+
+  it("maps Slashed → expired", () => {
+    expect(mapChainEventToIntentStatus("Slashed")).toBe("expired");
+  });
+
+  it("maps null → null", () => {
+    expect(mapChainEventToIntentStatus(null)).toBeNull();
+  });
+
+  it("maps unknown kind → null", () => {
+    expect(mapChainEventToIntentStatus("Ransomware")).toBeNull();
+  });
+});
+
+describe("EscrowReaderPool", () => {
+  let readers: FakeEscrowReader[];
+  let pool: EscrowReaderPool;
+
+  beforeEach(() => {
+    readers = [
+      new FakeEscrowReader("reader-1"),
+      new FakeEscrowReader("reader-2"),
+      new FakeEscrowReader("reader-3"),
+    ];
+    pool = new EscrowReaderPool({
+      readers,
+      quorumThreshold: 0.5,
+      disagreementThreshold: 0.25,
+    });
+    readerPoolEvents.removeAllListeners();
+  });
+
+  it("requires at least 3 readers", () => {
+    expect(
+      () => new EscrowReaderPool({ readers: [new FakeEscrowReader("r1"), new FakeEscrowReader("r2")] }),
+    ).toThrow("at least 3 readers");
+  });
+
+  it("returns correct reader count", () => {
+    expect(pool.readerCount).toBe(3);
+  });
+
+  it("builds consensus when all readers agree", async () => {
+    const heldState = makeSlotState("slot-1", {
+      latestEventKind: "Held",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 100,
+      eventCount: 1,
+    });
+
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [heldState]));
+    }
+
+    const result = await pool.vote(["slot-1"]);
+    expect(result.healthyReaderCount).toBe(3);
+    expect(result.failedReaderIds).toHaveLength(0);
+    expect(result.slotComparisons[0].consensus).toBe(true);
+    expect(result.slotComparisons[0].majorityState?.latestEventKind).toBe("Held");
+    expect(result.slotComparisons[0].agreeingReaders).toBe(3);
+    expect(result.slotComparisons[0].disagreementExceededThreshold).toBe(false);
+  });
+
+  it("detects reader disagreement", async () => {
+    readers[0].scriptSnapshot(
+      makeSnapshot("reader-1", [makeSlotState("slot-1", { latestEventKind: "Held", latestTxHash: "a".repeat(64), latestLedgerSeq: 100 })])
+    );
+    readers[1].scriptSnapshot(
+      makeSnapshot("reader-2", [makeSlotState("slot-1", { latestEventKind: "Held", latestTxHash: "a".repeat(64), latestLedgerSeq: 100 })])
+    );
+    readers[2].scriptSnapshot(
+      makeSnapshot("reader-3", [makeSlotState("slot-1", { latestEventKind: "Released", latestTxHash: "b".repeat(64), latestLedgerSeq: 101 })])
+    );
+
+    const alertPromise = new Promise<any>((resolve) => {
+      readerPoolEvents.once("alert", resolve);
+    });
+
+    const result = await pool.vote(["slot-1"]);
+    expect(result.slotComparisons[0].consensus).toBe(false);
+    expect(result.slotComparisons[0].majorityState?.latestEventKind).toBe("Held");
+    expect(result.slotComparisons[0].agreeingReaders).toBe(2);
+    expect(result.slotComparisons[0].disagreementExceededThreshold).toBe(true);
+
+    const alert = await alertPromise;
+    expect(alert.type).toBe("READER_DISAGREEMENT");
+    expect(alert.slotId).toBe("slot-1");
+  });
+
+  it("detects hung jury when no majority exists", async () => {
+    readers[0].scriptSnapshot(
+      makeSnapshot("reader-1", [makeSlotState("slot-1", { latestEventKind: "Held", latestTxHash: "a".repeat(64), latestLedgerSeq: 100 })])
+    );
+    readers[1].scriptSnapshot(
+      makeSnapshot("reader-2", [makeSlotState("slot-1", { latestEventKind: "Released", latestTxHash: "b".repeat(64), latestLedgerSeq: 101 })])
+    );
+    readers[2].scriptSnapshot(
+      makeSnapshot("reader-3", [makeSlotState("slot-1", { latestEventKind: "Refunded", latestTxHash: "c".repeat(64), latestLedgerSeq: 102 })])
+    );
+
+    const alertPromise = new Promise<any>((resolve) => {
+      readerPoolEvents.once("alert", resolve);
+    });
+
+    const result = await pool.vote(["slot-1"]);
+    expect(result.slotComparisons[0].consensus).toBe(false);
+    expect(result.slotComparisons[0].majorityState).toBeNull();
+
+    const alert = await alertPromise;
+    expect(alert.type).toBe("HUNG_JURY");
+  });
+
+  it("excludes failed readers from quorum", async () => {
+    readers[1].failNextSnapshot();
+
+    const heldState = makeSlotState("slot-1", {
+      latestEventKind: "Held",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 100,
+    });
+    readers[0].scriptSnapshot(makeSnapshot("reader-1", [heldState]));
+    readers[2].scriptSnapshot(makeSnapshot("reader-3", [heldState]));
+
+    const result = await pool.vote(["slot-1"]);
+    expect(result.healthyReaderCount).toBe(2);
+    expect(result.failedReaderIds).toEqual(["reader-2"]);
+    expect(result.slotComparisons[0].consensus).toBe(true);
+    expect(result.slotComparisons[0].agreeingReaders).toBe(2);
+  });
+
+  it("handles all readers failing", async () => {
+    for (const reader of readers) {
+      reader.failNextSnapshot();
+    }
+
+    const result = await pool.vote(["slot-1"]);
+    expect(result.healthyReaderCount).toBe(0);
+    expect(result.failedReaderIds).toEqual(["reader-1", "reader-2", "reader-3"]);
+    expect(result.slotComparisons[0].majorityState).toBeNull();
+  });
+
+  it("evaluates multiple slots correctly", async () => {
+    const slot1State = makeSlotState("slot-1", { latestEventKind: "Held", latestTxHash: "a".repeat(64), latestLedgerSeq: 100 });
+    const slot2State = makeSlotState("slot-2", { latestEventKind: "Released", latestTxHash: "b".repeat(64), latestLedgerSeq: 101 });
+
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [slot1State, slot2State]));
+    }
+
+    const result = await pool.vote(["slot-1", "slot-2"]);
+    expect(result.totalSlots).toBe(2);
+    expect(result.slotComparisons[0].consensus).toBe(true);
+    expect(result.slotComparisons[1].consensus).toBe(true);
+  });
+});
+
+describe("EscrowDriftReconciler", () => {
+  let readers: FakeEscrowReader[];
+  let pool: EscrowReaderPool;
+  let localRepo: FakeLocalStateRepo;
+  let reconciler: EscrowDriftReconciler;
+
+  beforeEach(() => {
+    readers = [
+      new FakeEscrowReader("reader-1"),
+      new FakeEscrowReader("reader-2"),
+      new FakeEscrowReader("reader-3"),
+    ];
+    pool = new EscrowReaderPool({
+      readers,
+      quorumThreshold: 0.5,
+      disagreementThreshold: 0.25,
+    });
+    localRepo = new FakeLocalStateRepo();
+    reconciler = new EscrowDriftReconciler({
+      readerPool: pool,
+      localRepo,
+      pollIntervalMs: 60000,
+      autoResolve: false,
+    });
+    driftEvents.removeAllListeners();
+    readerPoolEvents.removeAllListeners();
+  });
+
+  afterEach(() => {
+    reconciler.stop();
+  });
+
+  it("starts and stops without error", () => {
+    reconciler.start();
+    // @ts-expect-error - checking private state
+    expect(reconciler.isRunning).toBe(true);
+    reconciler.stop();
+    // @ts-expect-error - checking private state
+    expect(reconciler.isRunning).toBe(false);
+  });
+
+  it("handles empty active slot list gracefully", async () => {
+    localRepo.setActiveSlotIds([]);
+    const result = await reconciler.reconcile();
+    expect(result.slotsEvaluated).toBe(0);
+    expect(result.slotsInSync).toBe(0);
+    expect(result.driftedSlots).toHaveLength(0);
+  });
+
+  // ── No drift scenarios ────────────────────────────────────────────────────
+
+  it("detects no drift when chain and local DB agree (Held → confirmed)", async () => {
+    const slotState = makeSlotState("slot-1", {
+      latestEventKind: "Held",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 100,
+    });
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [slotState]));
+    }
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "confirmed",
+      lastKnownTxHash: "a".repeat(64),
+      lastKnownEventKind: "Held",
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.slotsEvaluated).toBe(1);
+    expect(result.slotsInSync).toBe(1);
+    expect(result.driftedSlots).toHaveLength(0);
+  });
+
+  it("detects no drift when chain and local DB agree (Released → cancelled)", async () => {
+    const slotState = makeSlotState("slot-1", {
+      latestEventKind: "Released",
+      latestTxHash: "b".repeat(64),
+      latestLedgerSeq: 101,
+    });
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [slotState]));
+    }
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "cancelled",
+      lastKnownTxHash: "b".repeat(64),
+      lastKnownEventKind: "Released",
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.slotsInSync).toBe(1);
+    expect(result.driftedSlots).toHaveLength(0);
+  });
+
+  it("detects no drift when both chain and local have no events", async () => {
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [makeSlotState("slot-1")]));
+    }
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "pending",
+      lastKnownTxHash: null,
+      lastKnownEventKind: null,
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.slotsInSync).toBe(1);
+  });
+
+  // ── Drift scenarios ───────────────────────────────────────────────────────
+
+  it("detects drift: chain has events, DB has none (structural drift)", async () => {
+    const slotState = makeSlotState("slot-1", {
+      latestEventKind: "Held",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 100,
+    });
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [slotState]));
+    }
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "pending",
+      lastKnownTxHash: null,
+      lastKnownEventKind: null,
+    });
+
+    const alertPromise = new Promise<any>((resolve) => {
+      driftEvents.once("alert", resolve);
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.slotsInSync).toBe(0);
+    expect(result.driftedSlots).toHaveLength(1);
+    expect(result.driftedSlots[0].slotId).toBe("slot-1");
+    expect(result.driftedSlots[0].description).toContain("DB has no escrow events");
+
+    const alert = await alertPromise;
+    expect(alert.type).toBe("DRIFT_DETECTED");
+  });
+
+  it("detects drift: tx hash mismatch between chain and DB", async () => {
+    const slotState = makeSlotState("slot-1", {
+      latestEventKind: "Held",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 100,
+    });
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [slotState]));
+    }
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "confirmed",
+      lastKnownTxHash: "b".repeat(64),
+      lastKnownEventKind: "Held",
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.driftedSlots).toHaveLength(1);
+    expect(result.driftedSlots[0].description).toContain("Tx hash mismatch");
+  });
+
+  it("detects drift: DB ahead of chain (local has events, chain has none)", async () => {
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [makeSlotState("slot-1")]));
+    }
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "confirmed",
+      lastKnownTxHash: "a".repeat(64),
+      lastKnownEventKind: "Held",
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.driftedSlots).toHaveLength(1);
+    expect(result.driftedSlots[0].description).toContain("possible reorg");
+  });
+
+  it("detects drift: intent status mismatch (same tx, diverging projection)", async () => {
+    const slotState = makeSlotState("slot-1", {
+      latestEventKind: "Slashed",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 103,
+    });
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [slotState]));
+    }
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "confirmed",
+      lastKnownTxHash: "a".repeat(64),
+      lastKnownEventKind: "Held",
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.driftedSlots).toHaveLength(1);
+    expect(result.driftedSlots[0].description).toContain("Intent status mismatch");
+  });
+
+  // ── Hung jury ─────────────────────────────────────────────────────────────
+
+  it("flags slot as drifted when hung jury (no quorum)", async () => {
+    readers[0].scriptSnapshot(
+      makeSnapshot("reader-1", [makeSlotState("slot-1", { latestEventKind: "Held", latestTxHash: "a".repeat(64), latestLedgerSeq: 100 })])
+    );
+    readers[1].scriptSnapshot(
+      makeSnapshot("reader-2", [makeSlotState("slot-1", { latestEventKind: "Released", latestTxHash: "b".repeat(64), latestLedgerSeq: 101 })])
+    );
+    readers[2].scriptSnapshot(
+      makeSnapshot("reader-3", [makeSlotState("slot-1", { latestEventKind: "Refunded", latestTxHash: "c".repeat(64), latestLedgerSeq: 102 })])
+    );
+
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "pending",
+      lastKnownTxHash: null,
+      lastKnownEventKind: null,
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.driftedSlots).toHaveLength(1);
+    expect(result.driftedSlots[0].description).toContain("No quorum");
+  });
+
+  // ── Reader failures ───────────────────────────────────────────────────────
+
+  it("handles one reader being down", async () => {
+    readers[0].failNextSnapshot();
+    const slotState = makeSlotState("slot-1", {
+      latestEventKind: "Held",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 100,
+    });
+    readers[1].scriptSnapshot(makeSnapshot("reader-2", [slotState]));
+    readers[2].scriptSnapshot(makeSnapshot("reader-3", [slotState]));
+
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "confirmed",
+      lastKnownTxHash: "a".repeat(64),
+      lastKnownEventKind: "Held",
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.readerFailures).toBe(1);
+    expect(result.slotsInSync).toBe(1);
+  });
+
+  it("handles local repo error gracefully", async () => {
+    const originalGet = localRepo.getActiveSlotIds;
+    localRepo.getActiveSlotIds = () => {
+      throw new Error("DB connection lost");
+    };
+
+    const result = await reconciler.reconcile();
+    expect(result.slotsEvaluated).toBe(0);
+    expect(result.slotsInSync).toBe(0);
+    expect(result.driftedSlots).toHaveLength(0);
+
+    localRepo.getActiveSlotIds = originalGet;
+  });
+
+  // ── Manual override ───────────────────────────────────────────────────────
+
+  it("applies manual override and emits events", async () => {
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "pending",
+      lastKnownTxHash: null,
+      lastKnownEventKind: null,
+    });
+
+    const alertPromise = new Promise<any>((resolve) => {
+      driftEvents.once("alert", resolve);
+    });
+
+    const result = await reconciler.manualOverride(
+      "slot-1",
+      "confirmed",
+      "Manual fix after quorum confirmed chain state was Held",
+      "192.168.1.1",
+    );
+
+    expect(result.previousState?.intentStatus).toBe("pending");
+    expect(result.newState.intentStatus).toBe("confirmed");
+
+    const alert = await alertPromise;
+    expect(alert.type).toBe("MANUAL_OVERRIDE_APPLIED");
+    expect(alert.slotId).toBe("slot-1");
+    expect(alert.previousStatus).toBe("pending");
+    expect(alert.newStatus).toBe("confirmed");
+
+    const updated = await localRepo.getSlotState("slot-1");
+    expect(updated?.intentStatus).toBe("confirmed");
+  });
+
+  // ── autoResolve safety ────────────────────────────────────────────────────
+
+  it("does not auto-apply drift resolution when autoResolve is false", async () => {
+    const slotState = makeSlotState("slot-1", {
+      latestEventKind: "Held",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 100,
+    });
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [slotState]));
+    }
+    localRepo.setActiveSlotIds(["slot-1"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "pending",
+      lastKnownTxHash: null,
+      lastKnownEventKind: null,
+    });
+
+    await reconciler.reconcile();
+
+    // Drift should be detected but local state should NOT change
+    const state = await localRepo.getSlotState("slot-1");
+    expect(state?.intentStatus).toBe("pending");
+  });
+
+  // ── Multiple slots ────────────────────────────────────────────────────────
+
+  it("handles mixed drift across multiple slots", async () => {
+    const slot1Chain = makeSlotState("slot-1", {
+      latestEventKind: "Held",
+      latestTxHash: "a".repeat(64),
+      latestLedgerSeq: 100,
+    });
+    const slot2Chain = makeSlotState("slot-2", {
+      latestEventKind: "Released",
+      latestTxHash: "b".repeat(64),
+      latestLedgerSeq: 101,
+    });
+
+    for (const reader of readers) {
+      reader.scriptSnapshot(makeSnapshot(reader.id, [slot1Chain, slot2Chain]));
+    }
+
+    localRepo.setActiveSlotIds(["slot-1", "slot-2"]);
+    localRepo.setSlotState("slot-1", {
+      slotId: "slot-1",
+      intentStatus: "confirmed",
+      lastKnownTxHash: "a".repeat(64),
+      lastKnownEventKind: "Held",
+    });
+    localRepo.setSlotState("slot-2", {
+      slotId: "slot-2",
+      intentStatus: "pending",
+      lastKnownTxHash: null,
+      lastKnownEventKind: null,
+    });
+
+    const result = await reconciler.reconcile();
+    expect(result.slotsEvaluated).toBe(2);
+    expect(result.slotsInSync).toBe(1);
+    expect(result.driftedSlots).toHaveLength(1);
+    expect(result.driftedSlots[0].slotId).toBe("slot-2");
+  });
+});

--- a/src/services/escrowDriftReconciler.ts
+++ b/src/services/escrowDriftReconciler.ts
@@ -1,0 +1,405 @@
+/**
+ * Escrow Drift Reconciler
+ * -----------------------
+ *
+ * Periodically compares escrow contract state (read via a quorum of
+ * independent Horizon readers) against the local DB state. When drift is
+ * detected the reconciler:
+ *
+ *   1. Emits the `escrow_drift_detected` metric.
+ *   2. Logs a fatal-level alert with full forensic details.
+ *   3. Emits an alarm event for downstream alerting.
+ *   4. Queues the affected slot for manual review.
+ *
+ * A manual override endpoint (POST /api/v1/admin/escrow/drift/override)
+ * allows an admin to force-update the local state after investigation.
+ *
+ * Architecture:
+ *   - EscrowReaderPool  — quorum of independent Horizon readers
+ *   - Local state repo  — the DB-backed view (booking intents + slots)
+ *   - Periodic tick     — run every N seconds, start/stop lifecycle
+ */
+
+import { EventEmitter } from "node:events";
+import { EscrowReaderPool } from "./escrowReaderPool.js";
+import {
+  escrowDriftDetected,
+  escrowDriftOverridesApplied,
+  escrowDriftReconciliationTicks,
+  escrowReaderDisagreementTotal,
+} from "../metrics.js";
+import { logger } from "../utils/logger.js";
+import type { SlotEscrowState } from "./escrowReader.js";
+
+// ─── Local DB State ──────────────────────────────────────────────────────────
+
+/**
+ * The reconciler's view of local DB state for a slot.
+ * This is intentionally minimal — only the fields needed for comparison.
+ */
+export interface LocalSlotState {
+  slotId: string;
+  /** The booking intent status in the local DB. */
+  intentStatus: LocalIntentStatus | null;
+  /** The latest known escrow tx hash in the local DB. */
+  lastKnownTxHash: string | null;
+  /** The latest known escrow event kind in the local DB. */
+  lastKnownEventKind: string | null;
+}
+
+export type LocalIntentStatus = "pending" | "confirmed" | "cancelled" | "expired";
+
+/**
+ * Repository interface for querying local state. Callers provide a concrete
+ * implementation backed by the real DB (or an in-memory mock for tests).
+ */
+export interface LocalStateRepository {
+  /** Return all slot ids that have active escrow-linked booking intents. */
+  getActiveSlotIds(): Promise<string[]>;
+  /** Return the local state for a single slot. */
+  getSlotState(slotId: string): Promise<LocalSlotState | null>;
+  /**
+   * Apply a manual override: update the local state to match the chain.
+   * Returns the updated state.
+   */
+  applyOverride(
+    slotId: string,
+    targetStatus: LocalIntentStatus,
+    reason: string,
+  ): Promise<LocalSlotState>;
+}
+
+// ─── Drift result types ──────────────────────────────────────────────────────
+
+export interface DriftedSlot {
+  slotId: string;
+  chainState: SlotEscrowState;
+  localState: LocalSlotState;
+  /** Human-readable description of the drift. */
+  description: string;
+}
+
+export interface ReconcilerTickResult {
+  /** Total active slots evaluated. */
+  slotsEvaluated: number;
+  /** Slots where the chain and local DB agree. */
+  slotsInSync: number;
+  /** Slots where drift was detected. */
+  driftedSlots: DriftedSlot[];
+  /** Number of reader failures during this tick. */
+  readerFailures: number;
+  /** ISO 8601 timestamp of the tick. */
+  timestamp: string;
+}
+
+export const driftEvents = new EventEmitter();
+
+export interface DriftDetectedEvent {
+  type: "DRIFT_DETECTED";
+  driftedSlots: DriftedSlot[];
+  timestamp: string;
+  message: string;
+}
+
+export interface ManualOverrideEvent {
+  type: "MANUAL_OVERRIDE_APPLIED";
+  slotId: string;
+  previousStatus: string;
+  newStatus: string;
+  reason: string;
+  actorIp: string;
+  timestamp: string;
+}
+
+// ─── Reconciler ──────────────────────────────────────────────────────────────
+
+export interface EscrowDriftReconcilerOptions {
+  /** The reader pool for quorum-voted chain state. */
+  readerPool: EscrowReaderPool;
+  /** Local state repository. */
+  localRepo: LocalStateRepository;
+  /** Poll interval in ms. Default 60_000 (1 minute). */
+  pollIntervalMs?: number;
+  /**
+   * Whether to auto-resolve drift by applying the chain state.
+   * SECURITY: this should be false in production. Default false.
+   */
+  autoResolve?: boolean;
+}
+
+export class EscrowDriftReconciler {
+  private readonly readerPool: EscrowReaderPool;
+  private readonly localRepo: LocalStateRepository;
+  private readonly pollIntervalMs: number;
+  private readonly autoResolve: boolean;
+  private isRunning: boolean = false;
+  private intervalId: NodeJS.Timeout | null = null;
+
+  constructor(options: EscrowDriftReconcilerOptions) {
+    this.readerPool = options.readerPool;
+    this.localRepo = options.localRepo;
+    this.pollIntervalMs = options.pollIntervalMs ?? 60_000;
+    this.autoResolve = options.autoResolve ?? false;
+  }
+
+  start(): void {
+    if (this.isRunning) return;
+    this.isRunning = true;
+    this.intervalId = setInterval(() => {
+      void this.reconcile();
+    }, this.pollIntervalMs);
+  }
+
+  stop(): void {
+    this.isRunning = false;
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /**
+   * Perform one full reconciliation sweep.
+   */
+  async reconcile(): Promise<ReconcilerTickResult> {
+    escrowDriftReconciliationTicks.inc();
+    const timestamp = new Date().toISOString();
+
+    let slotsEvaluated = 0;
+    let slotsInSync = 0;
+    const driftedSlots: DriftedSlot[] = [];
+    let readerFailures = 0;
+
+    // 1. Get active slot ids from local DB
+    let slotIds: string[];
+    try {
+      slotIds = await this.localRepo.getActiveSlotIds();
+    } catch (err: any) {
+      logger.warn(
+        { error: err.message },
+        "EscrowDriftReconciler: failed to fetch active slot ids from local repo. Skipping tick.",
+      );
+      return {
+        slotsEvaluated: 0,
+        slotsInSync: 0,
+        driftedSlots: [],
+        readerFailures: 0,
+        timestamp,
+      };
+    }
+
+    if (slotIds.length === 0) {
+      return { slotsEvaluated: 0, slotsInSync: 0, driftedSlots: [], readerFailures: 0, timestamp };
+    }
+
+    // 2. Get quorum-voted chain state
+    const voteResult = await this.readerPool.vote(slotIds);
+    readerFailures = voteResult.failedReaderIds.length;
+
+    // Track reader disagreements
+    for (const comparison of voteResult.slotComparisons) {
+      if (comparison.disagreementExceededThreshold) {
+        const disagreeingIds = Object.entries(comparison.readerStates)
+          .filter(([, s]) => {
+            if (!s) return true;
+            if (!comparison.majorityState) return true;
+            return (
+              s.latestEventKind !== comparison.majorityState.latestEventKind ||
+              s.latestTxHash !== comparison.majorityState.latestTxHash
+            );
+          })
+          .map(([id]) => id);
+        for (const readerId of disagreeingIds) {
+          escrowReaderDisagreementTotal.labels(readerId).inc();
+        }
+      }
+    }
+
+    // 3. Compare chain vs local for each slot
+    for (const comparison of voteResult.slotComparisons) {
+      slotsEvaluated++;
+
+      const chainState = comparison.majorityState;
+      const localState = await this.localRepo.getSlotState(comparison.slotId);
+
+      if (!localState) {
+        // Slot doesn't exist locally — not drift, slot may have been cleaned up
+        slotsInSync++;
+        continue;
+      }
+
+      if (!chainState) {
+        // Hung jury — no reliable chain state to compare against
+        // Still count as evaluated but not in sync
+        const description = `No quorum reached for slot ${comparison.slotId}; cannot compare chain vs local state`;
+        logger.warn({ slotId: comparison.slotId }, description);
+        driftedSlots.push({
+          slotId: comparison.slotId,
+          chainState: {
+            slotId: comparison.slotId,
+            latestEventKind: null,
+            latestTxHash: null,
+            latestLedgerSeq: -1,
+            bookingIntentId: null,
+            eventCount: 0,
+          },
+          localState,
+          description,
+        });
+        escrowDriftDetected.labels(comparison.slotId).set(1);
+        continue;
+      }
+
+      const drifted = this.compareStates(comparison.slotId, chainState, localState);
+      if (drifted) {
+        driftedSlots.push(drifted);
+        escrowDriftDetected.labels(comparison.slotId).set(1);
+      } else {
+        slotsInSync++;
+        escrowDriftDetected.labels(comparison.slotId).set(0);
+      }
+    }
+
+    // 4. Emit drift alert if any slots drifted
+    if (driftedSlots.length > 0) {
+      const event: DriftDetectedEvent = {
+        type: "DRIFT_DETECTED",
+        driftedSlots,
+        timestamp,
+        message: `Escrow state drift detected for ${driftedSlots.length} slot(s): ${driftedSlots.map((s) => s.slotId).join(", ")}`,
+      };
+
+      logger.fatal(
+        { driftedSlotIds: driftedSlots.map((s) => s.slotId) },
+        event.message,
+      );
+
+      driftEvents.emit("alert", event);
+    }
+
+    return { slotsEvaluated, slotsInSync, driftedSlots, readerFailures, timestamp };
+  }
+
+  /**
+   * Compare a single slot's chain state against its local DB state.
+   * Returns a DriftedSlot if there's a discrepancy, null if in sync.
+   */
+  private compareStates(
+    slotId: string,
+    chainState: SlotEscrowState,
+    localState: LocalSlotState,
+  ): DriftedSlot | null {
+    const expectedStatus = mapChainEventToIntentStatus(chainState.latestEventKind);
+
+    // Check 1: chain has events, local has none (structural drift — no tx hash in DB)
+    if (chainState.latestTxHash !== null && localState.lastKnownTxHash === null) {
+      return {
+        slotId,
+        chainState,
+        localState,
+        description: `Chain has event tx ${chainState.latestTxHash} but local DB has no escrow events for this slot`,
+      };
+    }
+
+    // Check 2: local has events, chain has none (DB ahead of chain — possible fork/reorg)
+    if (chainState.latestTxHash === null && localState.lastKnownTxHash !== null) {
+      return {
+        slotId,
+        chainState,
+        localState,
+        description: `Local DB has event tx ${localState.lastKnownTxHash} but chain has no escrow events for this slot (possible reorg)`,
+      };
+    }
+
+    // Check 3: tx hash mismatch (both have events but different hashes)
+    if (
+      chainState.latestTxHash !== null &&
+      localState.lastKnownTxHash !== null &&
+      chainState.latestTxHash !== localState.lastKnownTxHash
+    ) {
+      return {
+        slotId,
+        chainState,
+        localState,
+        description: `Tx hash mismatch: chain has ${chainState.latestTxHash} but local DB has ${localState.lastKnownTxHash}`,
+      };
+    }
+
+    // Check 4: intent status mismatch (same event, diverging projection)
+    if (expectedStatus !== null && localState.intentStatus !== null && expectedStatus !== localState.intentStatus) {
+      return {
+        slotId,
+        chainState,
+        localState,
+        description: `Intent status mismatch: chain expects "${expectedStatus}" (event ${chainState.latestEventKind}) but local DB has "${localState.intentStatus}"`,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Apply a manual override to force local state to match chain state.
+   * This is called by the admin endpoint, not automatically.
+   */
+  async manualOverride(
+    slotId: string,
+    targetStatus: LocalIntentStatus,
+    reason: string,
+    actorIp: string,
+  ): Promise<{ previousState: LocalSlotState | null; newState: LocalSlotState }> {
+    const previousState = await this.localRepo.getSlotState(slotId);
+
+    const newState = await this.localRepo.applyOverride(slotId, targetStatus, reason);
+
+    // Emit metric and event
+    escrowDriftOverridesApplied.labels(slotId).inc();
+    escrowDriftDetected.labels(slotId).set(0);
+
+    const event: ManualOverrideEvent = {
+      type: "MANUAL_OVERRIDE_APPLIED",
+      slotId,
+      previousStatus: previousState?.intentStatus ?? "unknown",
+      newStatus: targetStatus,
+      reason,
+      actorIp,
+      timestamp: new Date().toISOString(),
+    };
+    driftEvents.emit("alert", event);
+
+    logger.warn(
+      {
+        slotId,
+        previousStatus: previousState?.intentStatus,
+        newStatus: targetStatus,
+        reason,
+        actorIp,
+      },
+      "Manual escrow drift override applied",
+    );
+
+    return { previousState, newState };
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Map an escrow event kind to the expected booking intent status.
+ * Based on the state machine in EscrowStateProjector.
+ */
+export function mapChainEventToIntentStatus(
+  eventKind: string | null,
+): LocalIntentStatus | null {
+  switch (eventKind) {
+    case "Held":
+      return "confirmed";
+    case "Released":
+    case "Refunded":
+      return "cancelled";
+    case "Slashed":
+      return "expired";
+    default:
+      return null; // No chain events = no expected status
+  }
+}

--- a/src/services/escrowReader.ts
+++ b/src/services/escrowReader.ts
@@ -1,0 +1,204 @@
+/**
+ * Escrow Reader
+ * -------------
+ *
+ * Narrow interface for reading escrow contract state from the Stellar network.
+ * Each reader represents an independent Horizon endpoint that the reconciler
+ * queries to build a quorum vote on the authoritative escrow state.
+ *
+ * The interface is intentionally minimal: it exposes only the read paths the
+ * reconciler needs to compare chain state against the local DB. It does NOT
+ * mutate state — that responsibility belongs to the EscrowDriftReconciler.
+ */
+
+import type { EscrowEvent, EscrowEventKind, EscrowLedgerInfo } from "../scheduler/escrowEventTypes.js";
+
+export type { EscrowLedgerInfo } from "../scheduler/escrowEventTypes.js";
+
+// ─── Domain types for the reconciler ─────────────────────────────────────────
+
+/**
+ * Summary of the latest known escrow event for a specific slot, as seen
+ * by one reader. This is the unit of comparison for quorum voting.
+ */
+export interface SlotEscrowState {
+  /** The slot id this state describes. */
+  slotId: string;
+  /** The latest escrow event kind applied to this slot, or null if no events exist. */
+  latestEventKind: EscrowEventKind | null;
+  /** The tx hash of the latest event, or null. */
+  latestTxHash: string | null;
+  /** The ledger sequence of the latest event, or -1. */
+  latestLedgerSeq: number;
+  /** The booking intent id referenced by the latest event, if any. */
+  bookingIntentId: string | null;
+  /** Total number of events seen for this slot. */
+  eventCount: number;
+}
+
+/**
+ * Full escrow state snapshot returned by a reader. Contains per-slot state
+ * summaries and the network tip at read time.
+ */
+export interface EscrowStateSnapshot {
+  /** Per-slot escrow state summaries. */
+  slots: SlotEscrowState[];
+  /** The ledger info at the time the snapshot was taken. */
+  ledgerInfo: EscrowLedgerInfo;
+  /** ISO 8601 timestamp when the snapshot was read. */
+  readAt: string;
+  /** Reader identifier for attribution. */
+  readerId: string;
+}
+
+// ─── Reader interface ────────────────────────────────────────────────────────
+
+export interface IEscrowReader {
+  /** Unique human-readable identifier for this reader (e.g. "horizon-mainnet-1"). */
+  readonly id: string;
+
+  /**
+   * Fetch all escrow events for a specific slot within a ledger range.
+   * Returns events sorted by (ledgerSeq, eventIndex) ascending.
+   */
+  getSlotEvents(slotId: string, startLedger?: number): Promise<EscrowEvent[]>;
+
+  /**
+   * Return the latest ledger known to the network.
+   */
+  getLatestLedger(): Promise<EscrowLedgerInfo>;
+
+  /**
+   * Build a full escrow state snapshot — per-slot summaries for all known
+   * slots within the given ledger range, plus the current network tip.
+   */
+  snapshot(slotIds: string[], startLedger?: number): Promise<EscrowStateSnapshot>;
+}
+
+// ─── Horizon-backed implementation ───────────────────────────────────────────
+
+export interface HorizonEscrowReaderOptions {
+  /** Unique identifier for this reader instance. */
+  id: string;
+  /** Full Horizon API base URL (e.g. https://horizon.stellar.org). */
+  horizonUrl: string;
+}
+
+/**
+ * Horizon-backed implementation of IEscrowReader.
+ *
+ * Uses the Horizon REST API to fetch escrow contract events. Each instance
+ * is treated as an independent reader; the reconciler runs multiple instances
+ * against different (or same) Horizon endpoints for quorum voting.
+ */
+export class HorizonEscrowReader implements IEscrowReader {
+  public readonly id: string;
+  private readonly horizonUrl: string;
+
+  constructor(options: HorizonEscrowReaderOptions) {
+    this.id = options.id;
+    this.horizonUrl = options.horizonUrl.replace(/\/$/, "");
+  }
+
+  async getSlotEvents(slotId: string, startLedger?: number): Promise<EscrowEvent[]> {
+    // In production, this would query a Horizon endpoint that indexes escrow
+    // events by slot. For the reconciler, we fetch events in ledger range
+    // and filter client-side. The interface supports a future index-backed
+    // implementation without changing callers.
+    const all = await this.fetchEvents(startLedger ?? 0);
+    return all.filter((e) => e.slotId === slotId);
+  }
+
+  async getLatestLedger(): Promise<EscrowLedgerInfo> {
+    const url = `${this.horizonUrl}/ledgers?limit=1&order=desc`;
+    const response = await this.fetchJson<{
+      _embedded: { records: Array<{ sequence: number; closed_at: string; protocol_version?: number }> };
+    }>(url);
+
+    const record = response._embedded.records[0];
+    if (!record) {
+      throw new Error(`[${this.id}] Horizon returned empty ledger list`);
+    }
+
+    return {
+      latestLedgerSeq: record.sequence,
+      latestCloseTime: record.closed_at,
+      protocolVersion: record.protocol_version,
+    };
+  }
+
+  async snapshot(slotIds: string[], startLedger?: number): Promise<EscrowStateSnapshot> {
+    const ledgerInfo = await this.getLatestLedger();
+    const startSeq = startLedger ?? 0;
+    const allEvents = await this.fetchEvents(startSeq);
+
+    // Group events by slot, keeping only the latest per slot
+    const bySlot = new Map<string, EscrowEvent[]>();
+    for (const event of allEvents) {
+      if (!bySlot.has(event.slotId)) {
+        bySlot.set(event.slotId, []);
+      }
+      bySlot.get(event.slotId)!.push(event);
+    }
+
+    const slots: SlotEscrowState[] = [];
+    for (const slotId of slotIds) {
+      const events = bySlot.get(slotId) ?? [];
+      if (events.length === 0) {
+        slots.push({
+          slotId,
+          latestEventKind: null,
+          latestTxHash: null,
+          latestLedgerSeq: -1,
+          bookingIntentId: null,
+          eventCount: 0,
+        });
+        continue;
+      }
+
+      // Events are already sorted by (ledgerSeq, eventIndex)
+      const latest = events[events.length - 1];
+      slots.push({
+        slotId,
+        latestEventKind: latest.kind,
+        latestTxHash: latest.txHash,
+        latestLedgerSeq: latest.ledgerSeq,
+        bookingIntentId: latest.bookingIntentId ?? null,
+        eventCount: events.length,
+      });
+    }
+
+    return {
+      slots,
+      ledgerInfo,
+      readAt: new Date().toISOString(),
+      readerId: this.id,
+    };
+  }
+
+  // ─── Private helpers ───────────────────────────────────────────────────────
+
+  private async fetchEvents(_startLedger: number): Promise<EscrowEvent[]> {
+    // TODO: Wire to Soroban RPC getEvents when the escrow contract event
+    // index is available. A production deployment MUST replace this stub
+    // with a real RPC call that fetches, validates, and returns events.
+    return [];
+  }
+
+  private async fetchJson<T>(url: string): Promise<T> {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": `chronopay-escrow-reader/${this.id}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `[${this.id}] Horizon HTTP ${response.status}: ${await response.text().catch(() => "unknown error")}`,
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/src/services/escrowReaderPool.ts
+++ b/src/services/escrowReaderPool.ts
@@ -1,0 +1,291 @@
+/**
+ * Escrow Reader Pool
+ * ------------------
+ *
+ * Manages a pool of independent IEscrowReader instances and coordinates
+ * quorum voting to determine the authoritative escrow state. The pool:
+ *
+ *   1. Queries ALL readers in parallel for the same snapshot.
+ *   2. Compares their per-slot state summaries.
+ *   3. Resolves disagreements via majority vote.
+ *   4. Alarms when reader disagreement exceeds a configurable threshold.
+ *
+ * Vote aggregation:
+ *   - For each slot, the "canonical" state is the one agreed upon by a
+ *     simple majority (> 50%) of healthy readers.
+ *   - If no majority exists ("hung jury"), the slot is flagged as
+ *     `disputed` and an alarm is raised.
+ *   - Individual reader disagreements are tracked via a counter metric.
+ */
+
+import { EventEmitter } from "node:events";
+import type { IEscrowReader, SlotEscrowState, EscrowStateSnapshot } from "./escrowReader.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** Result of comparing two SlotEscrowState values. */
+export interface SlotStateComparison {
+  slotId: string;
+  /** True if all healthy readers agree on the latest event kind for this slot. */
+  consensus: boolean;
+  /** The majority-voted state, or null if no majority (hung jury). */
+  majorityState: SlotEscrowState | null;
+  /** Per-reader state values, keyed by reader id. */
+  readerStates: Record<string, SlotEscrowState | null>;
+  /** Number of readers that returned this slot. */
+  readerCount: number;
+  /** Number of readers that agree on the majority state. */
+  agreeingReaders: number;
+  /** True if the disagreement threshold was exceeded. */
+  disagreementExceededThreshold: boolean;
+}
+
+export interface QuorumVoteResult {
+  /** The snapshots returned by each healthy reader. */
+  snapshots: EscrowStateSnapshot[];
+  /** Per-slot comparisons with vote tallies. */
+  slotComparisons: SlotStateComparison[];
+  /** Set of reader ids that failed (errored or timed out). */
+  failedReaderIds: string[];
+  /** Total number of healthy readers that participated. */
+  healthyReaderCount: number;
+  /** Total slots evaluated. */
+  totalSlots: number;
+}
+
+export interface EscrowReaderPoolOptions {
+  /** Array of reader instances. Minimum 3 for meaningful quorum. */
+  readers: IEscrowReader[];
+  /**
+   * Minimum fraction of readers that must agree for consensus.
+   * Default 0.5 (simple majority). Must be > 0.5 for
+   * unambiguous majority with 3+ readers.
+   */
+  quorumThreshold?: number;
+  /**
+   * Maximum fraction of readers that can disagree before an alarm fires.
+   * Default 0.25 (if more than 25% disagree with majority on any slot).
+   */
+  disagreementThreshold?: number;
+  /** Timeout in ms for each reader's snapshot call. Default 10_000. */
+  readerTimeoutMs?: number;
+}
+
+// ─── Events ──────────────────────────────────────────────────────────────────
+
+export interface ReaderDisagreementEvent {
+  type: "READER_DISAGREEMENT";
+  slotId: string;
+  readerIds: string[];
+  majorityState: SlotEscrowState | null;
+  disagreeingCount: number;
+  totalReaders: number;
+  message: string;
+}
+
+export interface HungJuryEvent {
+  type: "HUNG_JURY";
+  slotId: string;
+  readerStates: Record<string, SlotEscrowState | null>;
+  message: string;
+}
+
+export const readerPoolEvents = new EventEmitter();
+
+// ─── Pool implementation ─────────────────────────────────────────────────────
+
+export class EscrowReaderPool {
+  private readonly readers: IEscrowReader[];
+  private readonly quorumThreshold: number;
+  private readonly disagreementThreshold: number;
+  private readonly readerTimeoutMs: number;
+
+  constructor(options: EscrowReaderPoolOptions) {
+    if (options.readers.length < 3) {
+      throw new Error(
+        `EscrowReaderPool requires at least 3 readers for meaningful quorum, got ${options.readers.length}`,
+      );
+    }
+    this.readers = [...options.readers];
+    this.quorumThreshold = options.quorumThreshold ?? 0.5;
+    this.disagreementThreshold = options.disagreementThreshold ?? 0.25;
+    this.readerTimeoutMs = options.readerTimeoutMs ?? 10_000;
+
+    if (this.quorumThreshold <= 0.5 && this.readers.length % 2 === 0) {
+      throw new Error(
+        `quorumThreshold must be > 0.5 for even-sized reader pools (got ${this.readers.length}) to avoid split-vote false majorities`,
+      );
+    }
+  }
+
+  get readerCount(): number {
+    return this.readers.length;
+  }
+
+  /**
+   * Query all readers in parallel and build a quorum vote result.
+   *
+   * Each reader returns a snapshot of escrow state. Failed readers
+   * (errors, timeouts) are excluded from the quorum but recorded.
+   */
+  async vote(slotIds: string[], startLedger?: number): Promise<QuorumVoteResult> {
+    const results = await Promise.allSettled(
+      this.readers.map((reader) =>
+        this.withTimeout(
+          reader.snapshot(slotIds, startLedger),
+          this.readerTimeoutMs,
+          reader.id,
+        ),
+      ),
+    );
+
+    const snapshots: EscrowStateSnapshot[] = [];
+    const failedReaderIds: string[] = [];
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === "fulfilled") {
+        snapshots.push(result.value);
+      } else {
+        failedReaderIds.push(this.readers[i].id);
+      }
+    }
+
+    const healthyCount = snapshots.length;
+
+    // Build slot comparisons
+    const slotComparisons = this.buildSlotComparisons(
+      slotIds,
+      snapshots,
+      healthyCount,
+    );
+
+    return {
+      snapshots,
+      slotComparisons,
+      failedReaderIds,
+      healthyReaderCount: healthyCount,
+      totalSlots: slotIds.length,
+    };
+  }
+
+  /**
+   * Compute per-slot vote tallies and emit alarms for disagreements.
+   */
+  private buildSlotComparisons(
+    slotIds: string[],
+    snapshots: EscrowStateSnapshot[],
+    healthyCount: number,
+  ): SlotStateComparison[] {
+    const comparisons: SlotStateComparison[] = [];
+
+    for (const slotId of slotIds) {
+      const readerStates: Record<string, SlotEscrowState | null> = {};
+
+      // Collect each reader's state for this slot
+      for (const snapshot of snapshots) {
+        const slotState = snapshot.slots.find((s) => s.slotId === slotId) ?? null;
+        readerStates[snapshot.readerId] = slotState;
+      }
+
+      // Tally votes: group by (latestEventKind, latestTxHash)
+      const voteTally = new Map<string, { state: SlotEscrowState; count: number }>();
+      for (const state of Object.values(readerStates)) {
+        if (!state) continue;
+        const key = `${state.latestEventKind ?? "none"}:${state.latestTxHash ?? "none"}`;
+        const entry = voteTally.get(key);
+        if (entry) {
+          entry.count += 1;
+        } else {
+          voteTally.set(key, { state, count: 1 });
+        }
+      }
+
+      // Find the majority state
+      const sortedVotes = Array.from(voteTally.values()).sort((a, b) => b.count - a.count);
+      const topVote = sortedVotes[0];
+      const majorityRequired = Math.ceil(healthyCount * this.quorumThreshold);
+
+      let majorityState: SlotEscrowState | null = null;
+      let consensus = false;
+      let agreeingReaders = 0;
+      let disagreementExceededThreshold = false;
+
+      if (topVote && topVote.count >= majorityRequired) {
+        majorityState = topVote.state;
+        agreeingReaders = topVote.count;
+        consensus = topVote.count === healthyCount;
+      }
+
+      // Hung jury: no majority (takes precedence over disagreement)
+      if (!majorityState && healthyCount > 0) {
+        readerPoolEvents.emit("alert", {
+          type: "HUNG_JURY",
+          slotId,
+          readerStates,
+          message: `No quorum reached for slot ${slotId}: ${healthyCount} readers could not agree`,
+        } satisfies HungJuryEvent);
+        // When there's no majority, all readers effectively disagree
+        disagreementExceededThreshold = healthyCount > 0;
+      }
+
+      // Check disagreement threshold (only when a majority exists)
+      const disagreeingCount = healthyCount - agreeingReaders;
+      if (
+        majorityState &&
+        healthyCount > 0 &&
+        disagreeingCount / healthyCount > this.disagreementThreshold
+      ) {
+        disagreementExceededThreshold = true;
+
+        readerPoolEvents.emit("alert", {
+          type: "READER_DISAGREEMENT",
+          slotId,
+          readerIds: Object.entries(readerStates)
+            .filter(([, s]) => s && (
+              s.latestEventKind !== majorityState.latestEventKind ||
+              s.latestTxHash !== majorityState.latestTxHash))
+            .map(([id]) => id),
+          majorityState,
+          disagreeingCount,
+          totalReaders: healthyCount,
+          message: `Reader disagreement threshold exceeded for slot ${slotId}: ${disagreeingCount}/${healthyCount} readers disagree`,
+        } satisfies ReaderDisagreementEvent);
+      }
+
+      comparisons.push({
+        slotId,
+        consensus,
+        majorityState,
+        readerStates,
+        readerCount: healthyCount,
+        agreeingReaders,
+        disagreementExceededThreshold,
+      });
+    }
+
+    return comparisons;
+  }
+
+  private async withTimeout<T>(
+    promise: Promise<T>,
+    ms: number,
+    readerId: string,
+  ): Promise<T> {
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(`Reader '${readerId}' timed out after ${ms}ms`));
+      }, ms);
+    });
+
+    try {
+      const result = await Promise.race([promise, timeout]);
+      clearTimeout(timer!);
+      return result;
+    } catch (err) {
+      clearTimeout(timer!);
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
Closes #443

### Summary

Drift between escrow contract state (Stellar/Soroban chain) and local DB state can strand buyer funds. This PR builds an **Escrow Drift Reconciler** that periodically compares chain state against local DB state and resolves disputes via a **quorum of independent Horizon readers**.

When drift is detected, the reconciler:
1. Emits the `escrow_drift_detected` Prometheus metric per slot
2. Logs a `fatal`-level alert with full forensic details
3. Emits a `DRIFT_DETECTED` alarm event for downstream alerting
4. Exposes a manual override endpoint for admin remediation

---

### Files Changed (6 files, +1,787 lines)

| File | Status | Lines | Description |
|------|--------|-------|-------------|
| `src/services/escrowReader.ts` | New | 204 | `IEscrowReader` interface + `HorizonEscrowReader` implementation |
| `src/services/escrowReaderPool.ts` | New | 291 | Multi-reader pool with quorum voting, hung jury detection, disagreement threshold alarms |
| `src/services/escrowDriftReconciler.ts` | New | 405 | Reconciler with 4-level drift comparison, metrics, alarm events, manual override |
| `src/services/__tests__/escrowDriftReconciler.test.ts` | New | 696 | 29 tests covering all edge cases |
| `src/metrics.ts` | Modified | +48 | 4 new budgeted Prometheus metrics |
| `src/routes/admin.ts` | Modified | +143 | `POST /api/v1/admin/escrow/drift/override` endpoint |

---

### Vote Aggregation & Quorum Logic

- **Quorum**: >= `ceil(healthyReaders * threshold)` readers must agree. Default threshold: 0.5 (simple majority).
- **Hung jury**: When no state reaches the quorum threshold, a `HUNG_JURY` alarm fires.
- **Reader disagreement**: When a majority exists but the disagreeing fraction exceeds `disagreementThreshold` (default 0.25), a `READER_DISAGREEMENT` alarm fires.
- **Even-sized pool guard**: Constructor rejects even-sized pools (4, 6, 8) with threshold <= 0.5 to prevent split-vote false majorities.

---

### Drift Detection (4-Level Comparison)

The `compareStates()` method checks in priority order:

1. **Structural -- chain has, local has none**: Chain reports an event tx hash but the local DB has no events. The local DB missed a projection.
2. **Structural -- local has, chain has none**: Local DB has an event but the chain reports none. Possible chain reorg or fork.
3. **Tx hash mismatch**: Both have events but the hashes differ. The local DB projected a different (possibly forged or replayed) event.
4. **Intent status mismatch**: Same tx hash on both sides, but the projected intent status diverged.

---

### Edge Cases Covered (29 Tests)

- All readers agree -- consensus, no alarms
- 2/3 readers agree, 1 disagrees -- majority found, `READER_DISAGREEMENT` alarm
- 3 readers all disagree (Held, Released, Refunded) -- hung jury, `HUNG_JURY` alarm
- 1 reader down (transport failure) -- excluded from quorum, 2 healthy form consensus
- All 3 readers down -- healthy count = 0, no alarms
- Chain has events, DB has none -- structural drift detected
- DB has events, chain has none -- structural drift (possible reorg)
- Same tx hash, different intent status -- status mismatch drift
- Same status, different tx hash -- hash mismatch drift
- Hung jury + local DB present -- slot flagged as drifted
- `autoResolve: false` (default) -- drift detected but local state NOT changed
- Manual override via `manualOverride()` -- state updated, `MANUAL_OVERRIDE_APPLIED` event, drift gauge reset to 0
- Empty active slot list -- graceful no-op
- Local repo throws -- tick returns gracefully
- Multiple slots with mixed sync/drift -- correct per-slot accounting

---

### Admin Override Endpoint

```
POST /api/v1/admin/escrow/drift/override
Header: x-chronopay-admin-token: <token>
Body: {
  "slotId": "slot-xxxxxxxx",
  "targetStatus": "confirmed",
  "reason": "Quorum of 3/3 readers confirmed Held event at ledger 123456."
}
```

- **Auth**: `requireAdminToken` middleware
- **Validation**: slotId required, targetStatus must be `pending | confirmed | cancelled | expired`, reason 20-2000 chars
- **Audit**: Every override logged via `defaultAuditLogger.log()` to the JSONL audit trail

---

### Security

- **No auto-resolution**: `autoResolve` defaults to `false` -- never mutates state without explicit admin action
- **Admin token required** on the override endpoint
- **Forensic justification**: Overrides require >= 20 char reason (discourages casual use)
- **Max length guard**: Reason capped at 2000 chars (prevents abuse)
- **Full audit trail**: Every override writes a versioned `AuditEventV1` to the JSONL audit log

---

### CI

- **29/29 tests pass** (0 failures)
- **0 TypeScript errors** in new/modified files
- Note: `HorizonEscrowReader.fetchEvents()` is a stub -- production deployment must wire to Soroban RPC `getEvents`
