### PR TITLE
feat: scheduled feature flag rollouts

### DIFF
--- a/docs/feature-flag-rollouts.md
+++ b/docs/feature-flag-rollouts.md
@@ -1,0 +1,146 @@
+# Scheduled Feature-Flag Rollouts (#570)
+
+Percentage-based, time-scheduled ramps for existing feature flags. A rollout
+schedule ramps a flag from 0% up to 100% of traffic through an ordered list
+of steps, each with its own activation time, scoped to a single
+**(flag, tenant, environment)** tuple. This layers on top of the existing
+boolean flag system in [`docs/feature-flags.md`](./feature-flags.md) — it
+does not replace it.
+
+## Model
+
+```
+RolloutSchedule {
+  id
+  flag              // one of FEATURE_FLAG_NAMES
+  tenantId          // a specific tenant id, or "*" (ALL_TENANTS) for every tenant
+  environment       // "development" | "test" | "production"
+  steps: [{ percentage, at }]   // percentage 1–100, at = ISO-8601 timestamp
+  status            // "pending" | "active" | "paused" | "rolled_back" | "completed"
+  currentStepIndex  // -1 until the first step fires
+  currentPercentage
+  history           // append-only log of created/advanced/paused/resumed/rolled_back
+}
+```
+
+Steps must be strictly increasing in both time and percentage — a schedule
+is a ramp, not an arbitrary sequence.
+
+Only one **in-flight** schedule (`pending`, `active`, or `paused`) may exist
+per `(flag, tenant, environment)` tuple at a time. A new one may be created
+once the previous has reached a terminal state (`completed` or
+`rolled_back`).
+
+## Evaluation
+
+The boolean flag is always the outer kill-switch:
+
+```
+isFeatureEnabledForTenant(flag, tenantId, bucketKey, environment?)
+  = isFeatureEnabled(flag) AND bucketOf(bucketKey) < rolloutPercentage(flag, tenantId, environment)
+```
+
+- If the boolean flag is disabled, the rollout percentage is irrelevant —
+  the request is always rejected. A ramp can never turn on a flag that is
+  off at the kill-switch level.
+- If no schedule governs the tuple, the rollout percentage defaults to
+  **100%** — a flag with no rollout schedule behaves exactly like the plain
+  boolean flag it always was. This keeps every existing `isFeatureEnabled`
+  call site unaffected.
+- A tenant-specific schedule takes priority over an `ALL_TENANTS` (`"*"`)
+  wildcard schedule for the same flag/environment.
+- `bucketKey` (e.g. a user id, session id, or tenant id) is hashed with a
+  32-bit FNV-1a hash into a bucket in `[0, 100)`. The same key always maps
+  to the same bucket, so a rollout is sticky per key across requests instead
+  of flapping.
+
+Access it via the request-scoped accessor:
+
+```ts
+req.flags!.isEnabledForTenant("CREATE_SLOT", tenantId, userId);
+```
+
+or the standalone functions in `src/flags/rolloutEvaluator.ts` for
+non-request contexts.
+
+## Scheduler
+
+`FlagRolloutScheduler` (`src/scheduler/flagRolloutScheduler.ts`) ticks once a
+minute by default (`FLAG_ROLLOUT_INTERVAL_MS`) and calls
+`RolloutScheduleRegistry.advanceDue(now)`, which advances every non-paused,
+non-terminal schedule to the **latest** step whose `at` has passed `now`.
+
+Disable the scheduler with `FLAG_ROLLOUT_SCHEDULER_DISABLED=true` (useful for
+one-off scripts and some test harnesses).
+
+### Missed steps / outage catch-up
+
+Advancing always jumps straight to the latest due step instead of replaying
+every intermediate one. If the scheduler process was down (or a schedule was
+paused) while two step times passed, the next `advanceDue` call (or a
+`resume`) applies the later step directly — it does not fire the
+intermediate percentage first. This is deliberate: an outage should not
+cause a burst of intermediate rollout percentages when the scheduler catches
+up.
+
+## Pause, resume, rollback
+
+- **Pause** (`POST /:id/pause`) freezes the schedule at its current
+  percentage. A paused schedule is skipped by every scheduler tick, even if
+  a step's time has since passed.
+- **Resume** (`POST /:id/resume`) un-pauses and immediately re-evaluates
+  "what step is due right now" — it does not wait for the next tick. If
+  steps became due while paused, resume jumps straight to the latest one
+  (same outage-catch-up behavior as the scheduler).
+- **Rollback** (`POST /:id/rollback`) reverts to an earlier step (defaults
+  to one step back; pass `toStepIndex` to jump back across multiple steps
+  at once, or `-1` to revert fully to 0%). Rollback is **terminal** — the
+  scheduler will never advance a rolled-back schedule again. An operator
+  must create a fresh schedule to resume ramping. This is intentional: an
+  incident-triggered rollback should never silently resume ramping up on
+  its own.
+
+## Admin API
+
+All routes are mounted at `/api/v1/admin/flag-rollouts` and require the
+`x-chronopay-admin-token` header (same gate as `/api/v1/admin/fraud-models`,
+see `src/middleware/authorization.ts`). Mutating actions take an explicit
+`actor` field in the request body rather than deriving an actor identity
+from the admin token itself, so the shared admin secret is never recorded as
+an actor in audit logs or schedule history.
+
+| Method | Path | Body | Notes |
+| --- | --- | --- | --- |
+| `POST` | `/` | `{ flag, tenantId, environment, steps, actor }` | Create a schedule. `409 SCHEDULE_IN_FLIGHT` if one is already in-flight for the tuple. |
+| `GET` | `/` | — | List schedules; optional `?flag=&tenantId=&environment=&status=` filters. |
+| `GET` | `/:id` | — | Fetch one schedule, including its full history. |
+| `POST` | `/:id/pause` | `{ actor, reason? }` | Freeze at the current percentage. |
+| `POST` | `/:id/resume` | `{ actor }` | Un-pause and catch up to now. |
+| `POST` | `/:id/rollback` | `{ actor, reason, toStepIndex? }` | Revert to an earlier step; terminal. |
+
+Every mutating action fires an audit event (`FLAG_ROLLOUT_CREATED`,
+`FLAG_ROLLOUT_PAUSED`, `FLAG_ROLLOUT_RESUMED`, `FLAG_ROLLOUT_ROLLED_BACK`)
+via `defaultAuditLogger`, fire-and-forget so a logging failure never blocks
+the response.
+
+### Error codes
+
+| Code | Status | Meaning |
+| --- | --- | --- |
+| `UNKNOWN_FLAG`, `UNKNOWN_ENVIRONMENT`, `MISSING_TENANT`, `MISSING_ACTOR`, `MISSING_REASON`, `EMPTY_STEPS`, `TOO_MANY_STEPS`, `INVALID_PERCENTAGE`, `INVALID_TIMESTAMP`, `STEPS_NOT_CHRONOLOGICAL`, `STEPS_NOT_INCREASING`, `INVALID_ROLLBACK_TARGET`, `NOTHING_TO_ROLLBACK` | 400 | Request validation failure. |
+| `NOT_FOUND` | 404 | Unknown schedule id. |
+| `SCHEDULE_IN_FLIGHT`, `ALREADY_PAUSED`, `ALREADY_ROLLED_BACK`, `INVALID_STATE_TRANSITION` | 409 | Conflicts with the schedule's current state. |
+
+## Security notes
+
+- Every admin route is behind the same shared-secret admin token gate used
+  by the fraud-model rollback endpoints; there is no unauthenticated read or
+  write access to rollout schedules.
+- The boolean flag remains the fail-closed kill-switch; a rollout schedule
+  can only narrow traffic further, never widen it past what the boolean flag
+  already allows.
+- Rollback is terminal by design, so an automated ramp can never silently
+  resume after an incident-triggered rollback.
+- Percentage bucketing is a deterministic hash, not `Math.random()` — the
+  same bucket key always gets the same decision, so a rollout cannot be
+  bypassed by retrying a request.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -25,3 +25,12 @@ Malformed values fail startup with a clear validation error.
 - Missing environment variables fall back to registry defaults.
 - Unknown feature flag lookups are treated as server misconfiguration and rejected.
 
+## Scheduled Percentage Rollouts
+
+Any flag in the registry above can additionally be ramped up gradually,
+per-tenant and per-environment, via a scheduled percentage rollout — see
+[`docs/feature-flag-rollouts.md`](./feature-flag-rollouts.md). The boolean
+flag documented here always remains the outer kill-switch: a rollout
+schedule can only narrow an *enabled* flag down to a percentage of traffic,
+never enable a flag that is disabled above.
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,6 +57,7 @@ import { registerWebhookRoutes } from "./routes/webhooks.js";
 import webhookRoutes from "./routes/webhooks.js";
 import { impersonationRecorder } from "./middleware/impersonationRecorder.js";
 import fraudModelsRouter from "./routes/fraudModels.js";
+import flagRolloutsRouter from "./routes/flagRollouts.js";
 import redactionPolicyRouter from "./routes/redactionPolicy.js";
 import { gdprExportRouter } from "./routes/gdprExport.js";
 import reputationRouter from "./routes/reputation.js";
@@ -514,6 +515,9 @@ export function createApp(options: AppFactoryOptions = {}) {
 
   // 3b-i. Fraud model admin routes (#455 rollback hotkey)
   app.use("/api/v1/admin/fraud-models", fraudModelsRouter);
+
+  // 3b-i-a. Scheduled feature-flag rollout admin routes (#570)
+  app.use("/api/v1/admin/flag-rollouts", flagRolloutsRouter);
 
   // 3b-ii. Reputation write-audit history (#457)
   app.get(

--- a/src/flags/__tests__/featureFlags.test.ts
+++ b/src/flags/__tests__/featureFlags.test.ts
@@ -294,6 +294,51 @@ describe("requireFeatureFlag", () => {
   });
 });
 
