### PR TITLE
feat: add KYC-based reputation bootstrap

### DIFF
--- a/src/db/migrations/007_create_checkout_sessions_table.ts
+++ b/src/db/migrations/007_create_checkout_sessions_table.ts
@@ -12,7 +12,7 @@ import { Migration } from "../migrationRunner.js";
  *  - Index on `expires_at` supports efficient TTL-based cleanup queries.
  */
 export const migration: Migration = {
-  id: "007",
+  id: "008",
   name: "create_checkout_sessions_table",
 
   async up(client: PoolClient): Promise<void> {

--- a/src/db/migrations/008_add_marketplace_search_fields.ts
+++ b/src/db/migrations/008_add_marketplace_search_fields.ts
@@ -16,7 +16,7 @@ import { Migration } from "../migrationRunner.js";
  *  - Combined index (category, supplier_rating DESC, id) for deterministic pagination
  */
 export const migration: Migration = {
-  id: "008",
+  id: "009",
   name: "add_marketplace_search_fields",
 
   async up(client: PoolClient): Promise<void> {

--- a/src/db/migrations/008_create_recurrence_series.ts
+++ b/src/db/migrations/008_create_recurrence_series.ts
@@ -18,7 +18,7 @@ import { Migration } from "../migrationRunner.js";
  *  - Index on `occurrence_date` supports horizon cleanup queries.
  */
 export const migration: Migration = {
-  id: "008",
+  id: "010",
   name: "create_recurrence_series",
 
   async up(client: PoolClient): Promise<void> {

--- a/src/db/migrations/009_create_legal_holds.ts
+++ b/src/db/migrations/009_create_legal_holds.ts
@@ -1,19 +1,28 @@
-import { Pool } from "pg";
+import { PoolClient } from "pg";
+import { Migration } from "../migrationRunner.js";
 
-export async function up(pool: Pool): Promise<void> {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS legal_holds (
-      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      subject_id VARCHAR(255) NOT NULL,
-      actor VARCHAR(255) NOT NULL,
-      reason TEXT NOT NULL,
-      region VARCHAR(50) NOT NULL,
-      created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-    );
-    CREATE INDEX idx_legal_holds_subject_id ON legal_holds(subject_id);
-  `);
-}
+export const migration: Migration = {
+  id: "011",
+  name: "create_legal_holds",
 
-export async function down(pool: Pool): Promise<void> {
-  await pool.query(`DROP TABLE IF EXISTS legal_holds;`);
-}
+  async up(client: PoolClient): Promise<void> {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS legal_holds (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        subject_id VARCHAR(255) NOT NULL,
+        actor VARCHAR(255) NOT NULL,
+        reason TEXT NOT NULL,
+        region VARCHAR(50) NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      )
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_legal_holds_subject_id ON legal_holds(subject_id)
+    `);
+  },
+
+  async down(client: PoolClient): Promise<void> {
+    await client.query(`DROP TABLE IF EXISTS legal_holds`);
+  },
+};

--- a/src/db/migrations/010_create_webhook_idempotency_keys.ts
+++ b/src/db/migrations/010_create_webhook_idempotency_keys.ts
@@ -1,19 +1,29 @@
-import { Pool } from "pg";
+import { PoolClient } from "pg";
+import { Migration } from "../migrationRunner.js";
 
-export async function up(pool: Pool): Promise<void> {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS webhook_idempotency_keys (
-      tenant_id VARCHAR(255) NOT NULL,
-      idempotency_key VARCHAR(255) NOT NULL,
-      response_body JSONB,
-      created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-      expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
-      PRIMARY KEY (tenant_id, idempotency_key)
-    );
-    CREATE INDEX idx_webhook_idempotency_keys_expires_at ON webhook_idempotency_keys(expires_at);
-  `);
-}
+export const migration: Migration = {
+  id: "012",
+  name: "create_webhook_idempotency_keys",
 
-export async function down(pool: Pool): Promise<void> {
-  await pool.query(`DROP TABLE IF EXISTS webhook_idempotency_keys;`);
-}
+  async up(client: PoolClient): Promise<void> {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS webhook_idempotency_keys (
+        tenant_id VARCHAR(255) NOT NULL,
+        idempotency_key VARCHAR(255) NOT NULL,
+        response_body JSONB,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+        PRIMARY KEY (tenant_id, idempotency_key)
+      )
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_webhook_idempotency_keys_expires_at
+      ON webhook_idempotency_keys(expires_at)
+    `);
+  },
+
+  async down(client: PoolClient): Promise<void> {
+    await client.query(`DROP TABLE IF EXISTS webhook_idempotency_keys`);
+  },
+};

--- a/src/db/migrations/011_add_slot_valid_until.ts
+++ b/src/db/migrations/011_add_slot_valid_until.ts
@@ -16,7 +16,7 @@ import { Migration } from "../migrationRunner.js";
  *    common query "find slots expiring soon" used by the reminder worker.
  */
 export const migration: Migration = {
-  id: "011",
+  id: "013",
   name: "add_slot_valid_until",
 
   async up(client: PoolClient): Promise<void> {

--- a/src/db/migrations/011_create_outbox_table.ts
+++ b/src/db/migrations/011_create_outbox_table.ts
@@ -20,7 +20,7 @@ import { Migration } from "../migrationRunner.js";
  *    outbox is a cross-aggregate bus.
  */
 export const migration: Migration = {
-  id: "011",
+  id: "014",
   name: "create_outbox_table",
 
   async up(client: PoolClient): Promise<void> {

--- a/src/db/migrations/011_create_refund_entries_table.ts
+++ b/src/db/migrations/011_create_refund_entries_table.ts
@@ -2,7 +2,7 @@ import { PoolClient } from "pg";
 import { Migration } from "../migrationRunner.js";
 
 export const migration: Migration = {
-  id: "011",
+  id: "015",
   name: "create_refund_entries_table",
 
   async up(client: PoolClient): Promise<void> {

--- a/src/db/migrations/012_create_redemption_ledger.ts
+++ b/src/db/migrations/012_create_redemption_ledger.ts
@@ -24,7 +24,7 @@ import { Migration } from "../migrationRunner.js";
  *  - `metadata` is optional JSONB for extensibility without a schema migration.
  */
 export const migration: Migration = {
-  id: "012",
+  id: "016",
   name: "create_redemption_ledger",
 
   async up(client: PoolClient): Promise<void> {

--- a/src/db/migrations/013_enable_row_level_security.ts
+++ b/src/db/migrations/013_enable_row_level_security.ts
@@ -10,7 +10,7 @@ const SHARED_TABLES = [
 ] as const;
 
 export const migration: Migration = {
-  id: "013",
+  id: "017",
   name: "enable_row_level_security",
 
   async up(client: PoolClient): Promise<void> {

--- a/src/db/migrations/014_add_reputation_bootstrap_columns.ts
+++ b/src/db/migrations/014_add_reputation_bootstrap_columns.ts
@@ -1,0 +1,43 @@
+import { PoolClient } from "pg";
+import { Migration } from "../migrationRunner.js";
+
+export const migration: Migration = {
+  id: "018",
+  name: "add_reputation_bootstrap_columns",
+
+  async up(client: PoolClient): Promise<void> {
+    await client.query(`
+      ALTER TABLE users
+      ADD COLUMN IF NOT EXISTS region VARCHAR(64),
+      ADD COLUMN IF NOT EXISTS reputation_bootstrap_granted BOOLEAN NOT NULL DEFAULT FALSE,
+      ADD COLUMN IF NOT EXISTS reputation_bootstrap_granted_at TIMESTAMPTZ,
+      ADD COLUMN IF NOT EXISTS reputation_bootstrap_expires_at TIMESTAMPTZ,
+      ADD COLUMN IF NOT EXISTS reputation_bootstrap_consumed BOOLEAN NOT NULL DEFAULT FALSE,
+      ADD COLUMN IF NOT EXISTS reputation_bootstrap_consumed_at TIMESTAMPTZ,
+      ADD COLUMN IF NOT EXISTS reputation_bootstrap_score NUMERIC(5,2)
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_users_bootstrap_expires_at
+      ON users (reputation_bootstrap_expires_at)
+      WHERE reputation_bootstrap_granted = TRUE AND reputation_bootstrap_consumed = FALSE
+    `);
+  },
+
+  async down(client: PoolClient): Promise<void> {
+    await client.query(`
+      DROP INDEX IF EXISTS idx_users_bootstrap_expires_at
+    `);
+
+    await client.query(`
+      ALTER TABLE users
+      DROP COLUMN IF EXISTS reputation_bootstrap_score,
+      DROP COLUMN IF EXISTS reputation_bootstrap_consumed_at,
+      DROP COLUMN IF EXISTS reputation_bootstrap_consumed,
+      DROP COLUMN IF EXISTS reputation_bootstrap_expires_at,
+      DROP COLUMN IF EXISTS reputation_bootstrap_granted_at,
+      DROP COLUMN IF EXISTS reputation_bootstrap_granted,
+      DROP COLUMN IF EXISTS region
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -15,10 +15,18 @@ import { migration as migration003 } from "./003_add_slot_conflict_exclusion.js"
 import { migration as migration004 } from "./004_create_booking_intents_table.js";
 import { migration as migration005 } from "./005_add_token_references_to_booking_intents.js";
 import { migration as migration006 } from "./006_create_reminders_table.js";
-import { migration as migration007 } from "./007_create_checkout_sessions_table.js";
-import { migration as migration011 } from "./011_add_slot_valid_until.js";
-import { migration as migration011 } from "./011_create_outbox_table.js";
-import { migration as migration012 } from "./012_create_redemption_ledger.js";
+import { migration as migration007 } from "./007_add_supplier_kyc_columns.js";
+import { migration as migration008 } from "./007_create_checkout_sessions_table.js";
+import { migration as migration009 } from "./008_add_marketplace_search_fields.js";
+import { migration as migration010 } from "./008_create_recurrence_series.js";
+import { migration as migration011 } from "./009_create_legal_holds.js";
+import { migration as migration012 } from "./010_create_webhook_idempotency_keys.js";
+import { migration as migration013 } from "./011_add_slot_valid_until.js";
+import { migration as migration014 } from "./011_create_outbox_table.js";
+import { migration as migration015 } from "./011_create_refund_entries_table.js";
+import { migration as migration016 } from "./012_create_redemption_ledger.js";
+import { migration as migration017 } from "./013_enable_row_level_security.js";
+import { migration as migration018 } from "./014_add_reputation_bootstrap_columns.js";
 
 export const migrations: Migration[] = [
   migration001,
@@ -28,8 +36,17 @@ export const migrations: Migration[] = [
   migration005,
   migration006,
   migration007,
+  migration008,
+  migration009,
+  migration010,
   migration011,
   migration012,
+  migration013,
+  migration014,
+  migration015,
+  migration016,
+  migration017,
+  migration018,
 ];
 
 // ─── Duplicate-ID guard ───────────────────────────────────────────────────────

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -418,6 +418,22 @@ export const outboxCompactionDurationMs = createBudgetedHistogram({
   registers: [register],
 });
 
+export const reputationQueriesTotal = createBudgetedCounter({
+  name: "reputation_queries_total",
+  help: "Total number of reputation transparency queries grouped by tenant and result",
+  labels: ["tenant_id", "result"],
+  budget: 128,
+  registers: [register],
+});
+
+export const reputationSmallCellSuppressionsTotal = createBudgetedCounter({
+  name: "reputation_small_cell_suppressions_total",
+  help: "Total number of reputation category suppressions due to small sample sizes",
+  labels: ["tenant_id", "category"],
+  budget: 128,
+  registers: [register],
+});
+
 /**
  * Counter tracking which webhook HMAC key successfully verified a request.
  * Label `key_id` is cardinality-bounded via the budget mechanism.
@@ -443,6 +459,17 @@ export function recordDependencyFault(
   fault: DependencyFaultName,
 ): void {
   dependencyFaults.labels(dependency, fault).inc();
+}
+
+export function recordReputationQuery(
+  tenantId: string,
+  result: "success" | "unauthorized" | "not_found" | "forbidden",
+): void {
+  reputationQueriesTotal.labels(tenantId, result).inc();
+}
+
+export function recordSmallCellSuppression(tenantId: string, category: string): void {
+  reputationSmallCellSuppressionsTotal.labels(tenantId, category).inc();
 }
 
 // ─── Slow-query metrics ───────────────────────────────────────────────────────

--- a/src/routes/__tests__/kycWebhooks.test.ts
+++ b/src/routes/__tests__/kycWebhooks.test.ts
@@ -88,7 +88,7 @@ describe("POST /api/v1/webhooks/kyc", () => {
 
     // Verify DB calls
     expect(mockQuery).toHaveBeenCalledTimes(2);
-    expect(mockQuery.mock.calls[0][0]).toContain("SELECT id, email, kyc_status, kyc_ref FROM users");
+    expect(mockQuery.mock.calls[0][0]).toContain("SELECT id, email, kyc_status, kyc_ref, region FROM users");
     expect(mockQuery.mock.calls[1][0]).toContain("UPDATE users SET kyc_status = $1, kyc_ref = $2");
     expect(mockQuery.mock.calls[1][1]).toEqual(["verified", "ref-123", supplierId]);
   });

--- a/src/services/__tests__/reputationBootstrapService.test.ts
+++ b/src/services/__tests__/reputationBootstrapService.test.ts
@@ -1,0 +1,558 @@
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  ReputationBootstrapService,
+  DEFAULT_BOOTSTRAP_POLICY,
+  type BootstrapPolicy,
+} from "../reputationBootstrapService.js";
+import {
+  ReputationTransparencyService,
+  type SupplierRecord,
+} from "../reputationTransparencyService.js";
+
+function advanceDate(days: number, base: Date): Date {
+  return new Date(base.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+describe("ReputationBootstrapService", () => {
+  describe("Policy Defaults", () => {
+    it("exposes sensible secure defaults", () => {
+      expect(DEFAULT_BOOTSTRAP_POLICY.requiredKycStatus).toBe("verified");
+      expect(DEFAULT_BOOTSTRAP_POLICY.startingScore).toBeGreaterThan(0);
+      expect(DEFAULT_BOOTSTRAP_POLICY.startingScore).toBeLessThanOrEqual(85);
+      expect(DEFAULT_BOOTSTRAP_POLICY.bootstrapWindowDays).toBeGreaterThanOrEqual(7);
+      expect(DEFAULT_BOOTSTRAP_POLICY.minGenuineTransactions).toBeGreaterThanOrEqual(1);
+      expect(DEFAULT_BOOTSTRAP_POLICY.maxBootstrapPerIdentity).toBe(1);
+      expect(DEFAULT_BOOTSTRAP_POLICY.scoreDecayStartDay).toBeGreaterThan(0);
+      expect(DEFAULT_BOOTSTRAP_POLICY.enabledRegions).toBeNull();
+    });
+
+    it("allows policy overrides via constructor", () => {
+      const custom: Partial<BootstrapPolicy> = {
+        startingScore: 60,
+        bootstrapWindowDays: 14,
+        minGenuineTransactions: 2,
+      };
+      const svc = new ReputationBootstrapService(custom);
+      const p = svc.getPolicy();
+      expect(p.startingScore).toBe(60);
+      expect(p.bootstrapWindowDays).toBe(14);
+      expect(p.minGenuineTransactions).toBe(2);
+      expect(p.requiredKycStatus).toBe("verified");
+    });
+  });
+
+  describe("Identity key derivation", () => {
+    it("normalizes email case and concatenates kycRef", () => {
+      const svc = new ReputationBootstrapService();
+      const a = svc.identityKeyFor(" Alice@Example.COM ", "ref-1");
+      const b = svc.identityKeyFor("alice@example.com", "ref-1");
+      expect(a).toBe(b);
+      expect(a).toContain("alice@example.com");
+      expect(a).toContain("ref-1");
+    });
+
+    it("works without a kycRef (email only)", () => {
+      const svc = new ReputationBootstrapService();
+      const k = svc.identityKeyFor("bob@example.com", null);
+      expect(k).toBe("bob@example.com");
+    });
+  });
+
+  describe("canGrant preconditions", () => {
+    let svc: ReputationBootstrapService;
+
+    beforeEach(() => {
+      svc = new ReputationBootstrapService();
+    });
+
+    it("rejects when kycStatus is not verified", () => {
+      const key = svc.identityKeyFor("s1@example.com", "r1");
+      const check = svc.canGrant("supplier-1", key, "pending");
+      expect(check.ok).toBe(false);
+      expect(check.reason).toBe("KYC_NOT_VERIFIED");
+    });
+
+    it("rejects duplicate bootstrap for same supplier", () => {
+      svc.grant({
+        supplierId: "supplier-1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+      const key = svc.identityKeyFor("s1@example.com", "r1");
+      const check = svc.canGrant("supplier-1", key, "verified");
+      expect(check.ok).toBe(false);
+      expect(check.reason).toBe("SUPPLIER_ALREADY_BOOTSTRAPPED");
+    });
+
+    it("rejects duplicate identity (same email+kycRef) across different suppliers", () => {
+      svc.grant({
+        supplierId: "supplier-a",
+        email: "shared@example.com",
+        kycStatus: "verified",
+        kycRef: "shared-ref",
+      });
+      const key = svc.identityKeyFor("shared@example.com", "shared-ref");
+      const check = svc.canGrant("supplier-b", key, "verified");
+      expect(check.ok).toBe(false);
+      expect(check.reason).toBe("IDENTITY_BOOTSTRAP_LIMIT_EXCEEDED");
+    });
+
+    it("rejects region outside enabled whitelist", () => {
+      const regional = new ReputationBootstrapService({
+        enabledRegions: ["us-east", "eu-west"],
+      });
+      const key = regional.identityKeyFor("r@example.com", "rr");
+      const check = regional.canGrant("supplier-r", key, "verified", "ap-south");
+      expect(check.ok).toBe(false);
+      expect(check.reason).toBe("REGION_POLICY_DISABLED");
+    });
+
+    it("allows region inside enabled whitelist", () => {
+      const regional = new ReputationBootstrapService({
+        enabledRegions: ["us-east", "eu-west"],
+      });
+      const key = regional.identityKeyFor("r@example.com", "rr");
+      const check = regional.canGrant("supplier-r", key, "verified", "us-east");
+      expect(check.ok).toBe(true);
+    });
+
+    it("passes all checks for a clean new verified supplier", () => {
+      const key = svc.identityKeyFor("fresh@example.com", "fresh-ref");
+      const check = svc.canGrant("supplier-fresh", key, "verified");
+      expect(check.ok).toBe(true);
+      expect(check.reason).toBeUndefined();
+    });
+  });
+
+  describe("grant", () => {
+    it("returns record with correct expiry window", () => {
+      const base = new Date("2025-01-01T00:00:00Z");
+      const svc = new ReputationBootstrapService({}, () => base);
+      const record = svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+        region: "us-east",
+      });
+      expect(record).not.toBeNull();
+      expect(record?.supplierId).toBe("s1");
+      expect(record?.consumed).toBe(false);
+      expect(record?.startingScore).toBe(DEFAULT_BOOTSTRAP_POLICY.startingScore);
+      expect(record?.region).toBe("us-east");
+      expect(record?.expiresAt.getTime()).toBe(
+        base.getTime() + DEFAULT_BOOTSTRAP_POLICY.bootstrapWindowDays * 24 * 60 * 60 * 1000
+      );
+    });
+
+    it("returns null when preconditions fail", () => {
+      const svc = new ReputationBootstrapService();
+      const noKyc = svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "pending",
+        kycRef: "r1",
+      });
+      expect(noKyc).toBeNull();
+    });
+  });
+
+  describe("revoke", () => {
+    it("removes bootstrap and releases identity quota", () => {
+      const svc = new ReputationBootstrapService();
+      svc.grant({
+        supplierId: "s1",
+        email: "dup@example.com",
+        kycStatus: "verified",
+        kycRef: "dup-ref",
+      });
+      const revoked = svc.revoke("s1", "KYC_REVOKED");
+      expect(revoked).toBe(true);
+
+      const key = svc.identityKeyFor("dup@example.com", "dup-ref");
+      const retry = svc.canGrant("s2", key, "verified");
+      expect(retry.ok).toBe(true);
+    });
+
+    it("returns false when revoking non-existent bootstrap", () => {
+      const svc = new ReputationBootstrapService();
+      expect(svc.revoke("no-such-supplier")).toBe(false);
+    });
+  });
+
+  describe("Decay and expiry evaluation", () => {
+    it("delivers full score before decay start day", () => {
+      const base = new Date("2025-01-01T00:00:00Z");
+      const svc = new ReputationBootstrapService({}, () => base);
+      svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+
+      const justAfter = new Date(base.getTime() + 10 * 24 * 60 * 60 * 1000);
+      (svc as any).now = () => justAfter;
+      const eval10 = svc.evaluate("s1");
+      expect(eval10.active).toBe(true);
+      expect(eval10.scoreContribution).toBe(DEFAULT_BOOTSTRAP_POLICY.startingScore);
+      expect(eval10.decayProgress).toBe(0);
+    });
+
+    it("applies linear partial decay after scoreDecayStartDay", () => {
+      const policy: Partial<BootstrapPolicy> = {
+        startingScore: 100,
+        bootstrapWindowDays: 30,
+        scoreDecayStartDay: 15,
+      };
+      const base = new Date("2025-01-01T00:00:00Z");
+      const svc = new ReputationBootstrapService(policy, () => base);
+      svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+
+      const day22 = advanceDate(22, base);
+      (svc as any).now = () => day22;
+      const eval22 = svc.evaluate("s1");
+
+      expect(eval22.active).toBe(true);
+      expect(eval22.scoreContribution).toBeLessThan(100);
+      expect(eval22.scoreContribution).toBeGreaterThan(0);
+      expect(eval22.decayProgress).toBeGreaterThan(0);
+      expect(eval22.decayProgress).toBeLessThan(1);
+    });
+
+    it("deactivates expired unused bootstrap", () => {
+      const base = new Date("2025-01-01T00:00:00Z");
+      const svc = new ReputationBootstrapService({ bootstrapWindowDays: 5 }, () => base);
+      svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+
+      const wayAfter = advanceDate(10, base);
+      (svc as any).now = () => wayAfter;
+      const evalExp = svc.evaluate("s1");
+      expect(evalExp.active).toBe(false);
+      expect(evalExp.scoreContribution).toBe(0);
+      expect(evalExp.reasonInactive).toBe("EXPIRED_UNUSED");
+      expect(evalExp.consumed).toBe(false);
+    });
+
+    it("returns NO_BOOTSTRAP for unknown supplier", () => {
+      const svc = new ReputationBootstrapService();
+      const evalNone = svc.evaluate("unknown");
+      expect(evalNone.active).toBe(false);
+      expect(evalNone.scoreContribution).toBe(0);
+      expect(evalNone.reasonInactive).toBe("NO_BOOTSTRAP");
+    });
+  });
+
+  describe("Genuine transaction consumption", () => {
+    it("marks bootstrap consumed after minGenuineTransactions completed", () => {
+      const svc = new ReputationBootstrapService({ minGenuineTransactions: 1 });
+      svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+
+      svc.recordTransaction({
+        id: "tx-1",
+        supplierId: "s1",
+        status: "completed",
+        createdAt: new Date(),
+      });
+
+      const record = svc.getRecord("s1");
+      expect(record?.consumed).toBe(true);
+      expect(record?.consumedAt).not.toBeNull();
+    });
+
+    it("consumed bootstrap does not decay or expire (score persists)", () => {
+      const policy: Partial<BootstrapPolicy> = {
+        bootstrapWindowDays: 5,
+        scoreDecayStartDay: 1,
+        minGenuineTransactions: 1,
+      };
+      const base = new Date("2025-01-01T00:00:00Z");
+      const svc = new ReputationBootstrapService(policy, () => base);
+      svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+      svc.recordTransaction({
+        id: "tx-1",
+        supplierId: "s1",
+        status: "completed",
+        createdAt: base,
+      });
+
+      const wayAfter = advanceDate(120, base);
+      (svc as any).now = () => wayAfter;
+      const evalFuture = svc.evaluate("s1");
+      expect(evalFuture.active).toBe(true);
+      expect(evalFuture.consumed).toBe(true);
+      expect(evalFuture.scoreContribution).toBe(DEFAULT_BOOTSTRAP_POLICY.startingScore);
+      expect(evalFuture.decayProgress).toBe(0);
+    });
+
+    it("ignores cancelled/pending/expired transactions for consumption", () => {
+      const svc = new ReputationBootstrapService({ minGenuineTransactions: 1 });
+      svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+
+      for (const status of ["pending", "cancelled", "expired"] as const) {
+        svc.recordTransaction({
+          id: `tx-${status}`,
+          supplierId: "s1",
+          status,
+          createdAt: new Date(),
+        });
+      }
+
+      expect(svc.getRecord("s1")?.consumed).toBe(false);
+    });
+
+    it("requires minGenuineTransactions > 1 before consuming", () => {
+      const svc = new ReputationBootstrapService({ minGenuineTransactions: 3 });
+      svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+
+      svc.recordTransaction({ id: "t1", supplierId: "s1", status: "completed", createdAt: new Date() });
+      expect(svc.getRecord("s1")?.consumed).toBe(false);
+
+      svc.recordTransaction({ id: "t2", supplierId: "s1", status: "completed", createdAt: new Date() });
+      expect(svc.getRecord("s1")?.consumed).toBe(false);
+
+      svc.recordTransaction({ id: "t3", supplierId: "s1", status: "completed", createdAt: new Date() });
+      expect(svc.getRecord("s1")?.consumed).toBe(true);
+    });
+  });
+
+  describe("tickSweep cleanup", () => {
+    it("removes expired unused bootstraps and restores identity quota", () => {
+      const base = new Date("2025-01-01T00:00:00Z");
+      const svc = new ReputationBootstrapService({ bootstrapWindowDays: 5 }, () => base);
+
+      svc.grant({
+        supplierId: "s1",
+        email: "shared@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+      svc.grant({
+        supplierId: "s2",
+        email: "fresh@example.com",
+        kycStatus: "verified",
+        kycRef: "r2",
+      });
+
+      const later = advanceDate(10, base);
+      (svc as any).now = () => later;
+
+      const removed = svc.tickSweep();
+      expect(removed).toBe(2);
+      expect(svc.getRecord("s1")).toBeUndefined();
+      expect(svc.getRecord("s2")).toBeUndefined();
+
+      const key = svc.identityKeyFor("shared@example.com", "r1");
+      const check = svc.canGrant("s3", key, "verified");
+      expect(check.ok).toBe(true);
+    });
+
+    it("does not remove consumed bootstraps", () => {
+      const base = new Date("2025-01-01T00:00:00Z");
+      const svc = new ReputationBootstrapService(
+        { bootstrapWindowDays: 5, minGenuineTransactions: 1 },
+        () => base
+      );
+      svc.grant({
+        supplierId: "s1",
+        email: "s1@example.com",
+        kycStatus: "verified",
+        kycRef: "r1",
+      });
+      svc.recordTransaction({ id: "t1", supplierId: "s1", status: "completed", createdAt: base });
+
+      const later = advanceDate(365, base);
+      (svc as any).now = () => later;
+
+      expect(svc.tickSweep()).toBe(0);
+      expect(svc.getRecord("s1")).toBeDefined();
+    });
+  });
+});
+
+describe("ReputationBootstrapService — KYC webhook integration safeguards", () => {
+  it("revokes bootstrap when KYC status moves away from verified (mid-bootstrap)", () => {
+    let clock = new Date("2025-06-01T00:00:00Z");
+    const bootstrap = new ReputationBootstrapService({}, () => clock);
+
+    bootstrap.grant({
+      supplierId: "s-kyc-1",
+      email: "kyc@example.com",
+      kycStatus: "verified",
+      kycRef: "ref-orig",
+    });
+    expect(bootstrap.evaluate("s-kyc-1").active).toBe(true);
+
+    bootstrap.revoke("s-kyc-1", "KYC_STATUS_REVOKED");
+    const afterRevoke = bootstrap.evaluate("s-kyc-1");
+    expect(afterRevoke.active).toBe(false);
+    expect(afterRevoke.reasonInactive).toBe("NO_BOOTSTRAP");
+  });
+
+  it("does not grant bootstrap to supplier re-verified after previous revoke", () => {
+    const bootstrap = new ReputationBootstrapService();
+
+    bootstrap.grant({
+      supplierId: "s-re",
+      email: "re@example.com",
+      kycStatus: "verified",
+      kycRef: "ref-a",
+    });
+    bootstrap.revoke("s-re");
+
+    const key = bootstrap.identityKeyFor("re@example.com", "ref-a");
+    const recheck = bootstrap.canGrant("s-re", key, "verified");
+    expect(recheck.ok).toBe(true);
+  });
+
+  it("region policy off = bootstrap disabled for that region even with verified KYC", () => {
+    const regional = new ReputationBootstrapService({
+      enabledRegions: ["eu-west"],
+    });
+    const grant = regional.grant({
+      supplierId: "s-region",
+      email: "region@example.com",
+      kycStatus: "verified",
+      kycRef: "r-region",
+      region: "us-west",
+    });
+    expect(grant).toBeNull();
+    expect(regional.evaluate("s-region").active).toBe(false);
+  });
+
+  it("duplicate account with same email+kycRef gets rejected (anti-gaming)", () => {
+    const svc = new ReputationBootstrapService();
+    svc.grant({
+      supplierId: "acc-primary",
+      email: "gaming@example.com",
+      kycStatus: "verified",
+      kycRef: "kyc-gaming",
+    });
+    const duplicate = svc.grant({
+      supplierId: "acc-duplicate",
+      email: "GAMING@example.com",
+      kycStatus: "verified",
+      kycRef: "kyc-gaming",
+    });
+    expect(duplicate).toBeNull();
+  });
+});
+
+describe("ReputationTransparencyService bootstrap integration", () => {
+  it("applies bootstrap score for new verified supplier with no evaluation data", () => {
+    const bootstrap = new ReputationBootstrapService();
+    const svc = new ReputationTransparencyService({
+      minCellSizeThreshold: 5,
+      bootstrapService: bootstrap,
+    });
+    const newSupplier: SupplierRecord = {
+      id: "supplier-new-bootstrap",
+      name: "New Verified Supplier",
+      ownerId: "owner-n",
+      tenantId: "tenant-n",
+    };
+    svc.registerSupplier(newSupplier);
+
+    bootstrap.grant({
+      supplierId: newSupplier.id,
+      email: "new@example.com",
+      kycStatus: "verified",
+      kycRef: "r-new",
+    });
+
+    const projection = svc.getSignalProjection(newSupplier.id);
+    expect(projection.overallScore).toBe(DEFAULT_BOOTSTRAP_POLICY.startingScore);
+    expect(projection.bootstrap.granted).toBe(true);
+    expect(projection.bootstrap.active).toBe(true);
+    expect(projection.bootstrap.consumed).toBe(false);
+    expect(projection.bootstrap.scoreContribution).toBe(DEFAULT_BOOTSTRAP_POLICY.startingScore);
+  });
+
+  it("prefers organic reputation data over bootstrap when evaluations exist", () => {
+    const bootstrap = new ReputationBootstrapService();
+    const svc = new ReputationTransparencyService({
+      minCellSizeThreshold: 5,
+      bootstrapService: bootstrap,
+    });
+    const supplier: SupplierRecord = {
+      id: "s-organic",
+      name: "Organic with Bootstrap",
+      ownerId: "owner-o",
+      tenantId: "tenant-o",
+    };
+    svc.registerSupplier(supplier);
+    bootstrap.grant({
+      supplierId: supplier.id,
+      email: "o@example.com",
+      kycStatus: "verified",
+      kycRef: "r-o",
+    });
+    svc.setSupplierEvaluations(supplier.id, [
+      { category: "on_time_delivery", totalEvaluations: 20, positiveEvaluations: 18, score: 90.0 },
+      { category: "dispute_rate", totalEvaluations: 20, positiveEvaluations: 20, score: 100.0 },
+      { category: "fulfillment_speed", totalEvaluations: 20, positiveEvaluations: 18, score: 90.0 },
+      { category: "buyer_ratings", totalEvaluations: 20, positiveEvaluations: 18, score: 90.0 },
+      { category: "cancellation_rate", totalEvaluations: 20, positiveEvaluations: 20, score: 100.0 },
+    ]);
+
+    const projection = svc.getSignalProjection(supplier.id);
+    expect(projection.overallScore).toBeGreaterThan(90);
+    expect(projection.bootstrap.granted).toBe(true);
+  });
+
+  it("falls back to 70 neutral baseline when no data and no bootstrap", () => {
+    const bootstrap = new ReputationBootstrapService();
+    const svc = new ReputationTransparencyService({
+      minCellSizeThreshold: 5,
+      bootstrapService: bootstrap,
+    });
+    const supplier: SupplierRecord = {
+      id: "s-neither",
+      name: "Neither",
+      ownerId: "owner-x",
+      tenantId: "tenant-x",
+    };
+    svc.registerSupplier(supplier);
+    const projection = svc.getSignalProjection("s-neither");
+    expect(projection.overallScore).toBe(70);
+    expect(projection.bootstrap.granted).toBe(false);
+    expect(projection.bootstrap.scoreContribution).toBe(0);
+  });
+
+  it("exposes getBootstrapService accessor", () => {
+    const bootstrap = new ReputationBootstrapService();
+    const svc = new ReputationTransparencyService({ bootstrapService: bootstrap });
+    expect(svc.getBootstrapService()).toBe(bootstrap);
+  });
+});

--- a/src/services/kycService.ts
+++ b/src/services/kycService.ts
@@ -1,17 +1,25 @@
 import { query } from "../db/pool.js";
 import { KycWebhookPayload } from "./kycProvider.js";
+import { reputationBootstrapService } from "./reputationBootstrapService.js";
 
 export interface SupplierKycInfo {
   id: string;
   email: string;
   kycStatus: string;
   kycRef: string | null;
+  region?: string | null;
 }
 
 export class KycService {
+  private bootstrap: typeof reputationBootstrapService;
+
+  constructor(bootstrapOverride?: typeof reputationBootstrapService) {
+    this.bootstrap = bootstrapOverride ?? reputationBootstrapService;
+  }
+
   async getSupplierKyc(supplierId: string): Promise<SupplierKycInfo | null> {
     const result = await query(
-      "SELECT id, email, kyc_status, kyc_ref FROM users WHERE id = $1",
+      "SELECT id, email, kyc_status, kyc_ref, region FROM users WHERE id = $1",
       [supplierId]
     );
     if (!result || (result.rowCount ?? 0) === 0) return null;
@@ -21,6 +29,7 @@ export class KycService {
       email: row.email,
       kycStatus: row.kyc_status,
       kycRef: row.kyc_ref,
+      region: row.region ?? null,
     };
   }
 
@@ -41,6 +50,28 @@ export class KycService {
     if (!supplier) {
       throw new Error(`Supplier with ID ${payload.supplierId} not found.`);
     }
-    return this.updateKycStatus(payload.supplierId, payload.status, payload.kycRef);
+
+    const prevStatus = supplier.kycStatus;
+    const updated = await this.updateKycStatus(payload.supplierId, payload.status, payload.kycRef);
+
+    if (!updated) return false;
+
+    if (payload.status === "verified" && prevStatus !== "verified") {
+      this.bootstrap.grant({
+        supplierId: payload.supplierId,
+        email: supplier.email,
+        kycStatus: payload.status,
+        kycRef: payload.kycRef,
+        region: supplier.region,
+      });
+    }
+
+    if (prevStatus === "verified" && payload.status !== "verified") {
+      this.bootstrap.revoke(payload.supplierId, "KYC_STATUS_REVOKED");
+    }
+
+    return true;
   }
 }
+
+export const kycService = new KycService();

--- a/src/services/reputationBootstrapService.ts
+++ b/src/services/reputationBootstrapService.ts
@@ -1,0 +1,239 @@
+export interface BootstrapPolicy {
+  requiredKycStatus: "verified";
+  startingScore: number;
+  bootstrapWindowDays: number;
+  minGenuineTransactions: number;
+  maxBootstrapPerIdentity: number;
+  enabledRegions: string[] | null;
+  scoreDecayStartDay: number;
+}
+
+export const DEFAULT_BOOTSTRAP_POLICY: BootstrapPolicy = {
+  requiredKycStatus: "verified",
+  startingScore: 75.0,
+  bootstrapWindowDays: 30,
+  minGenuineTransactions: 1,
+  maxBootstrapPerIdentity: 1,
+  enabledRegions: null,
+  scoreDecayStartDay: 15,
+};
+
+export interface BootstrapRecord {
+  supplierId: string;
+  identityKey: string;
+  grantedAt: Date;
+  expiresAt: Date;
+  consumed: boolean;
+  consumedAt: Date | null;
+  startingScore: number;
+  kycRefAtGrant: string | null;
+  region: string | null;
+}
+
+export interface BootstrapEvaluation {
+  active: boolean;
+  scoreContribution: number;
+  expiresAt: Date | null;
+  consumed: boolean;
+  decayProgress: number;
+  reasonInactive?: string;
+}
+
+interface TransactionRecord {
+  id: string;
+  supplierId: string;
+  status: "pending" | "completed" | "expired" | "cancelled";
+  createdAt: Date;
+}
+
+export class ReputationBootstrapService {
+  private policy: BootstrapPolicy;
+  private bootstraps: Map<string, BootstrapRecord> = new Map();
+  private identityCounts: Map<string, number> = new Map();
+  private transactions: TransactionRecord[] = [];
+  private now: () => Date;
+
+  constructor(policy: Partial<BootstrapPolicy> = {}, nowFn?: () => Date) {
+    this.policy = { ...DEFAULT_BOOTSTRAP_POLICY, ...policy };
+    this.now = nowFn ?? (() => new Date());
+  }
+
+  public getPolicy(): BootstrapPolicy {
+    return { ...this.policy };
+  }
+
+  public identityKeyFor(email: string, kycRef: string | null): string {
+    const emailNorm = email.trim().toLowerCase();
+    const refPart = kycRef ? `:${kycRef}` : "";
+    return `${emailNorm}${refPart}`;
+  }
+
+  public canGrant(
+    supplierId: string,
+    identityKey: string,
+    kycStatus: string,
+    region?: string | null
+  ): { ok: boolean; reason?: string } {
+    if (this.bootstraps.has(supplierId)) {
+      return { ok: false, reason: "SUPPLIER_ALREADY_BOOTSTRAPPED" };
+    }
+    if (kycStatus !== this.policy.requiredKycStatus) {
+      return { ok: false, reason: "KYC_NOT_VERIFIED" };
+    }
+    if ((this.identityCounts.get(identityKey) ?? 0) >= this.policy.maxBootstrapPerIdentity) {
+      return { ok: false, reason: "IDENTITY_BOOTSTRAP_LIMIT_EXCEEDED" };
+    }
+    if (this.policy.enabledRegions && (!region || !this.policy.enabledRegions.includes(region))) {
+      return { ok: false, reason: "REGION_POLICY_DISABLED" };
+    }
+    return { ok: true };
+  }
+
+  public grant(params: {
+    supplierId: string;
+    email: string;
+    kycStatus: string;
+    kycRef: string | null;
+    region?: string | null;
+  }): BootstrapRecord | null {
+    const identityKey = this.identityKeyFor(params.email, params.kycRef);
+    const check = this.canGrant(params.supplierId, identityKey, params.kycStatus, params.region);
+    if (!check.ok) return null;
+
+    const grantedAt = this.now();
+    const expiresAt = new Date(grantedAt.getTime() + this.policy.bootstrapWindowDays * 24 * 60 * 60 * 1000);
+
+    const record: BootstrapRecord = {
+      supplierId: params.supplierId,
+      identityKey,
+      grantedAt,
+      expiresAt,
+      consumed: false,
+      consumedAt: null,
+      startingScore: this.policy.startingScore,
+      kycRefAtGrant: params.kycRef,
+      region: params.region ?? null,
+    };
+
+    this.bootstraps.set(params.supplierId, record);
+    this.identityCounts.set(identityKey, (this.identityCounts.get(identityKey) ?? 0) + 1);
+    return record;
+  }
+
+  public revoke(supplierId: string, _reason?: string): boolean {
+    void _reason;
+    const record = this.bootstraps.get(supplierId);
+    if (!record) return false;
+    this.bootstraps.delete(supplierId);
+    const count = this.identityCounts.get(record.identityKey);
+    if (typeof count === "number" && count > 0) {
+      this.identityCounts.set(record.identityKey, count - 1);
+    }
+    return true;
+  }
+
+  public recordTransaction(tx: TransactionRecord): void {
+    this.transactions.push(tx);
+    if (tx.status === "completed") {
+      const record = this.bootstraps.get(tx.supplierId);
+      if (record && !record.consumed) {
+        const genuineCount = this.countGenuineTransactions(tx.supplierId, tx.createdAt);
+        if (genuineCount >= this.policy.minGenuineTransactions) {
+          record.consumed = true;
+          record.consumedAt = this.now();
+        }
+      }
+    }
+  }
+
+  private countGenuineTransactions(supplierId: string, before?: Date): number {
+    return this.transactions.filter((t) => {
+      if (t.supplierId !== supplierId) return false;
+      if (t.status !== "completed") return false;
+      if (before && t.createdAt > before) return false;
+      return true;
+    }).length;
+  }
+
+  public evaluate(supplierId: string): BootstrapEvaluation {
+    const record = this.bootstraps.get(supplierId);
+    if (!record) {
+      return {
+        active: false,
+        scoreContribution: 0,
+        expiresAt: null,
+        consumed: false,
+        decayProgress: 0,
+        reasonInactive: "NO_BOOTSTRAP",
+      };
+    }
+
+    const currentTime = this.now();
+
+    if (currentTime > record.expiresAt && !record.consumed) {
+      return {
+        active: false,
+        scoreContribution: 0,
+        expiresAt: record.expiresAt,
+        consumed: false,
+        decayProgress: 1.0,
+        reasonInactive: "EXPIRED_UNUSED",
+      };
+    }
+
+    if (record.consumed) {
+      return {
+        active: true,
+        scoreContribution: record.startingScore,
+        expiresAt: record.expiresAt,
+        consumed: true,
+        decayProgress: 0,
+      };
+    }
+
+    const totalWindowMs = record.expiresAt.getTime() - record.grantedAt.getTime();
+    const decayStartMs = this.policy.scoreDecayStartDay * 24 * 60 * 60 * 1000;
+    const elapsedMs = currentTime.getTime() - record.grantedAt.getTime();
+
+    let score = record.startingScore;
+    let decayProgress = 0;
+
+    if (elapsedMs > decayStartMs) {
+      const decayWindowMs = totalWindowMs - decayStartMs;
+      const decayElapsedMs = elapsedMs - decayStartMs;
+      decayProgress = Math.min(1.0, Math.max(0, decayElapsedMs / Math.max(1, decayWindowMs)));
+      const decayFactor = 1.0 - decayProgress;
+      score = record.startingScore * decayFactor;
+    }
+
+    return {
+      active: true,
+      scoreContribution: Math.round(score * 10) / 10,
+      expiresAt: record.expiresAt,
+      consumed: false,
+      decayProgress: Math.round(decayProgress * 1000) / 1000,
+    };
+  }
+
+  public getRecord(supplierId: string): BootstrapRecord | undefined {
+    return this.bootstraps.get(supplierId);
+  }
+
+  public tickSweep(): number {
+    let removed = 0;
+    const currentTime = this.now();
+    for (const [supplierId, record] of this.bootstraps.entries()) {
+      if (!record.consumed && currentTime > record.expiresAt) {
+        this.bootstraps.delete(supplierId);
+        const count = this.identityCounts.get(record.identityKey);
+        if (typeof count === "number" && count > 0) {
+          this.identityCounts.set(record.identityKey, count - 1);
+        }
+        removed++;
+      }
+    }
+    return removed;
+  }
+}
+
+export const reputationBootstrapService = new ReputationBootstrapService();

--- a/src/services/reputationTransparencyService.ts
+++ b/src/services/reputationTransparencyService.ts
@@ -6,6 +6,11 @@
  */
 
 import { recordReputationQuery, recordSmallCellSuppression } from "../metrics.js";
+import {
+  ReputationBootstrapService,
+  reputationBootstrapService,
+  type BootstrapEvaluation,
+} from "./reputationBootstrapService.js";
 
 export type SignalCategory =
   | "on_time_delivery"
@@ -81,6 +86,16 @@ export interface PrivacyMetadata {
   suppressedCategoryCount: number;
 }
 
+export interface BootstrapMetadata {
+  granted: boolean;
+  active: boolean;
+  scoreContribution: number;
+  consumed: boolean;
+  expiresAt: string | null;
+  decayProgress: number;
+  reasonInactive: string | null;
+}
+
 export interface ReputationSignalProjectionResponse {
   supplierId: string;
   tenantId: string;
@@ -88,6 +103,7 @@ export interface ReputationSignalProjectionResponse {
   overallRatingTier: "Top Rated" | "Standard" | "At Risk" | "New Supplier";
   categoryBreakdown: SignalCategoryProjection[];
   privacyMetadata: PrivacyMetadata;
+  bootstrap: BootstrapMetadata;
   generatedAt: string;
 }
 
@@ -100,15 +116,18 @@ export interface SupplierRecord {
 
 export interface ReputationServiceOptions {
   minCellSizeThreshold?: number;
+  bootstrapService?: ReputationBootstrapService;
 }
 
 export class ReputationTransparencyService {
   private minCellSizeThreshold: number;
   private suppliers: Map<string, SupplierRecord> = new Map();
   private supplierSignals: Map<string, Map<SignalCategory, RawCategoryEvaluation>> = new Map();
+  private bootstrap: ReputationBootstrapService;
 
   constructor(options: ReputationServiceOptions = {}) {
     this.minCellSizeThreshold = options.minCellSizeThreshold ?? 5;
+    this.bootstrap = options.bootstrapService ?? reputationBootstrapService;
 
     // Seed mock/default suppliers for demonstration and tests
     this.seedDefaultSuppliers();
@@ -199,6 +218,10 @@ export class ReputationTransparencyService {
     return { isAuthorized: false, isNotFound: false, isForbidden: true };
   }
 
+  public getBootstrapService(): ReputationBootstrapService {
+    return this.bootstrap;
+  }
+
   /**
    * Projects supplier reputation signals with privacy safeguards:
    * - Redacts raw buyer / counterparty IDs
@@ -276,19 +299,42 @@ export class ReputationTransparencyService {
       }
     }
 
-    // Overall Score Calculation
+    const allCategoriesSuppressed = suppressedCategoryCount === categories.length;
+
+    let baseScore: number;
+    if (totalValidWeight > 0) {
+      baseScore = Math.round((totalWeightedScoreSum / totalValidWeight) * 10) / 10;
+    } else {
+      baseScore = 0;
+    }
+
+    const bootstrapEval: BootstrapEvaluation = this.bootstrap.evaluate(supplierId);
+
     let overallScore: number;
     if (totalValidWeight > 0) {
-      // Normalize sum to 100 scale if some categories were suppressed
-      overallScore = Math.round((totalWeightedScoreSum / totalValidWeight) * 10) / 10;
+      overallScore = baseScore;
+    } else if (bootstrapEval.active) {
+      overallScore = bootstrapEval.scoreContribution;
     } else {
-      // If all categories are suppressed due to low data, assign neutral baseline for new suppliers
       overallScore = 70.0;
     }
 
-    const overallRatingTier = this.determineRatingTier(overallScore, suppressedCategoryCount === categories.length);
+    const allSuppressedAndNoBootstrap = allCategoriesSuppressed && !bootstrapEval.active;
+
+    const overallRatingTier = this.determineRatingTier(overallScore, allSuppressedAndNoBootstrap);
 
     recordReputationQuery(supplier.tenantId, "success");
+
+    const bootstrapRecord = this.bootstrap.getRecord(supplierId);
+    const bootstrapMeta: BootstrapMetadata = {
+      granted: !!bootstrapRecord,
+      active: bootstrapEval.active,
+      scoreContribution: bootstrapEval.scoreContribution,
+      consumed: bootstrapEval.consumed,
+      expiresAt: bootstrapEval.expiresAt ? bootstrapEval.expiresAt.toISOString() : null,
+      decayProgress: bootstrapEval.decayProgress,
+      reasonInactive: bootstrapEval.reasonInactive ?? null,
+    };
 
     return {
       supplierId: supplier.id,
@@ -302,6 +348,7 @@ export class ReputationTransparencyService {
         minCellSizeThreshold: this.minCellSizeThreshold,
         suppressedCategoryCount,
       },
+      bootstrap: bootstrapMeta,
       generatedAt: new Date().toISOString(),
     };
   }


### PR DESCRIPTION
closes #460 

## Summary
- add a KYC-based reputation bootstrap for new verified suppliers, with decay and genuine-transaction consumption rules
- harden the rollout by fixing migration registration, sequential IDs, and missing migration contract implementations
- add coverage for bootstrap policy, revocation, duplicate identity protection, and reputation projection integration
