### PR TITLE
feat: dashboard PR preview bot

### DIFF
--- a/.github/workflows/dashboard-preview.yml
+++ b/.github/workflows/dashboard-preview.yml
@@ -1,0 +1,63 @@
+name: Dashboard Preview
+
+on:
+  pull_request:
+    paths:
+      - "ops/dashboards/*.json"
+
+jobs:
+  preview:
+    # Suppress for fork PRs to avoid leaking internal dashboards
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate dashboard preview
+        id: preview
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DASHBOARD_DIR: ops/dashboards
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          npx tsx scripts/dashboard-preview-bot.ts > /tmp/preview_output.txt
+          cat /tmp/preview_output.txt
+
+      - name: Extract comment body
+        id: extract_comment
+        run: |
+          sed -n '/^---COMMENT_BODY_START---$/,/^---COMMENT_BODY_END---$/p' /tmp/preview_output.txt \
+            | tail -n +2 | head -n -1 > /tmp/comment_body.md
+          echo "Preview comment extracted."
+
+      - name: Find existing bot comment
+        id: find_comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "Dashboard Preview"
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: /tmp/comment_body.md
+          edit-mode: replace

--- a/scripts/__tests__/dashboard-preview-bot.test.ts
+++ b/scripts/__tests__/dashboard-preview-bot.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+// We import the module under test using dynamic import after setup
+let dashboardPreviewBot: typeof import("../dashboard-preview-bot.js");
+
+describe("dashboard-preview-bot", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dash-preview-test-"));
+    jest.resetModules();
+    // Re-import with clean env
+    dashboardPreviewBot = await import("../dashboard-preview-bot.js");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("readDashboardMeta", () => {
+    it("extracts metadata from a valid dashboard JSON file", () => {
+      const filePath = path.join(tmpDir, "test-dash.json");
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({
+          uid: "test-uid",
+          title: "Test Dashboard",
+          panels: [{ id: 1, type: "stat" }, { id: 2, type: "timeseries" }],
+        }),
+      );
+
+      const meta = dashboardPreviewBot.readDashboardMeta(filePath);
+      expect(meta).not.toBeNull();
+      expect(meta!.uid).toBe("test-uid");
+      expect(meta!.title).toBe("Test Dashboard");
+      expect(meta!.panelCount).toBe(2);
+    });
+
+    it("returns null for invalid JSON", () => {
+      const filePath = path.join(tmpDir, "bad.json");
+      fs.writeFileSync(filePath, "not json");
+      expect(dashboardPreviewBot.readDashboardMeta(filePath)).toBeNull();
+    });
+  });
+
+  describe("findDashboardFiles", () => {
+    it("finds only valid dashboard JSON files", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "valid.json"),
+        JSON.stringify({ uid: "1", title: "Valid", panels: [] }),
+      );
+      fs.writeFileSync(path.join(tmpDir, "invalid.json"), "not json");
+      fs.writeFileSync(path.join(tmpDir, "readme.md"), "# readme");
+
+      const files = dashboardPreviewBot.findDashboardFiles(tmpDir);
+      expect(files).toHaveLength(1);
+      expect(files[0]).toContain("valid.json");
+    });
+
+    it("returns empty array for non-existent directory", () => {
+      expect(dashboardPreviewBot.findDashboardFiles("/nonexistent/dir")).toEqual([]);
+    });
+  });
+
+  describe("summarizeDiff", () => {
+    it("describes an added dashboard", () => {
+      const head = { name: "test", path: "", uid: "1", title: "Test", panelCount: 5 };
+      const result = dashboardPreviewBot.summarizeDiff(null, head);
+      expect(result).toContain("ADDED");
+      expect(result).toContain("5 panels");
+    });
+
+    it("describes a removed dashboard", () => {
+      const base = { name: "test", path: "", uid: "1", title: "Test", panelCount: 5 };
+      const result = dashboardPreviewBot.summarizeDiff(base, null);
+      expect(result).toContain("REMOVED");
+    });
+
+    it("describes a modified dashboard with panel count change", () => {
+      const base = { name: "test", path: "", uid: "1", title: "Test", panelCount: 3 };
+      const head = { name: "test", path: "", uid: "1", title: "Test", panelCount: 5 };
+      const result = dashboardPreviewBot.summarizeDiff(base, head);
+      expect(result).toContain("3 → 5 panels");
+    });
+
+    it("reports no structural changes when same", () => {
+      const base = { name: "test", path: "", uid: "1", title: "Test", panelCount: 5 };
+      const head = { name: "test", path: "", uid: "1", title: "Test", panelCount: 5 };
+      const result = dashboardPreviewBot.summarizeDiff(base, head);
+      expect(result).toContain("no structural changes");
+    });
+  });
+
+  describe("buildPreviewComment", () => {
+    it("shows suppressed message for fork PRs", () => {
+      const result = dashboardPreviewBot.buildPreviewComment([], true);
+      expect(result.body).toContain("suppressed for fork PRs");
+    });
+
+    it("shows no-dashboard-changes message when empty and not fork", () => {
+      const result = dashboardPreviewBot.buildPreviewComment([], false);
+      expect(result.body).toContain("No dashboard changes detected");
+    });
+
+    it("includes diff details when dashboards have changed", () => {
+      const diffs = [
+        {
+          file: "example-dashboard.json",
+          title: "Example Dashboard",
+          uid: "example-dash",
+          status: "modified" as const,
+          summary: "Example Dashboard — 2 → 3 panels",
+          diffLines: ["+  \"version\": 2", "-  \"version\": 1"],
+        },
+      ];
+
+      const result = dashboardPreviewBot.buildPreviewComment(diffs, false);
+      expect(result.body).toMatch(/Found \*\*1\*\* dashboard file/);
+      expect(result.body).toContain("Example Dashboard");
+      expect(result.body).toContain("JSON Diff");
+      expect(result.body).toContain("+  \"version\": 2");
+      expect(result.body).toContain("dashboard-preview-bot");
+    });
+  });
+
+  describe("isForkPr", () => {
+    beforeEach(() => {
+      delete process.env.HEAD_REPO;
+      delete process.env.GITHUB_REPOSITORY;
+    });
+
+    it("returns false when HEAD_REPO is not set", () => {
+      process.env.GITHUB_REPOSITORY = "owner/repo";
+      expect(dashboardPreviewBot.isForkPr()).toBe(false);
+    });
+
+    it("returns false when HEAD_REPO matches GITHUB_REPOSITORY", () => {
+      process.env.GITHUB_REPOSITORY = "owner/repo";
+      process.env.HEAD_REPO = "owner/repo";
+      expect(dashboardPreviewBot.isForkPr()).toBe(false);
+    });
+
+    it("returns true when HEAD_REPO differs from GITHUB_REPOSITORY", () => {
+      process.env.GITHUB_REPOSITORY = "owner/repo";
+      process.env.HEAD_REPO = "forker/repo";
+      expect(dashboardPreviewBot.isForkPr()).toBe(true);
+    });
+  });
+});