+describe("featureFlagContextMiddleware isEnabledForTenant (#570)", () => {
+  beforeEach(async () => {
+    const { setFeatureFlagsFromEnv } = await import("../service.js");
+    setFeatureFlagsFromEnv({});
+    const { resetRolloutScheduleRegistry } = await import("../rolloutScheduleRegistry.js");
+    resetRolloutScheduleRegistry();
+  });
+
+  it("attaches isEnabledForTenant and it matches the plain flag when no schedule exists", async () => {
+    const { featureFlagContextMiddleware } = await import("../../middleware/featureFlags.js");
+    const req = {} as Request;
+    const res = {} as Response;
+    const next = jest.fn() as NextFunction;
+
+    featureFlagContextMiddleware(req, res, next);
+
+    expect(req.flags!.isEnabledForTenant("CREATE_SLOT", "tenant-a", "user-1", "production")).toBe(true);
+    expect(req.flags!.isEnabledForTenant("CREATE_BOOKING_INTENT", "tenant-a", "user-1", "production")).toBe(false);
+  });
+
+  it("narrows to a scheduled rollout percentage for the tenant", async () => {
+    const { featureFlagContextMiddleware } = await import("../../middleware/featureFlags.js");
+    const { getRolloutScheduleRegistry } = await import("../rolloutScheduleRegistry.js");
+    const { hashToBucket } = await import("../rolloutEvaluator.js");
+
+    getRolloutScheduleRegistry().create({
+      flag: "CREATE_SLOT",
+      tenantId: "tenant-a",
+      environment: "production",
+      actor: "alice",
+      steps: [{ percentage: 50, at: "2026-01-01T00:00:00.000Z" }],
+    });
+    getRolloutScheduleRegistry().advanceDue(new Date("2026-01-01T00:00:00.000Z"));
+
+    const req = {} as Request;
+    const res = {} as Response;
+    const next = jest.fn() as NextFunction;
+    featureFlagContextMiddleware(req, res, next);
+
+    const key = "user-42";
+    const expected = hashToBucket(key) < 50;
+    expect(req.flags!.isEnabledForTenant("CREATE_SLOT", "tenant-a", key, "production")).toBe(expected);
+  });
+});
+
 describe("initializeFeatureFlagsFromEnv", () => {
   it("reinitializes flags from process.env", async () => {
     process.env.FF_CREATE_SLOT = "false";

--- a/src/flags/__tests__/rolloutEvaluator.test.ts
+++ b/src/flags/__tests__/rolloutEvaluator.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import {
+  currentRolloutEnvironment,
+  getRolloutPercentage,
+  hashToBucket,
+  isBucketedIn,
+  isFeatureEnabledForTenant,
+} from "../rolloutEvaluator.js";
+import {
+  getRolloutScheduleRegistry,
+  resetRolloutScheduleRegistry,
+} from "../rolloutScheduleRegistry.js";
+import { setFeatureFlagsFromEnv } from "../service.js";
+
+describe("hashToBucket", () => {
+  it("is deterministic for the same input", () => {
+    expect(hashToBucket("tenant-a")).toBe(hashToBucket("tenant-a"));
+  });
+
+  it("always returns a value in [0, 100)", () => {
+    for (const key of ["a", "b", "user-123", "", "tenant-🚀", "x".repeat(500)]) {
+      const bucket = hashToBucket(key);
+      expect(bucket).toBeGreaterThanOrEqual(0);
+      expect(bucket).toBeLessThan(100);
+      expect(Number.isInteger(bucket)).toBe(true);
+    }
+  });
+
+  it("distributes distinct keys across many buckets (not a constant)", () => {
+    const buckets = new Set(Array.from({ length: 500 }, (_, i) => hashToBucket(`key-${i}`)));
+    expect(buckets.size).toBeGreaterThan(20);
+  });
+});
+
+describe("isBucketedIn", () => {
+  it("is always false at 0% and always true at 100%, regardless of hash", () => {
+    for (const key of ["a", "b", "c", "d", "e"]) {
+      expect(isBucketedIn(key, 0)).toBe(false);
+      expect(isBucketedIn(key, 100)).toBe(true);
+    }
+  });
+
+  it("agrees with the raw bucket/percentage comparison", () => {
+    const key = "tenant-a:user-42";
+    const bucket = hashToBucket(key);
+    expect(isBucketedIn(key, bucket)).toBe(false); // strictly less-than at the boundary
+    expect(isBucketedIn(key, bucket + 1)).toBe(true);
+  });
+
+  it("clamps out-of-range percentages safely", () => {
+    expect(isBucketedIn("k", -5)).toBe(false);
+    expect(isBucketedIn("k", 250)).toBe(true);
+  });
+});
+
+describe("currentRolloutEnvironment", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("reads a valid NODE_ENV", () => {
+    process.env.NODE_ENV = "production";
+    expect(currentRolloutEnvironment()).toBe("production");
+  });
+
+  it("falls back to development for an unrecognized or missing NODE_ENV", () => {
+    process.env.NODE_ENV = "staging";
+    expect(currentRolloutEnvironment()).toBe("development");
+    delete process.env.NODE_ENV;
+    expect(currentRolloutEnvironment()).toBe("development");
+  });
+});
+
+describe("getRolloutPercentage / isFeatureEnabledForTenant", () => {
+  beforeEach(() => {
+    resetRolloutScheduleRegistry();
+    setFeatureFlagsFromEnv({});
+  });
+
+  afterEach(() => {
+    resetRolloutScheduleRegistry();
+  });
+
+  it("returns 100 (unrestricted) when no schedule governs the tuple", () => {
+    expect(getRolloutPercentage("CREATE_SLOT", "tenant-a", "production")).toBe(100);
+  });
+
+  it("returns the schedule's current percentage once one governs the tuple", () => {
+    const registry = getRolloutScheduleRegistry();
+    registry.create({
+      flag: "CREATE_SLOT",
+      tenantId: "tenant-a",
+      environment: "production",
+      actor: "alice",
+      steps: [{ percentage: 25, at: "2026-01-01T00:00:00.000Z" }],
+    });
+    registry.advanceDue(new Date("2026-01-01T00:00:00.000Z"));
+
+    expect(getRolloutPercentage("CREATE_SLOT", "tenant-a", "production")).toBe(25);
+  });
+
+  it("the base boolean flag is a kill-switch that overrides any rollout percentage", () => {
+    // CREATE_SLOT defaults to enabled; force it off.
+    setFeatureFlagsFromEnv({ FF_CREATE_SLOT: "false" });
+
+    const registry = getRolloutScheduleRegistry();
+    registry.create({
+      flag: "CREATE_SLOT",
+      tenantId: "tenant-a",
+      environment: "production",
+      actor: "alice",
+      steps: [{ percentage: 100, at: "2026-01-01T00:00:00.000Z" }],
+    });
+    registry.advanceDue(new Date("2026-01-01T00:00:00.000Z"));
+
+    // Even at 100% rollout, a disabled base flag always evaluates to false.
+    expect(isFeatureEnabledForTenant("CREATE_SLOT", "tenant-a", "any-bucket-key", "production")).toBe(false);
+  });
+
+  it("with no schedule, an enabled flag behaves exactly like the plain boolean flag (100%)", () => {
+    expect(isFeatureEnabledForTenant("CREATE_SLOT", "tenant-a", "any-bucket-key", "production")).toBe(true);
+  });
+
+  it("defaults the environment argument to currentRolloutEnvironment() when omitted", () => {
+    // Under Jest, NODE_ENV is "test", which currentRolloutEnvironment() recognizes.
+    expect(getRolloutPercentage("CREATE_SLOT", "tenant-a")).toBe(100);
+    expect(isFeatureEnabledForTenant("CREATE_SLOT", "tenant-a", "any-bucket-key")).toBe(true);
+  });
+
+  it("gates a request by bucket key once a partial rollout is active", () => {
+    const registry = getRolloutScheduleRegistry();
+    registry.create({
+      flag: "CREATE_SLOT",
+      tenantId: "tenant-a",
+      environment: "production",
+      actor: "alice",
+      steps: [{ percentage: 50, at: "2026-01-01T00:00:00.000Z" }],
+    });
+    registry.advanceDue(new Date("2026-01-01T00:00:00.000Z"));
+
+    // Deterministic: same bucket key always yields the same decision.
+    const key = "user-777";
+    const first = isFeatureEnabledForTenant("CREATE_SLOT", "tenant-a", key, "production");
+    const second = isFeatureEnabledForTenant("CREATE_SLOT", "tenant-a", key, "production");
+    expect(first).toBe(second);
+    expect(first).toBe(hashToBucket(key) < 50);
+  });
+});

--- a/src/flags/__tests__/rolloutScheduleRegistry.test.ts
+++ b/src/flags/__tests__/rolloutScheduleRegistry.test.ts
@@ -1,0 +1,531 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import {
+  RolloutScheduleRegistry,
+  getRolloutScheduleRegistry,
+  resetRolloutScheduleRegistry,
+} from "../rolloutScheduleRegistry.js";
+import {
+  RolloutScheduleError,
+  ALL_TENANTS,
+  type CreateRolloutScheduleInput,
+  type RolloutStep,
+} from "../rolloutTypes.js";
+
+const T0 = "2026-01-01T00:00:00.000Z";
+const T1 = "2026-01-02T00:00:00.000Z";
+const T2 = "2026-01-03T00:00:00.000Z";
+const T3 = "2026-01-04T00:00:00.000Z";
+
+function baseInput(overrides: Partial<CreateRolloutScheduleInput> = {}): CreateRolloutScheduleInput {
+  return {
+    flag: "CREATE_SLOT",
+    tenantId: "tenant-a",
+    environment: "production",
+    actor: "alice",
+    steps: [
+      { percentage: 10, at: T0 },
+      { percentage: 50, at: T1 },
+      { percentage: 100, at: T2 },
+    ],
+    ...overrides,
+  };
+}
+
+function expectCode(fn: () => unknown, code: string): void {
+  try {
+    fn();
+    throw new Error("expected function to throw");
+  } catch (err) {
+    expect(err).toBeInstanceOf(RolloutScheduleError);
+    expect((err as RolloutScheduleError).code).toBe(code);
+  }
+}
+
+describe("RolloutScheduleRegistry", () => {
+  let registry: RolloutScheduleRegistry;
+
+  beforeEach(() => {
+    registry = new RolloutScheduleRegistry();
+  });
+
+  // ─── create() validation ────────────────────────────────────────────────
+
+  describe("create", () => {
+    it("creates a pending schedule at 0%", () => {
+      const schedule = registry.create(baseInput());
+
+      expect(schedule.status).toBe("pending");
+      expect(schedule.currentStepIndex).toBe(-1);
+      expect(schedule.currentPercentage).toBe(0);
+      expect(schedule.steps).toHaveLength(3);
+      expect(schedule.history).toHaveLength(1);
+      expect(schedule.history[0]).toMatchObject({ action: "created", percentage: 0, actor: "alice" });
+    });
+
+    it("rejects an unknown flag", () => {
+      expectCode(() => registry.create(baseInput({ flag: "NOT_A_FLAG" as any })), "UNKNOWN_FLAG");
+    });
+
+    it("rejects an unknown environment", () => {
+      expectCode(() => registry.create(baseInput({ environment: "staging" as any })), "UNKNOWN_ENVIRONMENT");
+    });
+
+    it("rejects a missing tenantId", () => {
+      expectCode(() => registry.create(baseInput({ tenantId: "  " })), "MISSING_TENANT");
+    });
+
+    it("rejects a missing actor", () => {
+      expectCode(() => registry.create(baseInput({ actor: "" })), "MISSING_ACTOR");
+    });
+
+    it("rejects an empty steps array", () => {
+      expectCode(() => registry.create(baseInput({ steps: [] })), "EMPTY_STEPS");
+    });
+
+    it("rejects more than 50 steps", () => {
+      const steps: RolloutStep[] = Array.from({ length: 51 }, (_, i) => ({
+        percentage: i + 1,
+        at: new Date(Date.parse(T0) + i * 1000).toISOString(),
+      }));
+      expectCode(() => registry.create(baseInput({ steps })), "TOO_MANY_STEPS");
+    });
+
+    it("rejects a non-integer or out-of-range percentage", () => {
+      expectCode(
+        () => registry.create(baseInput({ steps: [{ percentage: 0, at: T0 }] })),
+        "INVALID_PERCENTAGE",
+      );
+      expectCode(
+        () => registry.create(baseInput({ steps: [{ percentage: 101, at: T0 }] })),
+        "INVALID_PERCENTAGE",
+      );
+      expectCode(
+        () => registry.create(baseInput({ steps: [{ percentage: 12.5, at: T0 }] })),
+        "INVALID_PERCENTAGE",
+      );
+    });
+
+    it("rejects an invalid ISO timestamp", () => {
+      expectCode(
+        () => registry.create(baseInput({ steps: [{ percentage: 10, at: "not-a-date" }] })),
+        "INVALID_TIMESTAMP",
+      );
+    });
+
+    it("rejects steps that are not strictly chronological", () => {
+      expectCode(
+        () =>
+          registry.create(
+            baseInput({
+              steps: [
+                { percentage: 10, at: T1 },
+                { percentage: 50, at: T1 },
+              ],
+            }),
+          ),
+        "STEPS_NOT_CHRONOLOGICAL",
+      );
+      expectCode(
+        () =>
+          registry.create(
+            baseInput({
+              steps: [
+                { percentage: 10, at: T1 },
+                { percentage: 50, at: T0 },
+              ],
+            }),
+          ),
+        "STEPS_NOT_CHRONOLOGICAL",
+      );
+    });
+
+    it("rejects steps whose percentage does not strictly increase", () => {
+      expectCode(
+        () =>
+          registry.create(
+            baseInput({
+              steps: [
+                { percentage: 50, at: T0 },
+                { percentage: 50, at: T1 },
+              ],
+            }),
+          ),
+        "STEPS_NOT_INCREASING",
+      );
+      expectCode(
+        () =>
+          registry.create(
+            baseInput({
+              steps: [
+                { percentage: 50, at: T0 },
+                { percentage: 10, at: T1 },
+              ],
+            }),
+          ),
+        "STEPS_NOT_INCREASING",
+      );
+    });
+
+    it("rejects a duplicate in-flight schedule for the same flag/tenant/environment", () => {
+      registry.create(baseInput());
+      expectCode(() => registry.create(baseInput()), "SCHEDULE_IN_FLIGHT");
+    });
+
+    it("allows a new schedule once the previous one is rolled back", () => {
+      const first = registry.create(baseInput());
+      registry.advanceDue(new Date(T0));
+      registry.rollback({ id: first.id, actor: "alice", reason: "bad ramp, rolling back" });
+
+      const second = registry.create(baseInput());
+      expect(second.id).not.toBe(first.id);
+    });
+
+    it("allows a new schedule once the previous one has completed", () => {
+      const first = registry.create(baseInput());
+      registry.advanceDue(new Date(T2));
+      expect(registry.getById(first.id)?.status).toBe("completed");
+
+      const second = registry.create(baseInput());
+      expect(second.id).not.toBe(first.id);
+    });
+
+    it("does not block schedules for a different tenant or environment", () => {
+      registry.create(baseInput());
+      expect(() => registry.create(baseInput({ tenantId: "tenant-b" }))).not.toThrow();
+      expect(() => registry.create(baseInput({ tenantId: "tenant-a", environment: "development" }))).not.toThrow();
+    });
+  });
+
+  // ─── advanceDue() ───────────────────────────────────────────────────────
+
+  describe("advanceDue", () => {
+    it("stays pending before the first step's time", () => {
+      const schedule = registry.create(baseInput());
+      const advanced = registry.advanceDue(new Date(Date.parse(T0) - 1000));
+
+      expect(advanced).toHaveLength(0);
+      expect(registry.getById(schedule.id)?.status).toBe("pending");
+      expect(registry.getById(schedule.id)?.currentPercentage).toBe(0);
+    });
+
+    it("advances to the first step once its time passes", () => {
+      const schedule = registry.create(baseInput());
+      const advanced = registry.advanceDue(new Date(T0));
+
+      expect(advanced).toHaveLength(1);
+      const updated = registry.getById(schedule.id)!;
+      expect(updated.status).toBe("active");
+      expect(updated.currentStepIndex).toBe(0);
+      expect(updated.currentPercentage).toBe(10);
+      expect(updated.history.at(-1)).toMatchObject({ action: "advanced", percentage: 10, actor: "scheduler" });
+    });
+
+    it("marks the schedule completed on the last step", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T2));
+      const updated = registry.getById(schedule.id)!;
+
+      expect(updated.status).toBe("completed");
+      expect(updated.currentStepIndex).toBe(2);
+      expect(updated.currentPercentage).toBe(100);
+    });
+
+    it("jumps straight to the latest due step when multiple steps are missed (outage catch-up)", () => {
+      const schedule = registry.create(baseInput());
+
+      // Simulate the scheduler being down until well past step 1 and step 2's times.
+      const advanced = registry.advanceDue(new Date(Date.parse(T2) + 60_000));
+
+      expect(advanced).toHaveLength(1); // one advance call, not three
+      const updated = registry.getById(schedule.id)!;
+      expect(updated.currentStepIndex).toBe(2);
+      expect(updated.currentPercentage).toBe(100);
+      // Only one new "advanced" history entry was appended — no replay of step 0/1.
+      expect(updated.history.filter((h) => h.action === "advanced")).toHaveLength(1);
+    });
+
+    it("does not advance a paused schedule even if a step is due", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T0));
+      registry.pause(schedule.id, "alice");
+
+      const advanced = registry.advanceDue(new Date(T2));
+      expect(advanced).toHaveLength(0);
+      expect(registry.getById(schedule.id)?.currentPercentage).toBe(10);
+    });
+
+    it("does not advance a rolled-back schedule", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T1));
+      registry.rollback({ id: schedule.id, actor: "alice", reason: "incident: reverting ramp" });
+
+      const advanced = registry.advanceDue(new Date(T2));
+      expect(advanced).toHaveLength(0);
+    });
+
+    it("defaults `now` to the current wall-clock time when omitted", () => {
+      const schedule = registry.create(
+        baseInput({ steps: [{ percentage: 10, at: new Date(Date.now() - 1000).toISOString() }] }),
+      );
+      const advanced = registry.advanceDue();
+      expect(advanced).toHaveLength(1);
+      expect(registry.getById(schedule.id)?.currentPercentage).toBe(10);
+    });
+
+    it("does not re-advance a completed schedule", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T2));
+      const advanced = registry.advanceDue(new Date(Date.parse(T2) + 60_000));
+      expect(advanced).toHaveLength(0);
+      expect(registry.getById(schedule.id)?.status).toBe("completed");
+    });
+  });
+
+  // ─── pause() / resume() ─────────────────────────────────────────────────
+
+  describe("pause", () => {
+    it("freezes the schedule at its current percentage", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T0));
+
+      const paused = registry.pause(schedule.id, "alice", "investigating a bug");
+      expect(paused.status).toBe("paused");
+      expect(paused.currentPercentage).toBe(10);
+      expect(paused.history.at(-1)).toMatchObject({ action: "paused", reason: "investigating a bug" });
+    });
+
+    it("throws NOT_FOUND for an unknown id", () => {
+      expectCode(() => registry.pause("nope", "alice"), "NOT_FOUND");
+    });
+
+    it("throws MISSING_ACTOR when actor is blank", () => {
+      const schedule = registry.create(baseInput());
+      expectCode(() => registry.pause(schedule.id, ""), "MISSING_ACTOR");
+    });
+
+    it("throws ALREADY_PAUSED when pausing twice", () => {
+      const schedule = registry.create(baseInput());
+      registry.pause(schedule.id, "alice");
+      expectCode(() => registry.pause(schedule.id, "alice"), "ALREADY_PAUSED");
+    });
+
+    it("throws INVALID_STATE_TRANSITION for a completed schedule", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T2));
+      expectCode(() => registry.pause(schedule.id, "alice"), "INVALID_STATE_TRANSITION");
+    });
+
+    it("throws INVALID_STATE_TRANSITION for a rolled-back schedule", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T0));
+      registry.rollback({ id: schedule.id, actor: "alice", reason: "reverting due to error spike" });
+      expectCode(() => registry.pause(schedule.id, "alice"), "INVALID_STATE_TRANSITION");
+    });
+  });
+
+  describe("resume", () => {
+    it("catches up immediately to whatever step is due (step-during-outage-while-paused)", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T0)); // 10%
+      registry.pause(schedule.id, "alice");
+
+      // Steps 1 and 2's times pass while the schedule sits paused.
+      const resumed = registry.resume(schedule.id, "bob", new Date(Date.parse(T2) + 60_000));
+
+      expect(resumed.status).toBe("completed");
+      expect(resumed.currentPercentage).toBe(100);
+      const advancedEntries = resumed.history.filter((h) => h.action === "advanced");
+      expect(advancedEntries).toHaveLength(2); // step 0 (before pause) + the catch-up jump
+    });
+
+    it("resumes to 'pending' if no step was ever reached", () => {
+      const schedule = registry.create(baseInput());
+      registry.pause(schedule.id, "alice");
+      const resumed = registry.resume(schedule.id, "bob", new Date(Date.parse(T0) - 1000));
+      expect(resumed.status).toBe("pending");
+      expect(resumed.currentPercentage).toBe(0);
+    });
+
+    it("throws NOT_FOUND for an unknown id", () => {
+      expectCode(() => registry.resume("nope", "alice"), "NOT_FOUND");
+    });
+
+    it("throws MISSING_ACTOR when actor is blank", () => {
+      const schedule = registry.create(baseInput());
+      registry.pause(schedule.id, "alice");
+      expectCode(() => registry.resume(schedule.id, "  "), "MISSING_ACTOR");
+    });
+
+    it("throws INVALID_STATE_TRANSITION when the schedule is not paused", () => {
+      const schedule = registry.create(baseInput());
+      expectCode(() => registry.resume(schedule.id, "alice"), "INVALID_STATE_TRANSITION");
+    });
+  });
+
+  // ─── rollback() ─────────────────────────────────────────────────────────
+
+  describe("rollback", () => {
+    it("defaults to one step back", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T1)); // step index 1, 50%
+
+      const rolled = registry.rollback({ id: schedule.id, actor: "alice", reason: "error rate spiked" });
+      expect(rolled.status).toBe("rolled_back");
+      expect(rolled.currentStepIndex).toBe(0);
+      expect(rolled.currentPercentage).toBe(10);
+    });
+
+    it("rolls back across multiple steps at once when toStepIndex is given", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T2)); // step index 2, 100%, completed
+
+      const rolled = registry.rollback({
+        id: schedule.id,
+        actor: "alice",
+        reason: "full revert to pre-ramp state",
+        toStepIndex: -1,
+      });
+      expect(rolled.currentStepIndex).toBe(-1);
+      expect(rolled.currentPercentage).toBe(0);
+      expect(rolled.status).toBe("rolled_back");
+    });
+
+    it("is terminal — the scheduler will not advance it again even after rollback", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T1));
+      registry.rollback({ id: schedule.id, actor: "alice", reason: "reverting a bad ramp" });
+
+      const advanced = registry.advanceDue(new Date(Date.parse(T2) + 60_000));
+      expect(advanced).toHaveLength(0);
+      expect(registry.getById(schedule.id)?.status).toBe("rolled_back");
+      expect(registry.getById(schedule.id)?.currentPercentage).toBe(10);
+    });
+
+    it("throws NOT_FOUND for an unknown id", () => {
+      expectCode(
+        () => registry.rollback({ id: "nope", actor: "alice", reason: "some reason" }),
+        "NOT_FOUND",
+      );
+    });
+
+    it("throws MISSING_ACTOR when actor is blank", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T0));
+      expectCode(
+        () => registry.rollback({ id: schedule.id, actor: "", reason: "some reason" }),
+        "MISSING_ACTOR",
+      );
+    });
+
+    it("throws MISSING_REASON when reason is blank", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T0));
+      expectCode(() => registry.rollback({ id: schedule.id, actor: "alice", reason: "  " }), "MISSING_REASON");
+    });
+
+    it("throws NOTHING_TO_ROLLBACK when no step has been reached yet", () => {
+      const schedule = registry.create(baseInput());
+      expectCode(
+        () => registry.rollback({ id: schedule.id, actor: "alice", reason: "some reason" }),
+        "NOTHING_TO_ROLLBACK",
+      );
+    });
+
+    it("throws ALREADY_ROLLED_BACK on a second rollback", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T1));
+      registry.rollback({ id: schedule.id, actor: "alice", reason: "first rollback" });
+      expectCode(
+        () => registry.rollback({ id: schedule.id, actor: "alice", reason: "second rollback" }),
+        "ALREADY_ROLLED_BACK",
+      );
+    });
+
+    it("throws INVALID_ROLLBACK_TARGET when toStepIndex is not before the current step", () => {
+      const schedule = registry.create(baseInput());
+      registry.advanceDue(new Date(T1)); // step index 1
+
+      expectCode(
+        () =>
+          registry.rollback({ id: schedule.id, actor: "alice", reason: "bad target", toStepIndex: 1 }),
+        "INVALID_ROLLBACK_TARGET",
+      );
+      expectCode(
+        () =>
+          registry.rollback({ id: schedule.id, actor: "alice", reason: "bad target", toStepIndex: 2 }),
+        "INVALID_ROLLBACK_TARGET",
+      );
+      expectCode(
+        () =>
+          registry.rollback({ id: schedule.id, actor: "alice", reason: "bad target", toStepIndex: -2 }),
+        "INVALID_ROLLBACK_TARGET",
+      );
+    });
+  });
+
+  // ─── list() / getById() / findGoverningSchedule() ───────────────────────
+
+  describe("read helpers", () => {
+    it("getById returns undefined for an unknown id", () => {
+      expect(registry.getById("nope")).toBeUndefined();
+    });
+
+    it("list filters by flag, tenantId, environment, and status", () => {
+      registry.create(baseInput());
+      registry.create(baseInput({ tenantId: "tenant-b" }));
+      registry.create(baseInput({ flag: "SMS_NOTIFICATIONS", tenantId: "tenant-c" }));
+
+      expect(registry.list({ tenantId: "tenant-a" })).toHaveLength(1);
+      expect(registry.list({ flag: "SMS_NOTIFICATIONS" })).toHaveLength(1);
+      expect(registry.list({ environment: "production" })).toHaveLength(3);
+      expect(registry.list({ status: "pending" })).toHaveLength(3);
+      expect(registry.list()).toHaveLength(3);
+    });
+
+    it("findGoverningSchedule prefers a tenant-specific schedule over the wildcard", () => {
+      registry.create(baseInput({ tenantId: ALL_TENANTS, steps: [{ percentage: 5, at: T0 }] }));
+      registry.create(baseInput({ tenantId: "tenant-a", steps: [{ percentage: 40, at: T0 }] }));
+      registry.advanceDue(new Date(T0));
+
+      const governing = registry.findGoverningSchedule("CREATE_SLOT", "tenant-a", "production");
+      expect(governing?.currentPercentage).toBe(40);
+
+      const otherTenant = registry.findGoverningSchedule("CREATE_SLOT", "tenant-z", "production");
+      expect(otherTenant?.currentPercentage).toBe(5);
+    });
+
+    it("findGoverningSchedule returns undefined when nothing governs the tuple", () => {
+      expect(registry.findGoverningSchedule("CREATE_SLOT", "tenant-a", "production")).toBeUndefined();
+    });
+
+    it("returned schedules are deep copies that cannot mutate internal state", () => {
+      const schedule = registry.create(baseInput());
+      schedule.steps.push({ percentage: 999, at: T3 });
+      schedule.history.push({ action: "advanced", stepIndex: 5, percentage: 999, timestamp: T3, actor: "eve" });
+
+      const fresh = registry.getById(schedule.id)!;
+      expect(fresh.steps).toHaveLength(3);
+      expect(fresh.history).toHaveLength(1);
+    });
+  });
+});
+
+describe("getRolloutScheduleRegistry singleton", () => {
+  afterEach(() => {
+    resetRolloutScheduleRegistry();
+  });
+
+  it("returns the same instance across calls", () => {
+    expect(getRolloutScheduleRegistry()).toBe(getRolloutScheduleRegistry());
+  });
+
+  it("_reset clears schedules and identity", () => {
+    const registry = getRolloutScheduleRegistry();
+    registry.create(baseInput());
+    expect(registry.list()).toHaveLength(1);
+
+    resetRolloutScheduleRegistry();
+    expect(getRolloutScheduleRegistry()).not.toBe(registry);
+    expect(getRolloutScheduleRegistry().list()).toHaveLength(0);
+  });
+});

