### PR TITLE
feat: 60s signing-key revocation broadcast

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,5 @@
+import os from "os";
+
 export type NodeEnv = "development" | "test" | "production";
 
 export interface EncryptionKey {
@@ -37,6 +39,25 @@ export interface EnvConfig {
   networkPassphrase?: string;
   /** Pinned hash for the current active escrow contract */
   escrowContractHash?: string;
+
+  // ── Signing-key revocation ────────────────────────────────────────────────
+  /**
+   * Unique identifier for this replica, used in revocation ack messages.
+   * Required when the revocation broadcast feature is active.
+   * Defaults to the hostname or "unknown-replica".
+   */
+  replicaId: string;
+  /**
+   * Minimum fraction of replicas [0.0 – 1.0] that must acknowledge a
+   * revocation within the alarm window before the alarm is suppressed.
+   * Defaults to 0.8.
+   */
+  revocationAckThreshold: number;
+  /**
+   * Duration in milliseconds after which the AlarmService checks ack rate.
+   * Defaults to 60 000 ms.
+   */
+  revocationAlarmWindowMs: number;
 }
 
 export class EnvValidationError extends Error {
@@ -74,6 +95,21 @@ export function loadEnvConfig(env: NodeJS.ProcessEnv = process.env): EnvConfig {
   const networkPassphrase = parseOptionalString(env.STELLAR_NETWORK_PASSPHRASE);
   const escrowContractHash = parseOptionalString(env.ESCROW_CONTRACT_HASH);
 
+  // Revocation settings
+  const replicaId = parseReplicaId(env.REPLICA_ID);
+  const revocationAckThreshold = parseFloat01(
+    env.REVOCATION_ACK_THRESHOLD,
+    "REVOCATION_ACK_THRESHOLD",
+    0.8,
+    issues,
+  );
+  const revocationAlarmWindowMs = parsePositiveInteger(
+    env.REVOCATION_ALARM_WINDOW_MS,
+    "REVOCATION_ALARM_WINDOW_MS",
+    60_000,
+    issues,
+  );
+
   if (issues.length > 0) {
     throw new EnvValidationError(issues);
   }
@@ -93,6 +129,9 @@ export function loadEnvConfig(env: NodeJS.ProcessEnv = process.env): EnvConfig {
     horizonUrl,
     networkPassphrase,
     escrowContractHash,
+    replicaId,
+    revocationAckThreshold,
+    revocationAlarmWindowMs,
   };
 }
 
@@ -238,4 +277,32 @@ function parseOptionalUrl(rawValue: string | undefined, key: string, issues: str
     issues.push(`${key} must be a valid URL.`);
     return undefined;
   }
+}
+
+function parseReplicaId(rawValue: string | undefined): string {
+  if (rawValue === undefined || rawValue.trim().length === 0) {
+    // Fall back to the OS hostname so each pod/container gets a distinct ID
+    // without requiring explicit config.
+    try {
+      return os.hostname();
+    } catch {
+      return "unknown-replica";
+    }
+  }
+  return rawValue.trim();
+}
+
+function parseFloat01(rawValue: string | undefined, key: string, defaultValue: number, issues: string[]): number {
+  if (rawValue === undefined) return defaultValue;
+  const value = rawValue.trim();
+  if (value.length === 0) {
+    issues.push(`${key} must be a number between 0 and 1.`);
+    return defaultValue;
+  }
+  const parsed = Number(value);
+  if (isNaN(parsed) || parsed < 0 || parsed > 1) {
+    issues.push(`${key} must be a number between 0.0 and 1.0.`);
+    return defaultValue;
+  }
+  return parsed;
 }

--- a/src/middleware/rejectRevokedKey.ts
+++ b/src/middleware/rejectRevokedKey.ts
@@ -1,0 +1,61 @@
+/**
+ * rejectRevokedKey middleware
+ *
+ * Rejects any request that presents a signing key ID that has been revoked.
+ * The key ID is expected in the `x-signing-key-id` request header.
+ *
+ * Behaviour
+ * ─────────
+ * - If the header is absent the middleware passes through (other middleware
+ *   handles missing-auth cases).
+ * - If the header is present and the key is revoked, responds 401 with a
+ *   structured error payload.
+ * - If the header is present and the key is NOT revoked, calls next().
+ *
+ * Usage
+ * ─────
+ * ```ts
+ * import { revocationService } from "../services/revocationService.js";
+ * import { rejectRevokedKey }   from "../middleware/rejectRevokedKey.js";
+ *
+ * router.use(rejectRevokedKey(revocationService));
+ * ```
+ *
+ * The header name is `x-signing-key-id` (lowercase, per Express convention).
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import type { RevocationService } from "../services/revocationService.js";
+
+export const SIGNING_KEY_HEADER = "x-signing-key-id";
+
+/**
+ * Returns an Express middleware that rejects requests presenting a revoked
+ * signing key ID.
+ *
+ * @param revocationService  A started RevocationService instance.
+ */
+export function rejectRevokedKey(revocationService: RevocationService) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keyId = req.headers[SIGNING_KEY_HEADER];
+
+    // Header absent — not our concern; let auth middleware handle it.
+    if (!keyId) {
+      next();
+      return;
+    }
+
+    const id = Array.isArray(keyId) ? keyId[0] : keyId;
+
+    if (revocationService.isRevoked(id)) {
+      res.status(401).json({
+        success: false,
+        code: "KEY_REVOKED",
+        error: "The signing key presented has been revoked.",
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/services/__tests__/ackTracker.test.ts
+++ b/src/services/__tests__/ackTracker.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for AckTracker
+ *
+ * Covers:
+ * - recordAck writes to correct Redis hash key with TTL
+ * - recordAck validates keyId and replicaId
+ * - getAcks returns all ack entries
+ * - getAcks returns empty array when key missing
+ * - getAckRate happy path
+ * - getAckRate when no acks (returns 0)
+ * - getAckRate with knownReplicaCount=0 (vacuously 1.0)
+ * - Multiple replicas acking the same keyId
+ * - Custom prefix and TTL options
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { AckTracker, type AckRedisClient } from "../ackTracker.js";
+import type { RevocationAck } from "../revocationService.js";
+
+// ─── Fake Redis ───────────────────────────────────────────────────────────────
+
+class FakeAckRedis implements AckRedisClient {
+  private hashes = new Map<string, Map<string, string>>();
+  ttlCalls: Array<{ key: string; seconds: number }> = [];
+
+  async hset(key: string, field: string, value: string): Promise<number> {
+    if (!this.hashes.has(key)) this.hashes.set(key, new Map());
+    const wasNew = !this.hashes.get(key)!.has(field);
+    this.hashes.get(key)!.set(field, value);
+    return wasNew ? 1 : 0;
+  }
+
+  async hgetall(key: string): Promise<Record<string, string> | null> {
+    const map = this.hashes.get(key);
+    if (!map || map.size === 0) return null;
+    return Object.fromEntries(map.entries());
+  }
+
+  async expire(key: string, seconds: number): Promise<number> {
+    this.ttlCalls.push({ key, seconds });
+    return 1;
+  }
+
+  /** Test helper: simulate expired/missing key */
+  deleteKey(key: string): void {
+    this.hashes.delete(key);
+  }
+}
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+function makeTracker(opts?: { prefix?: string; ttl?: number }) {
+  const redis = new FakeAckRedis();
+  const tracker = new AckTracker({
+    redis,
+    keyPrefix: opts?.prefix,
+    ttlSeconds: opts?.ttl,
+  });
+  return { redis, tracker };
+}
+
+function makeAck(keyId: string, replicaId: string): RevocationAck {
+  return { keyId, replicaId, ackedAt: new Date().toISOString() };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("AckTracker — recordAck()", () => {
+  it("stores ack under the correct hash key", async () => {
+    const { redis, tracker } = makeTracker();
+    await tracker.recordAck(makeAck("key-1", "replica-A"));
+
+    const raw = await redis.hgetall("revoke:ack:key-1");
+    expect(raw).not.toBeNull();
+    expect(Object.keys(raw!)).toContain("replica-A");
+  });
+
+  it("sets TTL after writing", async () => {
+    const { redis, tracker } = makeTracker({ ttl: 70 });
+    await tracker.recordAck(makeAck("key-1", "replica-A"));
+
+    expect(redis.ttlCalls).toHaveLength(1);
+    expect(redis.ttlCalls[0]).toEqual({ key: "revoke:ack:key-1", seconds: 70 });
+  });
+
+  it("uses default TTL of 70 when not specified", async () => {
+    const { redis, tracker } = makeTracker();
+    await tracker.recordAck(makeAck("key-ttl", "r1"));
+    expect(redis.ttlCalls[0].seconds).toBe(70);
+  });
+
+  it("uses custom key prefix", async () => {
+    const { redis, tracker } = makeTracker({ prefix: "custom:prefix:" });
+    await tracker.recordAck(makeAck("key-2", "r1"));
+
+    const raw = await redis.hgetall("custom:prefix:key-2");
+    expect(raw).not.toBeNull();
+  });
+
+  it("multiple replicas acking the same key are stored under different fields", async () => {
+    const { redis, tracker } = makeTracker();
+    await tracker.recordAck(makeAck("key-multi", "r1"));
+    await tracker.recordAck(makeAck("key-multi", "r2"));
+    await tracker.recordAck(makeAck("key-multi", "r3"));
+
+    const raw = await redis.hgetall("revoke:ack:key-multi");
+    expect(Object.keys(raw!)).toHaveLength(3);
+  });
+
+  it("throws when keyId is empty", async () => {
+    const { tracker } = makeTracker();
+    await expect(tracker.recordAck(makeAck("", "r1"))).rejects.toThrow("keyId must be non-empty");
+  });
+
+  it("throws when keyId is whitespace only", async () => {
+    const { tracker } = makeTracker();
+    await expect(tracker.recordAck(makeAck("   ", "r1"))).rejects.toThrow("keyId must be non-empty");
+  });
+
+  it("throws when replicaId is empty", async () => {
+    const { tracker } = makeTracker();
+    await expect(tracker.recordAck(makeAck("key-x", ""))).rejects.toThrow("replicaId must be non-empty");
+  });
+});
+
+describe("AckTracker — getAcks()", () => {
+  it("returns all ack entries for a key", async () => {
+    const { tracker } = makeTracker();
+    const now = new Date().toISOString();
+    await tracker.recordAck({ keyId: "key-A", replicaId: "r1", ackedAt: now });
+    await tracker.recordAck({ keyId: "key-A", replicaId: "r2", ackedAt: now });
+
+    const acks = await tracker.getAcks("key-A");
+    expect(acks).toHaveLength(2);
+    expect(acks.map((a) => a.replicaId).sort()).toEqual(["r1", "r2"]);
+  });
+
+  it("returns empty array when no acks exist", async () => {
+    const { tracker } = makeTracker();
+    const acks = await tracker.getAcks("non-existent-key");
+    expect(acks).toEqual([]);
+  });
+
+  it("returns empty array after key has been deleted (simulated TTL)", async () => {
+    const { redis, tracker } = makeTracker();
+    await tracker.recordAck(makeAck("key-expired", "r1"));
+    redis.deleteKey("revoke:ack:key-expired");
+
+    const acks = await tracker.getAcks("key-expired");
+    expect(acks).toEqual([]);
+  });
+});
+
+describe("AckTracker — getAckRate()", () => {
+  it("returns 1.0 when all known replicas have acked", async () => {
+    const { tracker } = makeTracker();
+    await tracker.recordAck(makeAck("key-R", "r1"));
+    await tracker.recordAck(makeAck("key-R", "r2"));
+
+    expect(await tracker.getAckRate("key-R", 2)).toBe(1.0);
+  });
+
+  it("returns 0.5 when half of replicas have acked", async () => {
+    const { tracker } = makeTracker();
+    await tracker.recordAck(makeAck("key-half", "r1"));
+
+    expect(await tracker.getAckRate("key-half", 2)).toBe(0.5);
+  });
+
+  it("returns 0 when no acks exist", async () => {
+    const { tracker } = makeTracker();
+    expect(await tracker.getAckRate("key-none", 5)).toBe(0);
+  });
+
+  it("returns 1.0 when knownReplicaCount is 0 (vacuously satisfied)", async () => {
+    const { tracker } = makeTracker();
+    expect(await tracker.getAckRate("key-zero", 0)).toBe(1.0);
+  });
+
+  it("handles partial ack — 3 of 5 replicas", async () => {
+    const { tracker } = makeTracker();
+    for (const r of ["r1", "r2", "r3"]) {
+      await tracker.recordAck(makeAck("key-partial", r));
+    }
+    expect(await tracker.getAckRate("key-partial", 5)).toBeCloseTo(0.6);
+  });
+
+  it("ack rate can exceed 1.0 if more replicas than expected acked (not clamped)", async () => {
+    // This is intentional — AlarmService should not alarm in this case
+    const { tracker } = makeTracker();
+    await tracker.recordAck(makeAck("key-extra", "r1"));
+    await tracker.recordAck(makeAck("key-extra", "r2"));
+    await tracker.recordAck(makeAck("key-extra", "r3"));
+
+    // 3 acks but only 2 expected
+    expect(await tracker.getAckRate("key-extra", 2)).toBeCloseTo(1.5);
+  });
+});

--- a/src/services/__tests__/revocationService.test.ts
+++ b/src/services/__tests__/revocationService.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for RevocationService
+ *
+ * Covers:
+ * - Happy-path broadcast and local enforcement
+ * - Ack published on receive
+ * - Idempotent start()
+ * - revoke() validation (empty keyId)
+ * - Malformed message handling
+ * - Missing keyId field
+ * - Unknown / never-seen key treated as not-revoked
+ * - getRevokedKeys() snapshot
+ * - Publisher error surfaced via 'error' event
+ */
+
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import EventEmitter from "events";
+import {
+  RevocationService,
+  REVOCATION_CHANNEL,
+  ACK_CHANNEL,
+  type RevocationMessage,
+  type RevocationAck,
+  type RevocationPublisher,
+  type RevocationSubscriber,
+} from "../revocationService.js";
+
+// ─── Fake pub/sub helpers ────────────────────────────────────────────────────
+
+/**
+ * FakeRedis acts as both publisher and subscriber.
+ * Calling subscribe() records the channel; calling simulateMessage() fires
+ * the registered "message" listeners synchronously.
+ */
+class FakeRedis extends EventEmitter implements RevocationPublisher, RevocationSubscriber {
+  publishedMessages: Array<{ channel: string; message: string }> = [];
+  publishError: Error | null = null;
+
+  async publish(channel: string, message: string): Promise<number> {
+    if (this.publishError) throw this.publishError;
+    this.publishedMessages.push({ channel, message });
+    return 1;
+  }
+
+  async subscribe(_channel: string): Promise<unknown> {
+    return 1;
+  }
+
+  /** Simulate an inbound pub/sub message arriving on this connection. */
+  simulateMessage(channel: string, message: string): void {
+    this.emit("message", channel, message);
+  }
+}
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+function makeService(replicaId = "replica-1") {
+  const fake = new FakeRedis();
+  const service = new RevocationService({
+    replicaId,
+    publisher: fake,
+    subscriber: fake,
+  });
+  return { service, fake };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("RevocationService — start() and subscribe", () => {
+  it("subscribes to the default broadcast channel", async () => {
+    const { fake, service } = makeService();
+    const subscribeSpy = jest.spyOn(fake, "subscribe");
+    await service.start();
+    expect(subscribeSpy).toHaveBeenCalledWith(REVOCATION_CHANNEL);
+  });
+
+  it("start() is idempotent — subscribes only once", async () => {
+    const { fake, service } = makeService();
+    const subscribeSpy = jest.spyOn(fake, "subscribe");
+    await service.start();
+    await service.start();
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("RevocationService — revoke() broadcast", () => {
+  it("publishes to the broadcast channel", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+    await service.revoke("key-abc");
+    expect(fake.publishedMessages).toHaveLength(1);
+    expect(fake.publishedMessages[0].channel).toBe(REVOCATION_CHANNEL);
+  });
+
+  it("published payload contains keyId and revokedAt", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+    const before = Date.now();
+    await service.revoke("key-xyz", "COMPROMISED");
+    const msg: RevocationMessage = JSON.parse(fake.publishedMessages[0].message);
+    expect(msg.keyId).toBe("key-xyz");
+    expect(msg.reason).toBe("COMPROMISED");
+    expect(new Date(msg.revokedAt).getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it("trims whitespace from keyId before publishing", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+    await service.revoke("  key-trim  ");
+    const msg: RevocationMessage = JSON.parse(fake.publishedMessages[0].message);
+    expect(msg.keyId).toBe("key-trim");
+  });
+
+  it("throws on empty keyId", async () => {
+    const { service } = makeService();
+    await service.start();
+    await expect(service.revoke("")).rejects.toThrow("keyId must be a non-empty string");
+  });
+
+  it("throws on whitespace-only keyId", async () => {
+    const { service } = makeService();
+    await service.start();
+    await expect(service.revoke("   ")).rejects.toThrow("keyId must be a non-empty string");
+  });
+});
+
+describe("RevocationService — receive and enforce", () => {
+  it("marks key as revoked on receiving a valid message", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    const msg: RevocationMessage = { keyId: "key-1", revokedAt: new Date().toISOString() };
+    fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify(msg));
+
+    expect(service.isRevoked("key-1")).toBe(true);
+  });
+
+  it("emits 'revoked' event with the parsed message", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    const received: RevocationMessage[] = [];
+    service.on("revoked", (m: RevocationMessage) => received.push(m));
+
+    const msg: RevocationMessage = { keyId: "key-2", revokedAt: new Date().toISOString() };
+    fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify(msg));
+
+    expect(received).toHaveLength(1);
+    expect(received[0].keyId).toBe("key-2");
+  });
+
+  it("publishes an ack on the ack channel", async () => {
+    const { fake, service } = makeService("replica-A");
+    await service.start();
+
+    const msg: RevocationMessage = { keyId: "key-3", revokedAt: new Date().toISOString() };
+    fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify(msg));
+
+    // The ack publish is fire-and-forget; flush micro-task queue
+    await Promise.resolve();
+
+    const ackPub = fake.publishedMessages.find((p) => p.channel === ACK_CHANNEL);
+    expect(ackPub).toBeDefined();
+    const ack: RevocationAck = JSON.parse(ackPub!.message);
+    expect(ack.keyId).toBe("key-3");
+    expect(ack.replicaId).toBe("replica-A");
+    expect(typeof ack.ackedAt).toBe("string");
+  });
+
+  it("ignores messages on unrelated channels", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    fake.simulateMessage("other:channel", JSON.stringify({ keyId: "key-x", revokedAt: "" }));
+    expect(service.isRevoked("key-x")).toBe(false);
+  });
+
+  it("unknown key (never-seen) is not revoked", async () => {
+    const { service } = makeService();
+    await service.start();
+    expect(service.isRevoked("no-such-key")).toBe(false);
+  });
+});
+
+describe("RevocationService — malformed messages", () => {
+  it("emits 'error' on non-JSON payload", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    const errors: Error[] = [];
+    service.on("error", (e: Error) => errors.push(e));
+
+    fake.simulateMessage(REVOCATION_CHANNEL, "NOT_JSON{{");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("malformed message");
+  });
+
+  it("emits 'error' when keyId is missing", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    const errors: Error[] = [];
+    service.on("error", (e: Error) => errors.push(e));
+
+    fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify({ revokedAt: new Date().toISOString() }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("missing keyId");
+  });
+
+  it("emits 'error' when keyId is empty string", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    const errors: Error[] = [];
+    service.on("error", (e: Error) => errors.push(e));
+
+    fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify({ keyId: "  ", revokedAt: "" }));
+
+    expect(errors).toHaveLength(1);
+  });
+
+  it("does not revoke anything when message is malformed", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+    service.on("error", () => {}); // swallow
+
+    fake.simulateMessage(REVOCATION_CHANNEL, "GARBAGE");
+    expect(service.getRevokedKeys().size).toBe(0);
+  });
+});
+
+describe("RevocationService — ack publish failure", () => {
+  it("emits 'error' when ack publish throws", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    const errors: Error[] = [];
+    service.on("error", (e: Error) => errors.push(e));
+
+    fake.publishError = new Error("Redis disconnected");
+
+    const msg: RevocationMessage = { keyId: "key-fail", revokedAt: new Date().toISOString() };
+    fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify(msg));
+
+    await Promise.resolve(); // flush async ack publish
+
+    // Key should still be revoked locally even if ack fails
+    expect(service.isRevoked("key-fail")).toBe(true);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("RevocationService — getRevokedKeys()", () => {
+  it("returns a snapshot of all revoked key IDs", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    for (const id of ["k1", "k2", "k3"]) {
+      const msg: RevocationMessage = { keyId: id, revokedAt: new Date().toISOString() };
+      fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify(msg));
+    }
+
+    const snapshot = service.getRevokedKeys();
+    expect(snapshot.size).toBe(3);
+    expect(snapshot.has("k1")).toBe(true);
+    expect(snapshot.has("k2")).toBe(true);
+    expect(snapshot.has("k3")).toBe(true);
+  });
+
+  it("same key revoked twice is stored once", async () => {
+    const { fake, service } = makeService();
+    await service.start();
+
+    const msg: RevocationMessage = { keyId: "dup", revokedAt: new Date().toISOString() };
+    fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify(msg));
+    fake.simulateMessage(REVOCATION_CHANNEL, JSON.stringify(msg));
+
+    expect(service.getRevokedKeys().size).toBe(1);
+  });
+});