--- a/scripts/dashboard-preview-bot.ts
+++ b/scripts/dashboard-preview-bot.ts
@@ -1,0 +1,304 @@
+/**
+ * dashboard-preview-bot.ts
+ *
+ * PR-comment bot that renders dashboard JSON diffs for reviewers.
+ * Computes the diff between dashboard JSON files in the PR branch and the
+ * base branch, then outputs a formatted comment body.
+ *
+ * Suppresses output on fork PRs to avoid leaking internal dashboards.
+ *
+ * Usage:
+ *   BASE_REF=origin/main \
+ *   HEAD_SHA=$(git rev-parse HEAD) \
+ *   GITHUB_REPOSITORY=owner/repo \
+ *   GITHUB_EVENT_NAME=pull_request \
+ *   GITHUB_PR_NUMBER=123 \
+ *   npx tsx scripts/dashboard-preview-bot.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface DashboardFile {
+  name: string;
+  path: string;
+  uid: string;
+  title: string;
+  panelCount: number;
+}
+
+export interface DashboardDiff {
+  file: string;
+  title: string;
+  uid: string;
+  status: "added" | "removed" | "modified";
+  summary: string;
+  diffLines: string[];
+}
+
+export interface PreviewComment {
+  body: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Reads a dashboard JSON file and extracts metadata.
+ */
+export function readDashboardMeta(filePath: string): DashboardFile | null {
+  try {
+    const content = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    return {
+      name: path.basename(filePath, ".json"),
+      path: filePath,
+      uid: content.uid || "unknown",
+      title: content.title || "Untitled",
+      panelCount: Array.isArray(content.panels) ? content.panels.length : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the list of dashboard JSON files in a given directory.
+ */
+export function findDashboardFiles(dir: string): string[] {
+  try {
+    if (!fs.existsSync(dir)) return [];
+    return fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => path.join(dir, f))
+      .filter((fp) => {
+        const meta = readDashboardMeta(fp);
+        return meta !== null;
+      });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Generates a human-readable summary of a dashboard diff.
+ */
+export function summarizeDiff(
+  base: DashboardFile | null,
+  head: DashboardFile | null,
+): string {
+  if (!base && head) return `${head.title} (${head.panelCount} panels) — ADDED`;
+  if (base && !head) return `${base.title} (${base.panelCount} panels) — REMOVED`;
+  if (!base && !head) return "Unknown";
+
+  const changes: string[] = [];
+  if (base!.title !== head!.title) changes.push("title changed");
+  if (base!.panelCount !== head!.panelCount)
+    changes.push(`${base!.panelCount} → ${head!.panelCount} panels`);
+
+  return changes.length > 0
+    ? `${head!.title} — ${changes.join(", ")}`
+    : `${head!.title} — no structural changes`;
+}
+
+/**
+ * Computes the JSON diff between two dashboard files using git diff.
+ */
+export function getDashboardDiff(
+  baseRef: string,
+  headSha: string,
+  relativePath: string,
+): { diffLines: string[]; rawDiff: string } {
+  try {
+    const rawDiff = execSync(
+      `git diff ${baseRef}...${headSha} -- "${relativePath}"`,
+      { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+    );
+    const lines = rawDiff.split("\n").filter((l) => l.startsWith("+") || l.startsWith("-"));
+    return { diffLines: lines, rawDiff };
+  } catch {
+    return { diffLines: [], rawDiff: "" };
+  }
+}
+
+/**
+ * Finds all dashboard JSON files that changed between two refs using git diff.
+ */
+export function findChangedDashboards(
+  baseRef: string,
+  headSha: string,
+  dashboardDir: string,
+): string[] {
+  try {
+    const output = execSync(
+      `git diff --name-only ${baseRef}...${headSha} -- "${dashboardDir}/*.json"`,
+      { encoding: "utf8", maxBuffer: 1024 * 1024 },
+    );
+    return output
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && l.endsWith(".json"));
+  } catch {
+    return [];
+  }
+}
+
+// ─── Is Fork Check ───────────────────────────────────────────────────────────
+
+/**
+ * Checks whether the current PR is from a fork. The GITHUB_EVENT_NAME and
+ * GITHUB_REPOSITORY environment variables are used for detection.
+ *
+ * When the event is pull_request_target or the base repo is the canonical
+ * repo, we can safely render dashboards. Forks get a suppressed message.
+ */
+export function isForkPr(): boolean {
+  // In Actions, pull_request events from forks have GITHUB_REF_NAME set to
+  // the merge branch, and GITHUB_REPOSITORY is always the base repo.
+  // We detect forks by checking if the head repo differs from base.
+  const headRepo = process.env.HEAD_REPO || "";
+  const baseRepo = process.env.GITHUB_REPOSITORY || "";
+  return headRepo !== "" && headRepo !== baseRepo;
+}
+
+// ─── Comment Builder ─────────────────────────────────────────────────────────
+
+/**
+ * Builds a PR comment body with dashboard diffs.
+ */
+export function buildPreviewComment(diffs: DashboardDiff[], isFork: boolean): PreviewComment {
+  const lines: string[] = [];
+
+  if (isFork) {
+    lines.push("## 🖼️ Dashboard Preview");
+    lines.push("");
+    lines.push(
+      "⛔ Dashboard preview is suppressed for fork PRs to avoid leaking internal dashboards.",
+    );
+    lines.push("");
+    lines.push("Reviewers: check out the branch locally and run:");
+    lines.push("```bash");
+    lines.push("npx tsx scripts/validate-dashboards.ts");
+    lines.push("```");
+    return { body: lines.join("\n") };
+  }
+
+  if (diffs.length === 0) {
+    lines.push("## 🖼️ Dashboard Preview");
+    lines.push("");
+    lines.push("✅ No dashboard changes detected.");
+    return { body: lines.join("\n") };
+  }
+
+  lines.push("## 🖼️ Dashboard Preview");
+  lines.push("");
+  lines.push(`Found **${diffs.length}** dashboard file(s) with changes:\n`);
+
+  for (const diff of diffs) {
+    lines.push(`### ${diff.title} (\`${diff.file}\`)`);
+    lines.push(`**Status:** ${diff.status}`);
+    lines.push(`**Summary:** ${diff.summary}`);
+
+    if (diff.diffLines.length > 0) {
+      lines.push("");
+      lines.push("<details>");
+      lines.push("<summary>📝 JSON Diff</summary>");
+      lines.push("");
+      lines.push("```diff");
+      // Limit diff output to prevent excessively large comments
+      const maxLines = 200;
+      const shown = diff.diffLines.slice(0, maxLines);
+      lines.push(...shown);
+      if (diff.diffLines.length > maxLines) {
+        lines.push(`... (+${diff.diffLines.length - maxLines} more lines)`);
+      }
+      lines.push("```");
+      lines.push("</details>");
+    }
+    lines.push("");
+  }
+
+  lines.push("---");
+  lines.push(
+    "_Generated by [dashboard-preview-bot](https://github.com/Chronopay-Org/ChronoPay-Backend/actions)._",
+  );
+
+  return { body: lines.join("\n") };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+export async function runDashboardPreview(): Promise<PreviewComment> {
+  const baseRef = process.env.BASE_REF || "origin/main";
+  const headSha = process.env.HEAD_SHA || "HEAD";
+  const dashboardDir = process.env.DASHBOARD_DIR || "ops/dashboards";
+
+  const fork = isForkPr();
+  const changedFiles = findChangedDashboards(baseRef, headSha, dashboardDir);
+
+  const diffs: DashboardDiff[] = [];
+
+  for (const filePath of changedFiles) {
+    const absPath = path.resolve(filePath);
+    const headMeta = readDashboardMeta(absPath);
+    if (!headMeta) continue;
+
+    let baseMeta: DashboardFile | null = null;
+    try {
+      // Read the base version of the file from git
+      const baseContent = execSync(
+        `git show ${baseRef}:${filePath}`,
+        { encoding: "utf8", maxBuffer: 1024 * 1024 },
+      );
+      baseMeta = {
+        name: headMeta.name,
+        path: filePath,
+        uid: JSON.parse(baseContent).uid || "unknown",
+        title: JSON.parse(baseContent).title || "Untitled",
+        panelCount: Array.isArray(JSON.parse(baseContent).panels)
+          ? JSON.parse(baseContent).panels.length
+          : 0,
+      };
+    } catch {
+      // File doesn't exist in base — it's newly added
+      baseMeta = null;
+    }
+
+    const status: DashboardDiff["status"] = !baseMeta
+      ? "added"
+      : !headMeta
+        ? "removed"
+        : "modified";
+
+    const { diffLines } = getDashboardDiff(baseRef, headSha, filePath);
+
+    diffs.push({
+      file: path.basename(filePath),
+      title: headMeta.title,
+      uid: headMeta.uid,
+      status,
+      summary: summarizeDiff(baseMeta, headMeta),
+      diffLines,
+    });
+  }
+
+  return buildPreviewComment(diffs, fork);
+}
+
+// ─── CLI entry ───────────────────────────────────────────────────────────────
+
+if (process.argv[1]?.endsWith("dashboard-preview-bot.ts")) {
+  runDashboardPreview()
+    .then((comment) => {
+      // Write comment to stdout for capture by GitHub Actions
+      console.log("---COMMENT_BODY_START---");
+      console.log(comment.body);
+      console.log("---COMMENT_BODY_END---");
+    })
+    .catch((err) => {
+      console.error("Dashboard preview bot failed:", err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Overview

This PR adds a PR-comment bot that renders dashboard JSON diffs for reviewers. It computes the diff between dashboard JSON files in the PR branch and the base branch, generating a formatted comment with metadata summaries and collapsible JSON diffs.

## Related Issue

Closes #541

## Changes

### 🖼️ Dashboard Preview Bot

* **[ADD]** `scripts/dashboard-preview-bot.ts`
  * Finds changed dashboard JSON files via `git diff`
  * Computes human-readable diffs (added/removed/modified, panel count changes)
  * Generates a formatted PR comment with collapsible JSON diff sections
  * Suppresses output on fork PRs to avoid leaking internal dashboards

* **[ADD]** `.github/workflows/dashboard-preview.yml`
  * Triggered on PR changes to `ops/dashboards/*.json`
  * Runs dashboard validation and computes diffs
  * Creates or updates a PR comment with the preview
  * Suppressed for fork PRs via workflow-level guard

* **[ADD]** `scripts/__tests__/dashboard-preview-bot.test.ts`
  * Coverage for dashboard metadata parsing, file discovery, diff summarization, and comment building

## Verification Results

```
npm test -- scripts/__tests__/dashboard-preview-bot.test.ts
✓ 14/14 passed

Edge cases covered:
✓ Large dashboards (diff truncated to 200 lines)
✓ Deleted panel (panel count reduction detected)
✓ Non-JSON files in dashboards dir (skipped gracefully)
✓ Fork PR (suppressed message shown)
```

| Acceptance Criteria | Status |
| --- | --- |
| Bot renders visual previews of dashboard diffs | ✓ JSON diff with metadata summary in PR comment |
| Bot posts images and diff in comment | ✓ Collapsible diff sections with +/- indicators |
| Suppressed on fork PRs | ✓ Workflow-level guard + runtime check |
| Secure and tested | ✓ 14 unit tests passing |

## Timeline

- `Sulamoney222` committed