--- a/src/flags/index.ts
+++ b/src/flags/index.ts
@@ -9,8 +9,34 @@ export {
 } from "./service.js";
 export {
   FEATURE_FLAG_NAMES,
+  ROLLOUT_ENVIRONMENTS,
   type FeatureFlagAccessor,
   type FeatureFlagDefinition,
   type FeatureFlagName,
   type FeatureFlagState,
+  type RolloutEnvironment,
 } from "./types.js";
+export {
+  ALL_TENANTS,
+  RolloutScheduleError,
+  type CreateRolloutScheduleInput,
+  type RollbackRolloutInput,
+  type RolloutHistoryAction,
+  type RolloutHistoryEntry,
+  type RolloutSchedule,
+  type RolloutStatus,
+  type RolloutStep,
+} from "./rolloutTypes.js";
+export {
+  RolloutScheduleRegistry,
+  getRolloutScheduleRegistry,
+  resetRolloutScheduleRegistry,
+  type RolloutScheduleFilter,
+} from "./rolloutScheduleRegistry.js";
+export {
+  currentRolloutEnvironment,
+  getRolloutPercentage,
+  hashToBucket,
+  isBucketedIn,
+  isFeatureEnabledForTenant,
+} from "./rolloutEvaluator.js";

--- a/src/flags/rolloutEvaluator.ts
+++ b/src/flags/rolloutEvaluator.ts
@@ -1,0 +1,80 @@
+/**
+ * rolloutEvaluator.ts
+ * --------------------
+ * Bridges the boolean feature-flag system (service.ts) with scheduled
+ * percentage rollouts (rolloutScheduleRegistry.ts).
+ *
+ * Layering: the boolean flag is always the outer kill-switch. A rollout
+ * schedule only narrows an *enabled* flag down to a percentage of traffic;
+ * it can never turn on a flag that is disabled at the boolean level. This
+ * keeps the existing `isFeatureEnabled` semantics backward compatible and
+ * gives operators a single fail-closed switch that overrides every ramp.
+ */
+
+import { isFeatureEnabled } from "./service.js";
+import { ALL_TENANTS } from "./rolloutTypes.js";
+import { getRolloutScheduleRegistry, type RolloutScheduleRegistry } from "./rolloutScheduleRegistry.js";
+import { ROLLOUT_ENVIRONMENTS, type FeatureFlagName, type RolloutEnvironment } from "./types.js";
+
+/** Reads the current deployment environment, falling back to "development". */
+export function currentRolloutEnvironment(): RolloutEnvironment {
+  const raw = process.env.NODE_ENV;
+  return (ROLLOUT_ENVIRONMENTS as readonly string[]).includes(raw ?? "")
+    ? (raw as RolloutEnvironment)
+    : "development";
+}
+
+/**
+ * Deterministic string -> [0, 100) bucket using FNV-1a. Stable across
+ * processes and restarts so the same bucket key always lands in the same
+ * bucket, which is what makes percentage rollouts sticky per-tenant/user
+ * instead of flapping on every request.
+ */
+export function hashToBucket(input: string): number {
+  let hash = 0x811c9dc5; // FNV-1a 32-bit offset basis
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193); // FNV-1a 32-bit prime
+  }
+  return (hash >>> 0) % 100;
+}
+
+export function isBucketedIn(bucketKey: string, percentage: number): boolean {
+  if (percentage >= 100) return true;
+  if (percentage <= 0) return false;
+  return hashToBucket(bucketKey) < percentage;
+}
+
+/**
+ * Current rollout percentage for (flag, tenantId, environment). Returns 100
+ * (unrestricted) when no schedule governs this tuple, so a flag with no
+ * rollout schedule behaves exactly like the plain boolean flag it always was.
+ */
+export function getRolloutPercentage(
+  flag: FeatureFlagName,
+  tenantId: string,
+  environment: RolloutEnvironment = currentRolloutEnvironment(),
+  registry: RolloutScheduleRegistry = getRolloutScheduleRegistry(),
+): number {
+  const schedule = registry.findGoverningSchedule(flag, tenantId, environment);
+  return schedule ? schedule.currentPercentage : 100;
+}
+
+/**
+ * Full evaluation: the boolean flag must be enabled AND the bucket key must
+ * fall within the currently-active rollout percentage (if any schedule
+ * governs this tuple, tenant-specific schedules taking priority over an
+ * `ALL_TENANTS` wildcard).
+ */
+export function isFeatureEnabledForTenant(
+  flag: FeatureFlagName,
+  tenantId: string,
+  bucketKey: string,
+  environment: RolloutEnvironment = currentRolloutEnvironment(),
+): boolean {
+  if (!isFeatureEnabled(flag)) return false;
+  const percentage = getRolloutPercentage(flag, tenantId, environment);
+  return isBucketedIn(bucketKey, percentage);
+}
+
+export { ALL_TENANTS };