--- a/src/services/ackTracker.ts
+++ b/src/services/ackTracker.ts
@@ -1,0 +1,120 @@
+/**
+ * AckTracker
+ *
+ * Persists per-replica acknowledgements for each revocation event in Redis
+ * so that operators can review which replicas acknowledged within the SLA
+ * window after an incident.
+ *
+ * Storage layout
+ * ──────────────
+ * Key  : `revoke:ack:<keyId>`   (Redis Hash)
+ * Field: `<replicaId>`
+ * Value: ISO-8601 timestamp when the ack was received
+ *
+ * Each key is set with a TTL slightly larger than the alarm window (70 s by
+ * default) to guarantee the AlarmService can still read acks at the end of
+ * the 60 s window even with small clock skew.  The TTL is refreshed on every
+ * write to the hash.
+ *
+ * Ack rate
+ * ────────
+ * `getAckRate(keyId, knownReplicaCount)` returns the fraction of known
+ * replicas that have acknowledged, which AlarmService uses to decide whether
+ * to fire an alarm.
+ */
+
+import type { RevocationAck } from "./revocationService.js";
+
+// ─── Interface ───────────────────────────────────────────────────────────────
+
+/**
+ * Minimal Redis surface required by AckTracker.
+ * Tests inject an in-memory fake implementing this interface.
+ */
+export interface AckRedisClient {
+  /** Redis HSET (ioredis variadic form: hset(key, field, value, …)) */
+  hset(key: string, field: string, value: string): Promise<number>;
+  /** Redis HGETALL */
+  hgetall(key: string): Promise<Record<string, string> | null>;
+  /** Redis EXPIRE (seconds) */
+  expire(key: string, seconds: number): Promise<number>;
+}
+
+export interface AckTrackerOptions {
+  redis: AckRedisClient;
+  /** Key prefix. Defaults to "revoke:ack:". */
+  keyPrefix?: string;
+  /**
+   * TTL in seconds applied to each ack hash after every write.
+   * Should be >= alarmWindowMs / 1000 + some safety margin.
+   * Defaults to 70 s.
+   */
+  ttlSeconds?: number;
+}
+
+// ─── AckEntry ────────────────────────────────────────────────────────────────
+
+export interface AckEntry {
+  replicaId: string;
+  ackedAt: string;
+}
+
+// ─── AckTracker ──────────────────────────────────────────────────────────────
+
+export class AckTracker {
+  private readonly redis: AckRedisClient;
+  private readonly keyPrefix: string;
+  private readonly ttlSeconds: number;
+
+  constructor(opts: AckTrackerOptions) {
+    this.redis = opts.redis;
+    this.keyPrefix = opts.keyPrefix ?? "revoke:ack:";
+    this.ttlSeconds = opts.ttlSeconds ?? 70;
+  }
+
+  /**
+   * Record that `replicaId` acknowledged revocation of `keyId`.
+   *
+   * Uses two commands: HSET + EXPIRE. The EXPIRE is re-applied on every write
+   * so the TTL slides forward if the same key gets re-revoked.
+   */
+  async recordAck(ack: RevocationAck): Promise<void> {
+    const { keyId, replicaId, ackedAt } = ack;
+
+    if (!keyId || keyId.trim().length === 0) {
+      throw new Error("AckTracker.recordAck: keyId must be non-empty");
+    }
+    if (!replicaId || replicaId.trim().length === 0) {
+      throw new Error("AckTracker.recordAck: replicaId must be non-empty");
+    }
+
+    const redisKey = this.keyPrefix + keyId.trim();
+    await this.redis.hset(redisKey, replicaId.trim(), ackedAt);
+    await this.redis.expire(redisKey, this.ttlSeconds);
+  }
+
+  /**
+   * Return all ack entries for a given revoked key.
+   * Returns an empty array if no acks exist (key missing or expired).
+   */
+  async getAcks(keyId: string): Promise<AckEntry[]> {
+    const redisKey = this.keyPrefix + keyId.trim();
+    const raw = await this.redis.hgetall(redisKey);
+    if (!raw) return [];
+
+    return Object.entries(raw).map(([replicaId, ackedAt]) => ({ replicaId, ackedAt }));
+  }
+
+  /**
+   * Returns the fraction of `knownReplicaCount` replicas that have acked.
+   *
+   * - If knownReplicaCount is 0, returns 1.0 (vacuously satisfied).
+   * - If no acks exist at all, returns 0.
+   */
+  async getAckRate(keyId: string, knownReplicaCount: number): Promise<number> {
+    if (knownReplicaCount <= 0) return 1.0;
+
+    const acks = await this.getAcks(keyId);
+    return acks.length / knownReplicaCount;
+  }
+}