--- a/src/flags/rolloutScheduleRegistry.ts
+++ b/src/flags/rolloutScheduleRegistry.ts
@@ -1,0 +1,415 @@
+/**
+ * rolloutScheduleRegistry.ts
+ * --------------------------
+ * In-process registry for scheduled, percentage-based feature-flag rollouts
+ * (#570). A rollout schedule ramps a flag's traffic percentage up through an
+ * ordered list of time-based steps, scoped to a single (flag, tenant,
+ * environment) tuple — mirrors the in-memory singleton + immutable-read
+ * pattern used by `FraudModelRegistry` (see fraudModelRegistry.ts).
+ *
+ * Design constraints
+ * ------------------
+ * - Synchronous, single-writer, single-process. Node's single-threaded
+ *   execution makes read/write pairs atomic without an explicit mutex.
+ * - "Missed step" / "step during outage" safety: advancing always jumps to
+ *   the *latest* due step rather than replaying every intermediate step, so
+ *   a scheduler that was down (or a schedule that was paused) for a while
+ *   does not fire a burst of intermediate percentages on catch-up.
+ * - Rollback is terminal by design: once rolled back, the scheduler will
+ *   never advance the schedule again. An operator must create a fresh
+ *   schedule to resume ramping. This is deliberate — an incident-triggered
+ *   rollback should never silently resume ramping up on its own.
+ * - Only one "in-flight" (pending/active/paused) schedule may exist per
+ *   (flag, tenant, environment) tuple at a time; a new one may be created
+ *   once the previous is `completed` or `rolled_back`.
+ */
+
+import {
+  FEATURE_FLAG_NAMES,
+  ROLLOUT_ENVIRONMENTS,
+  type FeatureFlagName,
+  type RolloutEnvironment,
+} from "./types.js";
+import {
+  ALL_TENANTS,
+  RolloutScheduleError,
+  type CreateRolloutScheduleInput,
+  type RollbackRolloutInput,
+  type RolloutHistoryAction,
+  type RolloutSchedule,
+  type RolloutStatus,
+  type RolloutStep,
+} from "./rolloutTypes.js";
+
+const MAX_STEPS = 50;
+const SCHEDULER_ACTOR = "scheduler";
+
+export interface RolloutScheduleFilter {
+  flag?: FeatureFlagName;
+  tenantId?: string;
+  environment?: RolloutEnvironment;
+  status?: RolloutStatus;
+}
+
+function cloneSchedule(schedule: RolloutSchedule): RolloutSchedule {
+  return {
+    ...schedule,
+    steps: schedule.steps.map((s) => ({ ...s })),
+    history: schedule.history.map((h) => ({ ...h })),
+  };
+}
+
+function statusForStepIndex(stepIndex: number, stepsLength: number): RolloutStatus {
+  if (stepIndex < 0) return "pending";
+  return stepIndex === stepsLength - 1 ? "completed" : "active";
+}
+
+/** Returns the highest step index whose `at` has passed `nowMs`, or -1. */
+function computeDueStepIndex(steps: readonly RolloutStep[], nowMs: number): number {
+  let due = -1;
+  for (const step of steps) {
+    if (Date.parse(step.at) <= nowMs) {
+      due += 1;
+    } else {
+      break; // steps are validated to be chronologically sorted
+    }
+  }
+  return due;
+}
+
+function validateCreateInput(input: CreateRolloutScheduleInput): void {
+  if (!FEATURE_FLAG_NAMES.includes(input.flag)) {
+    throw new RolloutScheduleError(`Unknown feature flag: ${input.flag}`, "UNKNOWN_FLAG");
+  }
+  if (!ROLLOUT_ENVIRONMENTS.includes(input.environment)) {
+    throw new RolloutScheduleError(
+      `Unknown environment: "${input.environment}". Supported: ${ROLLOUT_ENVIRONMENTS.join(", ")}`,
+      "UNKNOWN_ENVIRONMENT",
+    );
+  }
+  if (typeof input.tenantId !== "string" || input.tenantId.trim() === "") {
+    throw new RolloutScheduleError("tenantId is required", "MISSING_TENANT");
+  }
+  if (typeof input.actor !== "string" || input.actor.trim() === "") {
+    throw new RolloutScheduleError("actor is required", "MISSING_ACTOR");
+  }
+  if (!Array.isArray(input.steps) || input.steps.length === 0) {
+    throw new RolloutScheduleError("At least one rollout step is required", "EMPTY_STEPS");
+  }
+  if (input.steps.length > MAX_STEPS) {
+    throw new RolloutScheduleError(
+      `At most ${MAX_STEPS} steps are supported (got ${input.steps.length})`,
+      "TOO_MANY_STEPS",
+    );
+  }
+
+  let prevTimeMs = -Infinity;
+  let prevPercentage = 0;
+  input.steps.forEach((step, i) => {
+    if (!Number.isInteger(step.percentage) || step.percentage < 1 || step.percentage > 100) {
+      throw new RolloutScheduleError(
+        `Step ${i} percentage must be an integer in [1, 100] (got ${step.percentage})`,
+        "INVALID_PERCENTAGE",
+      );
+    }
+    const timeMs = Date.parse(step.at);
+    if (Number.isNaN(timeMs)) {
+      throw new RolloutScheduleError(
+        `Step ${i} has an invalid ISO-8601 timestamp: "${step.at}"`,
+        "INVALID_TIMESTAMP",
+      );
+    }
+    if (timeMs <= prevTimeMs) {
+      throw new RolloutScheduleError(
+        `Step ${i} timestamp must be strictly after the previous step's timestamp`,
+        "STEPS_NOT_CHRONOLOGICAL",
+      );
+    }
+    if (step.percentage <= prevPercentage) {
+      throw new RolloutScheduleError(
+        `Step ${i} percentage (${step.percentage}) must be strictly greater than the previous step's (${prevPercentage})`,
+        "STEPS_NOT_INCREASING",
+      );
+    }
+    prevTimeMs = timeMs;
+    prevPercentage = step.percentage;
+  });
+}
+
+const IN_FLIGHT_STATUSES: readonly RolloutStatus[] = ["pending", "active", "paused"];
+
+export class RolloutScheduleRegistry {
+  private schedules = new Map<string, RolloutSchedule>();
+  /** (flag, tenant, environment) -> id of the schedule currently governing it. */
+  private currentByKey = new Map<string, string>();
+  private nextSeq = 1;
+
+  private key(flag: FeatureFlagName, tenantId: string, environment: RolloutEnvironment): string {
+    return `${flag}::${environment}::${tenantId}`;
+  }
+
+  private requireSchedule(id: string): RolloutSchedule {
+    const schedule = this.schedules.get(id);
+    if (!schedule) {
+      throw new RolloutScheduleError(`Rollout schedule not found: ${id}`, "NOT_FOUND");
+    }
+    return schedule;
+  }
+
+  private applyAdvance(schedule: RolloutSchedule, stepIndex: number, actor: string): void {
+    schedule.currentStepIndex = stepIndex;
+    schedule.currentPercentage = schedule.steps[stepIndex].percentage;
+    schedule.status = statusForStepIndex(stepIndex, schedule.steps.length);
+    schedule.updatedAt = new Date().toISOString();
+    schedule.history.push({
+      action: "advanced",
+      stepIndex,
+      percentage: schedule.currentPercentage,
+      timestamp: schedule.updatedAt,
+      actor,
+    });
+  }
+
+  create(input: CreateRolloutScheduleInput): RolloutSchedule {
+    validateCreateInput(input);
+
+    const key = this.key(input.flag, input.tenantId, input.environment);
+    const existingId = this.currentByKey.get(key);
+    if (existingId) {
+      const existing = this.schedules.get(existingId);
+      if (existing && IN_FLIGHT_STATUSES.includes(existing.status)) {
+        throw new RolloutScheduleError(
+          `An in-flight rollout schedule already exists for ${input.flag}/${input.environment}/${input.tenantId} ` +
+            `(id=${existingId}, status=${existing.status}); pause or roll it back before creating a new one.`,
+          "SCHEDULE_IN_FLIGHT",
+        );
+      }
+    }
+
+    const now = new Date().toISOString();
+    const id = `rollout-${this.nextSeq++}-${Math.random().toString(36).slice(2, 8)}`;
+    const schedule: RolloutSchedule = {
+      id,
+      flag: input.flag,
+      tenantId: input.tenantId.trim(),
+      environment: input.environment,
+      steps: input.steps.map((s) => ({ ...s })),
+      status: "pending",
+      currentStepIndex: -1,
+      currentPercentage: 0,
+      createdAt: now,
+      updatedAt: now,
+      createdBy: input.actor.trim(),
+      history: [
+        {
+          action: "created" satisfies RolloutHistoryAction,
+          stepIndex: -1,
+          percentage: 0,
+          timestamp: now,
+          actor: input.actor.trim(),
+        },
+      ],
+    };
+
+    this.schedules.set(id, schedule);
+    this.currentByKey.set(key, id);
+    return cloneSchedule(schedule);
+  }
+
+  getById(id: string): RolloutSchedule | undefined {
+    const schedule = this.schedules.get(id);
+    return schedule ? cloneSchedule(schedule) : undefined;
+  }
+
+  list(filter: RolloutScheduleFilter = {}): RolloutSchedule[] {
+    return Array.from(this.schedules.values())
+      .filter(
+        (s) =>
+          (filter.flag === undefined || s.flag === filter.flag) &&
+          (filter.tenantId === undefined || s.tenantId === filter.tenantId) &&
+          (filter.environment === undefined || s.environment === filter.environment) &&
+          (filter.status === undefined || s.status === filter.status),
+      )
+      .map(cloneSchedule);
+  }
+
+  /**
+   * The schedule currently governing (flag, tenantId, environment).
+   * A tenant-specific schedule takes priority over an `ALL_TENANTS` wildcard.
+   */
+  findGoverningSchedule(
+    flag: FeatureFlagName,
+    tenantId: string,
+    environment: RolloutEnvironment,
+  ): RolloutSchedule | undefined {
+    const specificId = this.currentByKey.get(this.key(flag, tenantId, environment));
+    if (specificId) {
+      const schedule = this.schedules.get(specificId);
+      if (schedule) return cloneSchedule(schedule);
+    }
+
+    if (tenantId !== ALL_TENANTS) {
+      const wildcardId = this.currentByKey.get(this.key(flag, ALL_TENANTS, environment));
+      if (wildcardId) {
+        const schedule = this.schedules.get(wildcardId);
+        if (schedule) return cloneSchedule(schedule);
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Advances every non-terminal, non-paused schedule to the latest step
+   * whose `at` has passed `now`. Called on every scheduler tick.
+   */
+  advanceDue(now: Date = new Date()): RolloutSchedule[] {
+    const nowMs = now.getTime();
+    const advanced: RolloutSchedule[] = [];
+
+    for (const schedule of this.schedules.values()) {
+      if (schedule.status === "paused" || schedule.status === "rolled_back" || schedule.status === "completed") {
+        continue;
+      }
+      const dueIndex = computeDueStepIndex(schedule.steps, nowMs);
+      if (dueIndex > schedule.currentStepIndex) {
+        this.applyAdvance(schedule, dueIndex, SCHEDULER_ACTOR);
+        advanced.push(cloneSchedule(schedule));
+      }
+    }
+
+    return advanced;
+  }
+
+  pause(id: string, actor: string, reason?: string): RolloutSchedule {
+    const schedule = this.requireSchedule(id);
+    if (schedule.status === "rolled_back" || schedule.status === "completed") {
+      throw new RolloutScheduleError(
+        `Cannot pause a schedule in terminal status "${schedule.status}"`,
+        "INVALID_STATE_TRANSITION",
+      );
+    }
+    if (schedule.status === "paused") {
+      throw new RolloutScheduleError("Schedule is already paused", "ALREADY_PAUSED");
+    }
+    if (typeof actor !== "string" || actor.trim() === "") {
+      throw new RolloutScheduleError("actor is required", "MISSING_ACTOR");
+    }
+
+    schedule.status = "paused";
+    schedule.updatedAt = new Date().toISOString();
+    schedule.history.push({
+      action: "paused",
+      stepIndex: schedule.currentStepIndex,
+      percentage: schedule.currentPercentage,
+      timestamp: schedule.updatedAt,
+      actor: actor.trim(),
+      reason,
+    });
+    return cloneSchedule(schedule);
+  }
+
+  /**
+   * Resumes a paused schedule. Immediately catches up to whatever step is
+   * due at `now` instead of waiting for the next scheduler tick — a
+   * schedule that missed step times while paused jumps straight to the
+   * latest due step rather than replaying each one in turn.
+   */
+  resume(id: string, actor: string, now: Date = new Date()): RolloutSchedule {
+    const schedule = this.requireSchedule(id);
+    if (schedule.status !== "paused") {
+      throw new RolloutScheduleError(
+        `Cannot resume a schedule in status "${schedule.status}" (only "paused" schedules can be resumed)`,
+        "INVALID_STATE_TRANSITION",
+      );
+    }
+    if (typeof actor !== "string" || actor.trim() === "") {
+      throw new RolloutScheduleError("actor is required", "MISSING_ACTOR");
+    }
+
+    schedule.status = statusForStepIndex(schedule.currentStepIndex, schedule.steps.length);
+    schedule.updatedAt = new Date().toISOString();
+    schedule.history.push({
+      action: "resumed",
+      stepIndex: schedule.currentStepIndex,
+      percentage: schedule.currentPercentage,
+      timestamp: schedule.updatedAt,
+      actor: actor.trim(),
+    });
+
+    const dueIndex = computeDueStepIndex(schedule.steps, now.getTime());
+    if (dueIndex > schedule.currentStepIndex) {
+      this.applyAdvance(schedule, dueIndex, actor.trim());
+    }
+
+    return cloneSchedule(schedule);
+  }
+
+  /**
+   * Rolls back a schedule to an earlier step (or to 0% pre-ramp state).
+   * Defaults to one step back; pass `toStepIndex` to jump back across
+   * multiple steps at once. Terminal: the scheduler will never advance a
+   * rolled-back schedule again.
+   */
+  rollback(input: RollbackRolloutInput): RolloutSchedule {
+    const schedule = this.requireSchedule(input.id);
+    if (schedule.status === "rolled_back") {
+      throw new RolloutScheduleError("Schedule has already been rolled back", "ALREADY_ROLLED_BACK");
+    }
+    if (typeof input.actor !== "string" || input.actor.trim() === "") {
+      throw new RolloutScheduleError("actor is required", "MISSING_ACTOR");
+    }
+    if (typeof input.reason !== "string" || input.reason.trim() === "") {
+      throw new RolloutScheduleError("A rollback reason is required", "MISSING_REASON");
+    }
+    if (schedule.currentStepIndex === -1) {
+      throw new RolloutScheduleError(
+        "Schedule has not advanced past 0% yet; there is nothing to roll back",
+        "NOTHING_TO_ROLLBACK",
+      );
+    }
+
+    const target = input.toStepIndex ?? schedule.currentStepIndex - 1;
+    if (!Number.isInteger(target) || target < -1 || target >= schedule.currentStepIndex) {
+      throw new RolloutScheduleError(
+        `toStepIndex must be an integer >= -1 and less than the current step index (${schedule.currentStepIndex}); got ${target}`,
+        "INVALID_ROLLBACK_TARGET",
+      );
+    }
+
+    schedule.currentStepIndex = target;
+    schedule.currentPercentage = target >= 0 ? schedule.steps[target].percentage : 0;
+    schedule.status = "rolled_back";
+    schedule.updatedAt = new Date().toISOString();
+    schedule.history.push({
+      action: "rolled_back",
+      stepIndex: target,
+      percentage: schedule.currentPercentage,
+      timestamp: schedule.updatedAt,
+      actor: input.actor.trim(),
+      reason: input.reason.trim(),
+    });
+
+    return cloneSchedule(schedule);
+  }
+
+  /** Test-isolation only — never call in production code. */
+  _reset(): void {
+    this.schedules.clear();
+    this.currentByKey.clear();
+    this.nextSeq = 1;
+  }
+}
+
+let _singleton: RolloutScheduleRegistry | null = null;
+
+export function getRolloutScheduleRegistry(): RolloutScheduleRegistry {
+  if (!_singleton) _singleton = new RolloutScheduleRegistry();
+  return _singleton;
+}
+
+/** Test-isolation only. */
+export function resetRolloutScheduleRegistry(): void {
+  if (_singleton) _singleton._reset();
+  _singleton = null;
+}

--- a/src/flags/rolloutTypes.ts
+++ b/src/flags/rolloutTypes.ts
@@ -1,0 +1,81 @@
+import type { FeatureFlagName, RolloutEnvironment } from "./types.js";
+
+export { ROLLOUT_ENVIRONMENTS, type RolloutEnvironment } from "./types.js";
+
+/** Special tenant id meaning "every tenant not covered by a more specific schedule". */
+export const ALL_TENANTS = "*";
+
+export type RolloutStatus =
+  | "pending"
+  | "active"
+  | "paused"
+  | "rolled_back"
+  | "completed";
+
+/** A single ramp step: the schedule advances to `percentage` once `at` has passed. */
+export interface RolloutStep {
+  /** Cumulative rollout percentage this step advances to, an integer in [1, 100]. */
+  percentage: number;
+  /** ISO-8601 timestamp at which this step becomes due. */
+  at: string;
+}
+
+export type RolloutHistoryAction =
+  | "created"
+  | "advanced"
+  | "paused"
+  | "resumed"
+  | "rolled_back";
+
+export interface RolloutHistoryEntry {
+  action: RolloutHistoryAction;
+  /** Step index reached as a result of this action; -1 means 0%/no step reached. */
+  stepIndex: number;
+  percentage: number;
+  timestamp: string;
+  actor: string;
+  reason?: string;
+}
+
+export interface RolloutSchedule {
+  id: string;
+  flag: FeatureFlagName;
+  /** Tenant this schedule governs, or `ALL_TENANTS` for a cross-tenant ramp. */
+  tenantId: string;
+  environment: RolloutEnvironment;
+  steps: RolloutStep[];
+  status: RolloutStatus;
+  /** Index into `steps` most recently applied; -1 means no step has been reached yet. */
+  currentStepIndex: number;
+  currentPercentage: number;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  history: RolloutHistoryEntry[];
+}
+
+export interface CreateRolloutScheduleInput {
+  flag: FeatureFlagName;
+  tenantId: string;
+  environment: RolloutEnvironment;
+  steps: RolloutStep[];
+  actor: string;
+}
+
+export interface RollbackRolloutInput {
+  id: string;
+  actor: string;
+  reason: string;
+  /** Step index to revert to; -1 means revert to 0%. Defaults to one step back. */
+  toStepIndex?: number;
+}
+
+export class RolloutScheduleError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = "RolloutScheduleError";
+  }
+}

--- a/src/flags/types.ts
+++ b/src/flags/types.ts
@@ -37,3 +37,8 @@ export interface FeatureFlagAccessor {
   isEnabled: (flag: FeatureFlagName) => boolean;
   list: () => FeatureFlagState;
 }
+
+/** Deployment environments a rollout schedule can target. Mirrors `NodeEnv`. */
+export const ROLLOUT_ENVIRONMENTS = ["development", "test", "production"] as const;
+
+export type RolloutEnvironment = (typeof ROLLOUT_ENVIRONMENTS)[number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,26 @@ if (process.env.FRAUD_DRIFT_ENABLED === "true") {
   );
 })();
 
+// ─── Feature-Flag Rollout Scheduler (#570) ──────────────────────────────────
+// Advances scheduled percentage rollouts (src/flags/rolloutScheduleRegistry.ts)
+// to whatever step is due. Enabled by default; set
+// FLAG_ROLLOUT_SCHEDULER_DISABLED=true to skip (e.g. in single-shot scripts).
+(async () => {
+  if (process.env.FLAG_ROLLOUT_SCHEDULER_DISABLED === "true") {
+    console.log(
+      "[flag-rollout-scheduler] Disabled via FLAG_ROLLOUT_SCHEDULER_DISABLED",
+    );
+    return;
+  }
+
+  const { createFlagRolloutScheduler } = await import(
+    "./scheduler/flagRolloutScheduler.js"
+  );
+  createFlagRolloutScheduler({
+    runIntervalMs: Number(process.env.FLAG_ROLLOUT_INTERVAL_MS) || undefined,
+  }).start();
+})();
+
 const PORT = config.port || 3001;
 const server = app.listen(PORT, () => {
   console.log(`ChronoPay API listening on http://localhost:${PORT}`);

--- a/src/middleware/featureFlags.ts
+++ b/src/middleware/featureFlags.ts
@@ -1,7 +1,10 @@
 import { NextFunction, Request, Response } from "express";
 import {
+  type FeatureFlagAccessor,
   type FeatureFlagName,
+  type RolloutEnvironment,
   getFeatureFlagAccessor,
+  isFeatureEnabledForTenant,
   isGuardedRouteRegistered,
   setFeatureFlagsFromEnv,
 } from "../flags/index.js";
@@ -9,11 +12,25 @@ import { AppError, ServiceUnavailableError } from "../errors/AppError.js";
 import { ERROR_CODES } from "../errors/errorCodes.js";
 import { sendErrorResponse } from "../errors/sendError.js";
 
+/**
+ * Accessor extended with scheduled-rollout awareness (#570). `isEnabled`
+ * keeps its existing all-or-nothing semantics; `isEnabledForTenant` layers a
+ * per-tenant/per-environment rollout percentage on top when one is scheduled.
+ */
+export interface TenantAwareFeatureFlagAccessor extends FeatureFlagAccessor {
+  isEnabledForTenant: (
+    flag: FeatureFlagName,
+    tenantId: string,
+    bucketKey: string,
+    environment?: RolloutEnvironment,
+  ) => boolean;
+}
+
 // Extend Express Request to include flags
 declare global {
   namespace Express {
     interface Request {
-      flags?: ReturnType<typeof getFeatureFlagAccessor>;
+      flags?: TenantAwareFeatureFlagAccessor;
     }
   }
 }
@@ -23,7 +40,16 @@ export function featureFlagContextMiddleware(
   _res: Response,
   next: NextFunction,
 ): void {
-  (req as any).flags = getFeatureFlagAccessor();
+  const base = getFeatureFlagAccessor();
+  (req as any).flags = {
+    ...base,
+    isEnabledForTenant: (
+      flag: FeatureFlagName,
+      tenantId: string,
+      bucketKey: string,
+      environment?: RolloutEnvironment,
+    ): boolean => isFeatureEnabledForTenant(flag, tenantId, bucketKey, environment),
+  } satisfies TenantAwareFeatureFlagAccessor;
   next();
 }
 

--- a/src/routes/__tests__/flagRollouts.test.ts
+++ b/src/routes/__tests__/flagRollouts.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Integration tests for `/api/v1/admin/flag-rollouts` (#570). Mounts the
+ * route on a fresh Express app with `requireAdminToken` configured so
+ * headers behave authentically — same pattern as `fraudModels.test.ts`.
+ */
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import flagRolloutsRouter from "../flagRollouts.js";
+import { defaultAuditLogger } from "../../services/auditLogger.js";
+import { resetRolloutScheduleRegistry } from "../../flags/rolloutScheduleRegistry.js";
+
+const ADMIN_TOKEN = "test-admin-token-rollouts";
+process.env.CHRONOPAY_ADMIN_TOKEN = ADMIN_TOKEN;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/admin/flag-rollouts", flagRolloutsRouter);
+  return app;
+}
+
+const BASE_PAYLOAD = {
+  flag: "CREATE_SLOT",
+  tenantId: "tenant-a",
+  environment: "production",
+  actor: "alice",
+  steps: [
+    { percentage: 10, at: "2026-01-01T00:00:00.000Z" },
+    { percentage: 100, at: "2026-01-02T00:00:00.000Z" },
+  ],
+};
+
+describe("flag rollout admin routes", () => {
+  let auditSpy: jest.SpiedFunction<typeof defaultAuditLogger.log>;
+
+  beforeEach(() => {
+    auditSpy = jest.spyOn(defaultAuditLogger, "log").mockImplementation(() => Promise.resolve());
+    resetRolloutScheduleRegistry();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("auth", () => {
+    it("returns 401 without an admin token", async () => {
+      const res = await request(makeApp()).post("/api/v1/admin/flag-rollouts").send(BASE_PAYLOAD);
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 with a wrong admin token", async () => {
+      const res = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", "wrong-token")
+        .send(BASE_PAYLOAD);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("POST /", () => {
+    it("creates a schedule and emits an audit event", async () => {
+      const res = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.schedule.status).toBe("pending");
+      expect(res.body.schedule.currentPercentage).toBe(0);
+      expect(auditSpy).toHaveBeenCalledWith(
+        "FLAG_ROLLOUT_CREATED",
+        expect.anything(),
+        expect.objectContaining({ status: 201, resource: "/api/v1/admin/flag-rollouts" }),
+      );
+    });
+
+    it("returns 400 EMPTY_STEPS when the steps field is missing entirely", async () => {
+      const { steps: _steps, ...withoutSteps } = BASE_PAYLOAD;
+      const res = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(withoutSteps);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("EMPTY_STEPS");
+    });
+
+    it("returns 400 with the registry's validation error code", async () => {
+      const res = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ ...BASE_PAYLOAD, flag: "NOT_REAL" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("UNKNOWN_FLAG");
+    });
+
+    it("propagates a non-registry error instead of swallowing it", async () => {
+      const { getRolloutScheduleRegistry } = await import("../../flags/rolloutScheduleRegistry.js");
+      const crashSpy = jest
+        .spyOn(getRolloutScheduleRegistry(), "create")
+        .mockImplementationOnce(() => {
+          throw new Error("unexpected failure");
+        });
+
+      const res = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+
+      expect(res.status).toBe(500);
+      crashSpy.mockRestore();
+    });
+
+    it("does not fail the request when the audit logger rejects", async () => {
+      auditSpy.mockImplementation(() => Promise.reject(new Error("audit sink unavailable")));
+
+      const res = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+
+      expect(res.status).toBe(201);
+    });
+
+    it("returns 409 for a duplicate in-flight schedule", async () => {
+      await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+
+      const res = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe("SCHEDULE_IN_FLIGHT");
+    });
+  });
+
+  describe("GET /", () => {
+    it("lists schedules with optional filters", async () => {
+      await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+      await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ ...BASE_PAYLOAD, tenantId: "tenant-b" });
+
+      const all = await request(makeApp())
+        .get("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN);
+      expect(all.body.schedules).toHaveLength(2);
+
+      const filtered = await request(makeApp())
+        .get("/api/v1/admin/flag-rollouts?tenantId=tenant-b")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN);
+      expect(filtered.body.schedules).toHaveLength(1);
+      expect(filtered.body.schedules[0].tenantId).toBe("tenant-b");
+    });
+  });
+
+  describe("GET /:id", () => {
+    it("returns a single schedule", async () => {
+      const created = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+
+      const res = await request(makeApp())
+        .get(`/api/v1/admin/flag-rollouts/${created.body.schedule.id}`)
+        .set("x-chronopay-admin-token", ADMIN_TOKEN);
+
+      expect(res.status).toBe(200);
+      expect(res.body.schedule.id).toBe(created.body.schedule.id);
+    });
+
+    it("returns 404 for an unknown id", async () => {
+      const res = await request(makeApp())
+        .get("/api/v1/admin/flag-rollouts/does-not-exist")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN);
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("POST /:id/pause and /:id/resume", () => {
+    it("pauses and resumes a schedule", async () => {
+      // Steps set far in the future so resume's catch-up has nothing due yet —
+      // this test is about the pause/resume state machine, not the catch-up.
+      const created = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({
+          ...BASE_PAYLOAD,
+          steps: [
+            { percentage: 10, at: "2099-01-01T00:00:00.000Z" },
+            { percentage: 100, at: "2099-01-02T00:00:00.000Z" },
+          ],
+        });
+      const id = created.body.schedule.id;
+
+      const paused = await request(makeApp())
+        .post(`/api/v1/admin/flag-rollouts/${id}/pause`)
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ actor: "bob", reason: "investigating errors" });
+      expect(paused.status).toBe(200);
+      expect(paused.body.schedule.status).toBe("paused");
+      expect(auditSpy).toHaveBeenCalledWith(
+        "FLAG_ROLLOUT_PAUSED",
+        expect.anything(),
+        expect.objectContaining({ status: 200 }),
+      );
+
+      const resumed = await request(makeApp())
+        .post(`/api/v1/admin/flag-rollouts/${id}/resume`)
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ actor: "bob" });
+      expect(resumed.status).toBe(200);
+      expect(resumed.body.schedule.status).toBe("pending");
+    });
+
+    it("returns 409 when pausing an already-paused schedule", async () => {
+      const created = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+      const id = created.body.schedule.id;
+
+      await request(makeApp())
+        .post(`/api/v1/admin/flag-rollouts/${id}/pause`)
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ actor: "bob" });
+
+      const res = await request(makeApp())
+        .post(`/api/v1/admin/flag-rollouts/${id}/pause`)
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ actor: "bob" });
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe("ALREADY_PAUSED");
+    });
+
+    it("returns 409 when resuming a schedule that is not paused", async () => {
+      const created = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+      const id = created.body.schedule.id;
+
+      const res = await request(makeApp())
+        .post(`/api/v1/admin/flag-rollouts/${id}/resume`)
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ actor: "bob" });
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe("INVALID_STATE_TRANSITION");
+    });
+  });
+
+  describe("POST /:id/rollback", () => {
+    it("rolls back a schedule and marks it terminal", async () => {
+      const created = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+      const id = created.body.schedule.id;
+
+      // Manually advance the underlying registry so there is a step to roll back from.
+      const { getRolloutScheduleRegistry } = await import("../../flags/rolloutScheduleRegistry.js");
+      getRolloutScheduleRegistry().advanceDue(new Date("2026-01-01T00:00:00.000Z"));
+
+      const res = await request(makeApp())
+        .post(`/api/v1/admin/flag-rollouts/${id}/rollback`)
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ actor: "bob", reason: "error rate spiked after step 1", toStepIndex: -1 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.schedule.status).toBe("rolled_back");
+      expect(res.body.schedule.currentPercentage).toBe(0);
+      expect(auditSpy).toHaveBeenCalledWith(
+        "FLAG_ROLLOUT_ROLLED_BACK",
+        expect.anything(),
+        expect.objectContaining({ status: 200 }),
+      );
+    });
+
+    it("returns 400 when reason is missing", async () => {
+      const created = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send(BASE_PAYLOAD);
+      const id = created.body.schedule.id;
+
+      const { getRolloutScheduleRegistry } = await import("../../flags/rolloutScheduleRegistry.js");
+      getRolloutScheduleRegistry().advanceDue(new Date("2026-01-01T00:00:00.000Z"));
+
+      const res = await request(makeApp())
+        .post(`/api/v1/admin/flag-rollouts/${id}/rollback`)
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ actor: "bob" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("MISSING_REASON");
+    });
+
+    it("returns 404 for an unknown id", async () => {
+      const res = await request(makeApp())
+        .post("/api/v1/admin/flag-rollouts/does-not-exist/rollback")
+        .set("x-chronopay-admin-token", ADMIN_TOKEN)
+        .send({ actor: "bob", reason: "some reason" });
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe("NOT_FOUND");
+    });
+  });
+});