--- a/src/services/alarmService.ts
+++ b/src/services/alarmService.ts
@@ -1,0 +1,147 @@
+/**
+ * AlarmService
+ *
+ * Watches in-flight signing-key revocations and emits an `alarm` event when
+ * the per-key ack rate falls below the configured threshold at the end of the
+ * 60 s SLA window.
+ *
+ * Flow
+ * ────
+ * 1. Call `trackRevocation(keyId)` immediately after broadcasting a revocation.
+ * 2. The service schedules a one-shot check at `alarmWindowMs` (default 60 000 ms).
+ * 3. At deadline the ack rate is computed via `AckTracker.getAckRate()`.
+ * 4. If rate < `threshold`, `alarm` is emitted with an `AlarmPayload`.
+ * 5. Timers are cleaned up on `destroy()`.
+ *
+ * Event: `alarm`  →  AlarmPayload
+ *
+ * Design notes
+ * ────────────
+ * - No persistent state: if the process restarts mid-window the alarm is lost.
+ *   This is acceptable because the goal is real-time alerting, not auditing.
+ *   Post-incident review uses the AckTracker Redis hashes directly.
+ * - The service intentionally does NOT talk to a pager/webhook itself; callers
+ *   wire the `alarm` event to their alerting pipeline.
+ */
+
+import EventEmitter from "events";
+import type { AckTracker } from "./ackTracker.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface AlarmPayload {
+  keyId: string;
+  ackRate: number;
+  threshold: number;
+  knownReplicaCount: number;
+  checkedAt: string;
+  windowMs: number;
+}
+
+export interface AlarmServiceOptions {
+  ackTracker: AckTracker;
+  /**
+   * Total number of replicas that should ack. Used to compute the ack rate.
+   * Must be >= 1.
+   */
+  knownReplicaCount: number;
+  /**
+   * Minimum ack rate [0.0 – 1.0] required to suppress the alarm.
+   * Defaults to 0.8.
+   */
+  threshold?: number;
+  /**
+   * How long (ms) to wait before checking the ack rate.
+   * Defaults to 60 000 ms.
+   */
+  alarmWindowMs?: number;
+}
+
+// ─── AlarmService ─────────────────────────────────────────────────────────────
+
+export class AlarmService extends EventEmitter {
+  private readonly ackTracker: AckTracker;
+  private readonly knownReplicaCount: number;
+  private readonly threshold: number;
+  private readonly alarmWindowMs: number;
+
+  /** Map of keyId → NodeJS.Timeout so we can cancel on destroy(). */
+  private readonly pending = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(opts: AlarmServiceOptions) {
+    super();
+
+    if (opts.knownReplicaCount < 1) {
+      throw new RangeError("AlarmService: knownReplicaCount must be >= 1");
+    }
+
+    this.ackTracker = opts.ackTracker;
+    this.knownReplicaCount = opts.knownReplicaCount;
+    this.threshold = opts.threshold ?? 0.8;
+    this.alarmWindowMs = opts.alarmWindowMs ?? 60_000;
+
+    if (this.threshold < 0 || this.threshold > 1) {
+      throw new RangeError("AlarmService: threshold must be between 0.0 and 1.0");
+    }
+  }
+
+  /**
+   * Register a revocation event for alarm tracking.
+   * Schedules a one-shot ack-rate check after `alarmWindowMs`.
+   * If the key is already tracked the existing timer is preserved (idempotent).
+   */
+  trackRevocation(keyId: string): void {
+    if (!keyId || keyId.trim().length === 0) {
+      throw new Error("AlarmService.trackRevocation: keyId must be non-empty");
+    }
+    const id = keyId.trim();
+    if (this.pending.has(id)) return; // already tracking
+
+    const timer = setTimeout(() => {
+      this.pending.delete(id);
+      this._checkAckRate(id).catch((err: unknown) => {
+        this.emit("error", err instanceof Error ? err : new Error(String(err)));
+      });
+    }, this.alarmWindowMs);
+
+    // Allow the Node.js process to exit even if this timer is pending.
+    if (typeof timer.unref === "function") timer.unref();
+
+    this.pending.set(id, timer);
+  }
+
+  /**
+   * Cancel all pending timers. Call when shutting down the service.
+   */
+  destroy(): void {
+    for (const timer of this.pending.values()) {
+      clearTimeout(timer);
+    }
+    this.pending.clear();
+  }
+
+  /**
+   * Returns the number of revocations currently being tracked.
+   */
+  pendingCount(): number {
+    return this.pending.size;
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private async _checkAckRate(keyId: string): Promise<void> {
+    const ackRate = await this.ackTracker.getAckRate(keyId, this.knownReplicaCount);
+
+    if (ackRate < this.threshold) {
+      const payload: AlarmPayload = {
+        keyId,
+        ackRate,
+        threshold: this.threshold,
+        knownReplicaCount: this.knownReplicaCount,
+        checkedAt: new Date().toISOString(),
+        windowMs: this.alarmWindowMs,
+      };
+      this.emit("alarm", payload);
+    }
+  }
+}

--- a/src/services/revocationService.ts
+++ b/src/services/revocationService.ts
@@ -1,0 +1,224 @@
+/**
+ * RevocationService
+ *
+ * Broadcasts signing-key revocations to all replicas in under 60 seconds via
+ * Redis pub/sub, enforces revocations locally in-memory, and sends per-replica
+ * acknowledgements back through a dedicated ack channel.
+ *
+ * Design
+ * ──────
+ * - A **publisher** Redis connection is used for PUBLISH commands.
+ * - A **subscriber** Redis connection is dedicated to SUBSCRIBE (ioredis
+ *   moves a connection into subscriber mode on the first subscribe() call,
+ *   after which it can't issue regular commands).
+ * - Revoked key IDs are stored in an in-memory `Set` so `isRevoked()` is
+ *   O(1) and never hits Redis on the hot path.
+ * - On receiving a revocation message this replica:
+ *     1. Adds the key ID to the local revoked set.
+ *     2. Emits the `revoked` event (for internal listeners).
+ *     3. Publishes an ack to the ack channel.
+ * - The service is intentionally decoupled from HTTP — it can be started once
+ *   at app boot and shared across middleware.
+ *
+ * Channel protocol
+ * ────────────────
+ * Broadcast channel : `revoke:signing-keys`
+ * Payload           : JSON – RevocationMessage
+ *
+ * Ack channel       : `revoke:signing-keys:ack`
+ * Payload           : JSON – RevocationAck
+ *
+ * Both channels use the same JSON envelope for forward-compatibility.
+ */
+
+import EventEmitter from "events";
+import { createRequire } from "module";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface RevocationMessage {
+  /** The signing key ID being revoked. */
+  keyId: string;
+  /** ISO-8601 timestamp when the revocation was initiated. */
+  revokedAt: string;
+  /** Arbitrary reason code (e.g. "COMPROMISED", "EXPIRED"). */
+  reason?: string;
+}
+
+export interface RevocationAck {
+  keyId: string;
+  replicaId: string;
+  ackedAt: string;
+}
+
+/**
+ * Minimal Redis surface required by RevocationService.
+ * The publisher needs publish; the subscriber needs subscribe/on.
+ * Tests inject fakes that satisfy this interface.
+ */
+export interface RevocationPublisher {
+  publish(channel: string, message: string): Promise<number>;
+}
+
+export interface RevocationSubscriber {
+  subscribe(channel: string): Promise<unknown>;
+  on(event: "message", handler: (channel: string, message: string) => void): this;
+  on(event: string, handler: (...args: unknown[]) => void): this;
+}
+
+export interface RevocationServiceOptions {
+  /** Identifies this replica in ack payloads. */
+  replicaId: string;
+  /** Redis client used for publishing (regular commands). */
+  publisher: RevocationPublisher;
+  /** Redis client used for subscribing (subscriber mode). */
+  subscriber: RevocationSubscriber;
+  /** Pub/sub channel name. Defaults to "revoke:signing-keys". */
+  broadcastChannel?: string;
+  /** Ack channel name. Defaults to "revoke:signing-keys:ack". */
+  ackChannel?: string;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+export const REVOCATION_CHANNEL = "revoke:signing-keys";
+export const ACK_CHANNEL = "revoke:signing-keys:ack";
+
+// ─── Service ─────────────────────────────────────────────────────────────────
+
+export class RevocationService extends EventEmitter {
+  private readonly replicaId: string;
+  private readonly publisher: RevocationPublisher;
+  private readonly subscriber: RevocationSubscriber;
+  private readonly broadcastChannel: string;
+  private readonly ackChannel: string;
+
+  /** In-memory set of revoked key IDs. Hot-path lookup is O(1). */
+  private readonly revokedKeys = new Set<string>();
+
+  private subscribed = false;
+
+  constructor(opts: RevocationServiceOptions) {
+    super();
+    this.replicaId = opts.replicaId;
+    this.publisher = opts.publisher;
+    this.subscriber = opts.subscriber;
+    this.broadcastChannel = opts.broadcastChannel ?? REVOCATION_CHANNEL;
+    this.ackChannel = opts.ackChannel ?? ACK_CHANNEL;
+  }
+
+  /**
+   * Attach the message listener and subscribe to the broadcast channel.
+   * Call once at startup. Safe to call multiple times (idempotent).
+   */
+  async start(): Promise<void> {
+    if (this.subscribed) return;
+    this.subscribed = true;
+
+    this.subscriber.on("message", (channel, message) => {
+      if (channel !== this.broadcastChannel) return;
+      this._handleMessage(message);
+    });
+
+    await this.subscriber.subscribe(this.broadcastChannel);
+  }
+
+  /**
+   * Broadcast a revocation to all replicas.
+   *
+   * @param keyId   The signing key ID to revoke.
+   * @param reason  Optional human-readable reason.
+   */
+  async revoke(keyId: string, reason?: string): Promise<void> {
+    if (!keyId || keyId.trim().length === 0) {
+      throw new Error("keyId must be a non-empty string");
+    }
+
+    const message: RevocationMessage = {
+      keyId: keyId.trim(),
+      revokedAt: new Date().toISOString(),
+      reason,
+    };
+
+    await this.publisher.publish(this.broadcastChannel, JSON.stringify(message));
+  }
+
+  /**
+   * Returns true if the given key ID has been revoked on this replica.
+   * O(1) — never hits Redis.
+   */
+  isRevoked(keyId: string): boolean {
+    return this.revokedKeys.has(keyId);
+  }
+
+  /**
+   * Expose the current revoked key IDs (read-only snapshot).
+   * Useful for diagnostics and health checks.
+   */
+  getRevokedKeys(): ReadonlySet<string> {
+    return this.revokedKeys;
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private _handleMessage(raw: string): void {
+    let msg: RevocationMessage;
+
+    try {
+      msg = JSON.parse(raw) as RevocationMessage;
+    } catch {
+      this.emit("error", new Error(`RevocationService: malformed message: ${raw}`));
+      return;
+    }
+
+    if (!msg.keyId || typeof msg.keyId !== "string") {
+      this.emit("error", new Error(`RevocationService: missing keyId in message: ${raw}`));
+      return;
+    }
+
+    const keyId = msg.keyId.trim();
+    if (keyId.length === 0) {
+      this.emit("error", new Error(`RevocationService: empty keyId in message`));
+      return;
+    }
+
+    // 1. Enforce locally.
+    this.revokedKeys.add(keyId);
+
+    // 2. Notify internal listeners.
+    this.emit("revoked", msg);
+
+    // 3. Acknowledge back on the ack channel (fire-and-forget).
+    const ack: RevocationAck = {
+      keyId,
+      replicaId: this.replicaId,
+      ackedAt: new Date().toISOString(),
+    };
+    this.publisher.publish(this.ackChannel, JSON.stringify(ack)).catch((err: unknown) => {
+      this.emit("error", err instanceof Error ? err : new Error(String(err)));
+    });
+  }
+}
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+/**
+ * Create a RevocationService backed by two dedicated ioredis connections
+ * (one publisher, one subscriber).  Should be called once at app startup.
+ *
+ * Only used in production — tests inject fakes via the constructor.
+ */
+export function createRevocationService(
+  replicaId: string,
+  redisUrl: string,
+): RevocationService {
+  const require = createRequire(import.meta.url);
+  const { Redis } = require("ioredis") as {
+    Redis: new (url: string) => RevocationPublisher & RevocationSubscriber;
+  };
+
+  const publisher = new Redis(redisUrl);
+  const subscriber = new Redis(redisUrl);
+
+  return new RevocationService({ replicaId, publisher, subscriber });
+}


### PR DESCRIPTION
- RevocationService: Redis pub/sub broadcast + local in-memory enforcement
- AckTracker: per-replica ack storage in Redis HSET with TTL
- AlarmService: emits 'alarm' event when ack rate falls below threshold
- rejectRevokedKey middleware: 401 on revoked signing key header
- env.ts: REPLICA_ID, REVOCATION_ACK_THRESHOLD, REVOCATION_ALARM_WINDOW_MS
- Tests: revocationService and ackTracker unit tests
- closes #525