--- a/src/routes/flagRollouts.ts
+++ b/src/routes/flagRollouts.ts
@@ -1,0 +1,225 @@
+/**
+ * flagRollouts.ts (admin route)
+ * ------------------------------
+ * Routes mounted under `/api/v1/admin/flag-rollouts` (#570).
+ *
+ * POST   /                 – create a scheduled percentage rollout
+ * GET    /                 – list rollout schedules (optional filters)
+ * GET    /:id              – get a single schedule, including its history
+ * POST   /:id/pause        – pause a schedule (freezes at its current %)
+ * POST   /:id/resume       – resume a paused schedule (catches up to now)
+ * POST   /:id/rollback     – roll back to an earlier step (terminal)
+ *
+ * All mutating actions require an `actor` in the request body — deliberately
+ * NOT derived from the admin token itself, so the shared admin secret never
+ * ends up recorded as an actor identity in audit logs or schedule history.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { requireAdminToken } from "../middleware/authorization.js";
+import { defaultAuditLogger } from "../services/auditLogger.js";
+import {
+  RolloutScheduleError,
+  getRolloutScheduleRegistry,
+  type FeatureFlagName,
+  type RolloutEnvironment,
+  type RolloutStatus,
+} from "../flags/index.js";
+
+const router = Router();
+
+const ERROR_STATUS_BY_CODE: Record<string, number> = {
+  NOT_FOUND: 404,
+  SCHEDULE_IN_FLIGHT: 409,
+  ALREADY_PAUSED: 409,
+  ALREADY_ROLLED_BACK: 409,
+  INVALID_STATE_TRANSITION: 409,
+  NOTHING_TO_ROLLBACK: 409,
+};
+
+function statusForError(err: RolloutScheduleError): number {
+  return ERROR_STATUS_BY_CODE[err.code] ?? 400;
+}
+
+function handleRolloutError(res: Response, err: unknown): Response {
+  if (err instanceof RolloutScheduleError) {
+    return res.status(statusForError(err)).json({
+      success: false,
+      code: err.code,
+      error: err.message,
+    });
+  }
+  throw err;
+}
+
+function auditFireAndForget(
+  action: string,
+  context: Record<string, unknown>,
+  req: Request,
+  status: number | string,
+): void {
+  void defaultAuditLogger
+    .log(
+      action,
+      { method: req.method, context },
+      { actorIp: req.ip || req.socket?.remoteAddress, resource: req.originalUrl, status },
+    )
+    .catch(() => undefined);
+}
+
+// ---------------------------------------------------------------------------
+// POST / — create a rollout schedule
+// ---------------------------------------------------------------------------
+
+router.post("/", requireAdminToken, (req: Request, res: Response) => {
+  const body = req.body && typeof req.body === "object" ? req.body : {};
+  const { flag, tenantId, environment, steps, actor } = body as {
+    flag?: FeatureFlagName;
+    tenantId?: string;
+    environment?: RolloutEnvironment;
+    steps?: Array<{ percentage: number; at: string }>;
+    actor?: string;
+  };
+
+  try {
+    const registry = getRolloutScheduleRegistry();
+    const schedule = registry.create({
+      flag: flag as FeatureFlagName,
+      tenantId: tenantId as string,
+      environment: environment as RolloutEnvironment,
+      steps: Array.isArray(steps) ? steps : [],
+      actor: actor as string,
+    });
+
+    auditFireAndForget(
+      "FLAG_ROLLOUT_CREATED",
+      { scheduleId: schedule.id, flag: schedule.flag, tenantId: schedule.tenantId, environment: schedule.environment, steps: schedule.steps, actor: schedule.createdBy },
+      req,
+      201,
+    );
+
+    return res.status(201).json({ success: true, schedule });
+  } catch (err) {
+    return handleRolloutError(res, err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET / — list schedules (optional filters)
+// ---------------------------------------------------------------------------
+
+router.get("/", requireAdminToken, (req: Request, res: Response) => {
+  const registry = getRolloutScheduleRegistry();
+  const { flag, tenantId, environment, status } = req.query as Record<string, string | undefined>;
+
+  const schedules = registry.list({
+    flag: flag as FeatureFlagName | undefined,
+    tenantId,
+    environment: environment as RolloutEnvironment | undefined,
+    status: status as RolloutStatus | undefined,
+  });
+
+  return res.status(200).json({ success: true, schedules });
+});
+
+// ---------------------------------------------------------------------------
+// GET /:id — fetch a single schedule
+// ---------------------------------------------------------------------------
+
+router.get("/:id", requireAdminToken, (req: Request, res: Response) => {
+  const registry = getRolloutScheduleRegistry();
+  const schedule = registry.getById(req.params.id);
+
+  if (!schedule) {
+    return res.status(404).json({
+      success: false,
+      code: "NOT_FOUND",
+      error: `Rollout schedule not found: ${req.params.id}`,
+    });
+  }
+
+  return res.status(200).json({ success: true, schedule });
+});
+
+// ---------------------------------------------------------------------------
+// POST /:id/pause
+// ---------------------------------------------------------------------------
+
+router.post("/:id/pause", requireAdminToken, (req: Request, res: Response) => {
+  const { actor, reason } = (req.body ?? {}) as { actor?: string; reason?: string };
+
+  try {
+    const registry = getRolloutScheduleRegistry();
+    const schedule = registry.pause(req.params.id, actor as string, reason);
+
+    auditFireAndForget(
+      "FLAG_ROLLOUT_PAUSED",
+      { scheduleId: schedule.id, actor: schedule.history.at(-1)?.actor, reason },
+      req,
+      200,
+    );
+
+    return res.status(200).json({ success: true, schedule });
+  } catch (err) {
+    return handleRolloutError(res, err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /:id/resume
+// ---------------------------------------------------------------------------
+
+router.post("/:id/resume", requireAdminToken, (req: Request, res: Response) => {
+  const { actor } = (req.body ?? {}) as { actor?: string };
+
+  try {
+    const registry = getRolloutScheduleRegistry();
+    const schedule = registry.resume(req.params.id, actor as string);
+
+    auditFireAndForget(
+      "FLAG_ROLLOUT_RESUMED",
+      { scheduleId: schedule.id, actor, currentPercentage: schedule.currentPercentage },
+      req,
+      200,
+    );
+
+    return res.status(200).json({ success: true, schedule });
+  } catch (err) {
+    return handleRolloutError(res, err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /:id/rollback
+// ---------------------------------------------------------------------------
+
+router.post("/:id/rollback", requireAdminToken, (req: Request, res: Response) => {
+  const { actor, reason, toStepIndex } = (req.body ?? {}) as {
+    actor?: string;
+    reason?: string;
+    toStepIndex?: number;
+  };
+
+  try {
+    const registry = getRolloutScheduleRegistry();
+    const schedule = registry.rollback({
+      id: req.params.id,
+      actor: actor as string,
+      reason: reason as string,
+      toStepIndex,
+    });
+
+    auditFireAndForget(
+      "FLAG_ROLLOUT_ROLLED_BACK",
+      { scheduleId: schedule.id, actor, reason, currentPercentage: schedule.currentPercentage },
+      req,
+      200,
+    );
+
+    return res.status(200).json({ success: true, schedule });
+  } catch (err) {
+    return handleRolloutError(res, err);
+  }
+});
+
+export default router;

--- a/src/scheduler/__tests__/flagRolloutScheduler.test.ts
+++ b/src/scheduler/__tests__/flagRolloutScheduler.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import { FlagRolloutScheduler, createFlagRolloutScheduler } from "../flagRolloutScheduler.js";
+import { RolloutScheduleRegistry } from "../../flags/rolloutScheduleRegistry.js";
+
+const T0 = "2026-01-01T00:00:00.000Z";
+
+function makeRegistryWithOneStepDueAt(at: string): RolloutScheduleRegistry {
+  const registry = new RolloutScheduleRegistry();
+  registry.create({
+    flag: "CREATE_SLOT",
+    tenantId: "tenant-a",
+    environment: "production",
+    actor: "alice",
+    steps: [{ percentage: 20, at }],
+  });
+  return registry;
+}
+
+describe("FlagRolloutScheduler", () => {
+  describe("runOnce", () => {
+    it("advances due schedules and returns them", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const scheduler = new FlagRolloutScheduler({
+        registry,
+        now: () => new Date(T0),
+      });
+
+      const advanced = scheduler.runOnce();
+      expect(advanced).toHaveLength(1);
+      expect(advanced[0].currentPercentage).toBe(20);
+    });
+
+    it("returns an empty array and skips onAdvance when nothing is due", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const onAdvance = jest.fn();
+      const scheduler = new FlagRolloutScheduler({
+        registry,
+        now: () => new Date(Date.parse(T0) - 60_000),
+        onAdvance,
+      });
+
+      const advanced = scheduler.runOnce();
+      expect(advanced).toHaveLength(0);
+      expect(onAdvance).not.toHaveBeenCalled();
+    });
+
+    it("invokes onAdvance with the advanced schedules", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const onAdvance = jest.fn();
+      const scheduler = new FlagRolloutScheduler({ registry, now: () => new Date(T0), onAdvance });
+
+      scheduler.runOnce();
+      expect(onAdvance).toHaveBeenCalledTimes(1);
+      expect(onAdvance).toHaveBeenCalledWith([
+        expect.objectContaining({ currentPercentage: 20 }),
+      ]);
+    });
+
+    it("uses the real clock by default", () => {
+      const registry = makeRegistryWithOneStepDueAt(new Date(Date.now() - 1000).toISOString());
+      const scheduler = new FlagRolloutScheduler({ registry });
+      expect(scheduler.runOnce()).toHaveLength(1);
+    });
+  });
+
+  describe("start/stop", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("ticks immediately and then on the configured interval", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const onAdvance = jest.fn();
+      const scheduler = new FlagRolloutScheduler({
+        registry,
+        now: () => new Date(T0),
+        runIntervalMs: 1000,
+        onAdvance,
+      });
+
+      scheduler.start();
+      jest.advanceTimersByTime(0);
+      expect(scheduler.getRunCount()).toBe(1);
+      expect(onAdvance).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(1000);
+      expect(scheduler.getRunCount()).toBe(2);
+
+      scheduler.stop();
+    });
+
+    it("is idempotent to call start() twice", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const scheduler = new FlagRolloutScheduler({ registry, now: () => new Date(T0), runIntervalMs: 1000 });
+
+      scheduler.start();
+      scheduler.start();
+      jest.advanceTimersByTime(0);
+      expect(scheduler.getRunCount()).toBe(1);
+      scheduler.stop();
+    });
+
+    it("stops ticking once stop() is called", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const scheduler = new FlagRolloutScheduler({ registry, now: () => new Date(T0), runIntervalMs: 1000 });
+
+      scheduler.start();
+      jest.advanceTimersByTime(0);
+      expect(scheduler.isActive()).toBe(true);
+
+      scheduler.stop();
+      expect(scheduler.isActive()).toBe(false);
+
+      jest.advanceTimersByTime(5000);
+      expect(scheduler.getRunCount()).toBe(1); // no further ticks
+    });
+
+    it("stops itself after maxRuns", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const scheduler = new FlagRolloutScheduler({
+        registry,
+        now: () => new Date(T0),
+        runIntervalMs: 1000,
+        maxRuns: 2,
+      });
+
+      scheduler.start();
+      jest.advanceTimersByTime(0);
+      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1000);
+
+      expect(scheduler.getRunCount()).toBe(2);
+      expect(scheduler.isActive()).toBe(false);
+    });
+
+    it("keeps ticking even if a single tick throws an Error", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      jest.spyOn(registry, "advanceDue").mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+      const scheduler = new FlagRolloutScheduler({ registry, now: () => new Date(T0), runIntervalMs: 1000 });
+
+      scheduler.start();
+      jest.advanceTimersByTime(0); // throws, caught internally
+      expect(scheduler.getRunCount()).toBe(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.any(String), "boom");
+
+      jest.advanceTimersByTime(1000); // should still run normally
+      expect(scheduler.getRunCount()).toBe(2);
+
+      scheduler.stop();
+      errorSpy.mockRestore();
+    });
+
+    it("logs a non-Error thrown value as-is", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      jest.spyOn(registry, "advanceDue").mockImplementationOnce(() => {
+        throw "not-an-error-instance";
+      });
+      const scheduler = new FlagRolloutScheduler({ registry, now: () => new Date(T0), runIntervalMs: 1000 });
+
+      scheduler.start();
+      jest.advanceTimersByTime(0);
+      expect(errorSpy).toHaveBeenCalledWith(expect.any(String), "not-an-error-instance");
+
+      scheduler.stop();
+      errorSpy.mockRestore();
+    });
+
+    it("does not run a tick that fires after stop() was already called", () => {
+      const registry = makeRegistryWithOneStepDueAt(T0);
+      const scheduler = new FlagRolloutScheduler({ registry, now: () => new Date(T0), runIntervalMs: 1000 });
+
+      scheduler.start();
+      scheduler.stop(); // stop before the setTimeout(tick, 0) has a chance to fire
+      jest.advanceTimersByTime(0);
+
+      expect(scheduler.getRunCount()).toBe(0);
+    });
+  });
+
+  describe("createFlagRolloutScheduler", () => {
+    it("builds a scheduler instance", () => {
+      expect(createFlagRolloutScheduler()).toBeInstanceOf(FlagRolloutScheduler);
+    });
+  });
+});

--- a/src/scheduler/flagRolloutScheduler.ts
+++ b/src/scheduler/flagRolloutScheduler.ts
@@ -1,0 +1,107 @@
+/**
+ * flagRolloutScheduler.ts
+ * ------------------------
+ * Periodically advances scheduled feature-flag rollouts (#570) to whatever
+ * step is due. Mirrors the `TierAlertScheduler` shape (see
+ * tierAlertScheduler.ts): a `setTimeout`-chained tick loop with an
+ * injectable registry/clock so tests never depend on real wall-clock time.
+ *
+ * "Missed step" / "outage" safety is handled inside
+ * `RolloutScheduleRegistry.advanceDue` itself — this class just decides
+ * *when* to call it.
+ */
+
+import {
+  getRolloutScheduleRegistry,
+  type RolloutScheduleRegistry,
+} from "../flags/rolloutScheduleRegistry.js";
+import type { RolloutSchedule } from "../flags/rolloutTypes.js";
+
+export interface FlagRolloutSchedulerOptions {
+  registry?: RolloutScheduleRegistry;
+  runIntervalMs?: number;
+  now?: () => Date;
+  onAdvance?: (advanced: RolloutSchedule[]) => void;
+  maxRuns?: number;
+}
+
+const DEFAULT_INTERVAL_MS = 60 * 1000; // 1 minute — fine granularity for step timestamps
+
+export class FlagRolloutScheduler {
+  private registry: RolloutScheduleRegistry;
+  private runIntervalMs: number;
+  private now: () => Date;
+  private onAdvance?: (advanced: RolloutSchedule[]) => void;
+  private maxRuns?: number;
+  private timer: NodeJS.Timeout | null = null;
+  private runCount = 0;
+  private isRunning = false;
+
+  constructor(options: FlagRolloutSchedulerOptions = {}) {
+    this.registry = options.registry ?? getRolloutScheduleRegistry();
+    this.runIntervalMs = options.runIntervalMs ?? DEFAULT_INTERVAL_MS;
+    this.now = options.now ?? (() => new Date());
+    this.onAdvance = options.onAdvance;
+    this.maxRuns = options.maxRuns;
+  }
+
+  runOnce(): RolloutSchedule[] {
+    const advanced = this.registry.advanceDue(this.now());
+    if (advanced.length > 0) {
+      this.onAdvance?.(advanced);
+    }
+    return advanced;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.isRunning = true;
+
+    const tick = (): void => {
+      if (!this.isRunning) return;
+
+      if (this.maxRuns !== undefined && this.runCount >= this.maxRuns) {
+        this.stop();
+        return;
+      }
+
+      try {
+        this.runCount++;
+        this.runOnce();
+      } catch (err) {
+        console.error(
+          "[flag-rollout-scheduler] Advance tick failed:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+
+      if (this.isRunning) {
+        this.timer = setTimeout(tick, this.runIntervalMs);
+      }
+    };
+
+    this.timer = setTimeout(tick, 0);
+  }
+
+  stop(): void {
+    this.isRunning = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  getRunCount(): number {
+    return this.runCount;
+  }
+
+  isActive(): boolean {
+    return this.isRunning;
+  }
+}
+
+export function createFlagRolloutScheduler(
+  options?: FlagRolloutSchedulerOptions,
+): FlagRolloutScheduler {
+  return new FlagRolloutScheduler(options);
+}


### PR DESCRIPTION
## Summary

Closes #570

Adds scheduled, percentage-based feature-flag rollouts on top of the existing boolean flag system (`src/flags`, `src/middleware/featureFlags.ts`), scoped per-tenant and per-environment, with pause and rollback hooks.

- **Schedule model** (`src/flags/rolloutScheduleRegistry.ts`): each schedule is scoped to a `(flag, tenantId, environment)` tuple and ramps through an ordered list of `{ percentage, at }` steps (strictly increasing in both time and percentage). Only one in-flight schedule per tuple at a time; a new one can be created once the previous is `completed` or `rolled_back`.
- **Scheduler** (`src/scheduler/flagRolloutScheduler.ts`): ticks once a minute (configurable via `FLAG_ROLLOUT_INTERVAL_MS`, disable with `FLAG_ROLLOUT_SCHEDULER_DISABLED=true`) and advances every due schedule to its **latest** due step — a missed step or scheduler outage jumps straight to the correct percentage instead of replaying intermediate steps.
- **Evaluation** (`src/flags/rolloutEvaluator.ts`): `isFeatureEnabledForTenant(flag, tenantId, bucketKey, environment?)` layers a deterministic FNV-1a bucket hash on top of the existing boolean flag — the boolean flag remains the fail-closed kill-switch, and a flag with no schedule still behaves exactly as before (100%). Wired into `req.flags.isEnabledForTenant(...)` via the feature-flag middleware.
- **Pause / resume**: pause freezes at the current percentage and is skipped by the scheduler entirely; resume immediately catches up to whatever step is due "now" rather than waiting for the next tick.
- **Rollback**: terminal by design — reverts to an earlier step (defaults to one step back, or pass `toStepIndex` to jump back across multiple steps at once / `-1` for a full revert to 0%), and the scheduler will never advance a rolled-back schedule again. An operator must create a fresh schedule to resume ramping, which is intentional for incident response.
- **Admin API** (`src/routes/flagRollouts.ts`), mounted at `/api/v1/admin/flag-rollouts`, gated by the existing `requireAdminToken` middleware: `POST /`, `GET /`, `GET /:id`, `POST /:id/pause`, `POST /:id/resume`, `POST /:id/rollback`. Mutating actions audit-log via `defaultAuditLogger` and take an explicit `actor` field in the body rather than deriving one from the admin token, so the shared secret is never recorded as an actor identity.
- **Docs**: `docs/feature-flag-rollouts.md` (new) documents the model, evaluation order, and edge-case handling; `docs/feature-flags.md` links to it.

## Test plan

- [x] `src/flags/__tests__/rolloutScheduleRegistry.test.ts` — create validation, advance/missed-step/outage-catchup, pause/resume (including catch-up while paused), rollback (default one-step-back, multi-step, terminal), list/getById/findGoverningSchedule (tenant-specific over wildcard priority)
- [x] `src/flags/__tests__/rolloutEvaluator.test.ts` — bucket hash determinism/distribution, boundary behavior, boolean-flag-as-kill-switch layering, no-schedule fallback to 100%
- [x] `src/scheduler/__tests__/flagRolloutScheduler.test.ts` — runOnce, start/stop/maxRuns, tick error handling
- [x] `src/routes/__tests__/flagRollouts.test.ts` — auth, full CRUD + pause/resume/rollback happy paths and error codes
- [x] `src/flags/__tests__/featureFlags.test.ts` — `req.flags.isEnabledForTenant` middleware wiring
- [x] `npm run typecheck` — no new errors introduced (confirmed against a clean `main` baseline: 165 pre-existing errors before and after this change)
- [x] `npx eslint` on all new/changed files — clean (two pre-existing `src/app.ts` lint errors confirmed unrelated to this change via baseline diff)
- [x] New test files: 120/120 passing, ~99.6% statement / ~95% branch coverage on the new rollout modules

Note: `npm run test:coverage` on this repo currently has ~140 pre-existing failing test suites unrelated to this change (e.g. a duplicate-identifier syntax error in `src/metrics.ts` that breaks Babel parsing for any suite importing it) — confirmed present on a clean `main` checkout before this branch existed. This PR does not touch any of those files and does not add to that failure count.