### PR TITLE
feat: partial unique index for active booking-intents per slot

### DIFF
--- a/scripts/test-graph.json
+++ b/scripts/test-graph.json
@@ -444,6 +444,15 @@
     "src/__tests__/db/connection.test.ts"
   ],
 
+  "src/db/migrations/019_add_active_booking_intent_unique_idx.ts": [
+    "src/__tests__/db/connection.test.ts",
+    "src/modules/booking-intents/__tests__/pg-booking-intent-repository.test.ts"
+  ],
+
+  "src/modules/booking-intents/pg-booking-intent-repository.ts": [
+    "src/modules/booking-intents/__tests__/pg-booking-intent-repository.test.ts"
+  ],
+
   "src/db/driftDetector.ts": [
     "src/__tests__/db/connection.test.ts"
   ],

--- a/src/__tests__/booking-intents.test.ts
+++ b/src/__tests__/booking-intents.test.ts
@@ -5,6 +5,8 @@ import {
   InMemoryBookingIntentRepository,
   type BookingIntentRecord,
 } from "../modules/booking-intents/booking-intent-repository.js";
+import { BookingIntentService } from "../modules/booking-intents/booking-intent-service.js";
+import { InMemorySlotRepository } from "../modules/slots/slot-repository.js";
 
 // Minimal valid intent fields (minus id, which the repo assigns)
 const BASE_INTENT: Omit<BookingIntentRecord, "id"> = {
@@ -16,6 +18,10 @@ const BASE_INTENT: Omit<BookingIntentRecord, "id"> = {
   status: "pending",
   createdAt: new Date().toISOString(),
 };
+
+// Slot seeded in InMemorySlotRepository's DEFAULT_SLOTS that is bookable
+// and owned by "alice" (not "user1" or "user2"), so no self-booking conflict.
+const ALICE_SLOT_ID = "slot-11111111-1111-4111-8111-111111111111";
 
 describe("booking intents endpoints", () => {
   let app: express.Express;
@@ -125,5 +131,96 @@ describe("booking intents endpoints", () => {
       const res = await request(app).get("/api/v1/booking-intents");
       expect(res.status).toBe(401);
     });
+  });
+});
+
+// ─── Concurrent-create: at-most-one active intent per slot ───────────────────
+//
+// The partial unique index (migration 019) is the DB-level guarantee.
+// This suite verifies the same invariant at the service layer, which the
+// index mirrors: exactly one of N concurrent creates for the same slot wins;
+// the rest receive 409 CONFLICT.
+//
+// The "after terminal state" case verifies that the partial index (and the
+// in-memory analogue) allows a new intent once the prior one is no longer
+// active — i.e. the constraint is partial, not global.
+
+describe("concurrent booking-intent creates — one active per slot", () => {
+  // Build a lightweight app wired to explicit repos so we can control state.
+  function makeServiceApp(userId = "user1") {
+    const slotRepo = new InMemorySlotRepository();
+    const intentRepo = new InMemoryBookingIntentRepository();
+    const service = new BookingIntentService(intentRepo, slotRepo);
+
+    const app = express();
+    app.use(express.json());
+
+    // Thin router that bypasses auth/feature-flag middleware for these tests.
+    // Mirrors exactly what the real POST / handler does after auth passes.
+    app.post("/intents", async (req: any, res: any) => {
+      try {
+        const intent = await service.createIntent(req.body, {
+          userId: req.headers["x-user-id"] as string ?? userId,
+          role: "customer",
+        });
+        res.status(201).json({ success: true, intent });
+      } catch (err: any) {
+        res.status(err.statusCode ?? err.status ?? 500).json({
+          success: false,
+          error: err.message,
+          code: err.code,
+        });
+      }
+    });
+
+    return { app, intentRepo, slotRepo, service };
+  }
+
+  it("exactly one of 5 concurrent creates for the same slot succeeds", async () => {
+    const { app } = makeServiceApp();
+
+    const body = {
+      slotId: ALICE_SLOT_ID,
+    };
+
+    const requests = Array.from({ length: 5 }, (_, i) =>
+      request(app)
+        .post("/intents")
+        .set("x-user-id", `customer-${i}`)
+        .send(body),
+    );
+
+    const responses = await Promise.all(requests);
+    const statuses = responses.map((r) => r.status);
+
+    const created = statuses.filter((s) => s === 201);
+    const conflicted = statuses.filter((s) => s === 409);
+
+    expect(created).toHaveLength(1);
+    expect(conflicted).toHaveLength(4);
+
+    const conflictBodies = responses
+      .filter((r) => r.status === 409)
+      .map((r) => r.body);
+    conflictBodies.forEach((body) => {
+      expect(body.success).toBe(false);
+      expect(body.code).toBe("CONFLICT");
+    });
+  });
+
+  it("allows a new intent for a slot once the prior intent is no longer active", async () => {
+    const { intentRepo, service } = makeServiceApp();
+
+    const actor = { userId: "user1", role: "customer" as const };
+
+    // Create the first intent and confirm it (terminal state).
+    const first = await service.createIntent({ slotId: ALICE_SLOT_ID }, actor);
+    intentRepo.updateStatus(first.id, "confirmed");
+
+    // A second create for the same slot should now succeed because "confirmed"
+    // is not in the active statuses covered by the partial index.
+    const second = await service.createIntent({ slotId: ALICE_SLOT_ID }, actor);
+    expect(second.slotId).toBe(ALICE_SLOT_ID);
+    expect(second.status).toBe("pending");
   });
 });

--- a/src/db/migrations/019_add_active_booking_intent_unique_idx.ts
+++ b/src/db/migrations/019_add_active_booking_intent_unique_idx.ts
@@ -1,0 +1,56 @@
+import { PoolClient } from "pg";
+import { Migration } from "../migrationRunner.js";
+
+/**
+ * Migration 019 — add_active_booking_intent_unique_idx
+ *
+ * Adds a partial unique index on booking_intents(slot_id) covering only
+ * active intents, i.e. those with status 'pending' or 'hold_placed'.
+ *
+ * Why a partial index instead of a full UNIQUE constraint:
+ *  - The existing UNIQUE constraint on slot_id (added in 004) would block a
+ *    new intent after a prior one is cancelled or completed, which is wrong.
+ *  - A partial index scoped to active statuses means at most one in-flight
+ *    intent per slot at any time, while allowing new intents once the
+ *    previous one reaches a terminal state (cancelled / expired / confirmed).
+ *
+ * The application layer still does an optimistic check before inserting, but
+ * that check has a race window under concurrent requests.  This index is the
+ * authoritative last line of defence — any race loser receives a Postgres
+ * unique_violation (23505) which the repository maps to a 409 Conflict.
+ *
+ * Note: migration 004 added a plain UNIQUE constraint on slot_id.  We drop
+ * that here because it is strictly more restrictive than this partial index
+ * and would reject valid creates for slots whose previous intent is done.
+ */
+export const migration: Migration = {
+  id: "019",
+  name: "add_active_booking_intent_unique_idx",
+
+  async up(client: PoolClient): Promise<void> {
+    // Drop the overly-broad full unique constraint added in migration 004.
+    await client.query(`
+      ALTER TABLE booking_intents
+        DROP CONSTRAINT IF EXISTS booking_intents_slot_id_key
+    `);
+
+    // Partial unique index: only one active intent per slot at a time.
+    await client.query(`
+      CREATE UNIQUE INDEX idx_booking_intents_one_active_per_slot
+        ON booking_intents (slot_id)
+        WHERE status IN ('pending', 'hold_placed')
+    `);
+  },
+
+  async down(client: PoolClient): Promise<void> {
+    await client.query(`
+      DROP INDEX IF EXISTS idx_booking_intents_one_active_per_slot
+    `);
+
+    // Restore the original constraint so a rollback leaves the schema as it was.
+    await client.query(`
+      ALTER TABLE booking_intents
+        ADD CONSTRAINT booking_intents_slot_id_key UNIQUE (slot_id)
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -33,6 +33,7 @@ import { migration as migration014b } from "./014_create_reputation_events.js";
 import { migration as migration015 } from "./015_create_reputation_snapshots.js";
 import { migration as migration016 } from "./016_add_grace_window_config.js";
 import { migration as migration017 } from "./018_add_partner_token_quotas.js";
+import { migration as migration019 } from "./019_add_active_booking_intent_unique_idx.js";
 
 export const migrations: Migration[] = [
   migration001,
@@ -58,6 +59,7 @@ export const migrations: Migration[] = [
   migration015,
   migration016,
   migration017,
+  migration019,
 ];
 
 // ─── Duplicate-ID guard ───────────────────────────────────────────────────────

--- a/src/modules/booking-intents/__tests__/pg-booking-intent-repository.test.ts
+++ b/src/modules/booking-intents/__tests__/pg-booking-intent-repository.test.ts
@@ -1,5 +1,6 @@
 import { jest } from "@jest/globals";
 import { PgBookingIntentRepository } from "../pg-booking-intent-repository.js";
+import { ConflictError } from "../../../errors/AppError.js";
 import { QueryResult } from "pg";
 
 describe("PgBookingIntentRepository", () => {
@@ -71,6 +72,70 @@ describe("PgBookingIntentRepository", () => {
       );
 
       expect(result).toEqual(expectedRecord);
+    });
+
+    it("throws ConflictError when postgres reports a unique_violation (23505)", async () => {
+      const pgUniqueViolation = Object.assign(new Error("duplicate key value"), {
+        code: "23505",
+      });
+      mockQuery.mockRejectedValueOnce(pgUniqueViolation);
+
+      const intentData = {
+        slotId: "slot-123",
+        professional: "prof-456",
+        customerId: "cust-789",
+        startTime: 1000,
+        endTime: 2000,
+        status: "pending" as const,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+
+      await expect(repository.create(intentData)).rejects.toBeInstanceOf(ConflictError);
+    });
+
+    it("ConflictError from 23505 carries a 409 status code", async () => {
+      const pgUniqueViolation = Object.assign(new Error("duplicate key value"), {
+        code: "23505",
+      });
+      mockQuery.mockRejectedValueOnce(pgUniqueViolation);
+
+      const intentData = {
+        slotId: "slot-123",
+        professional: "prof-456",
+        customerId: "cust-789",
+        startTime: 1000,
+        endTime: 2000,
+        status: "pending" as const,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+
+      let caught: any;
+      try {
+        await repository.create(intentData);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ConflictError);
+      expect(caught.statusCode).toBe(409);
+      expect(caught.message).toMatch(/active booking intent/i);
+    });
+
+    it("re-throws non-23505 database errors unchanged", async () => {
+      const dbError = Object.assign(new Error("connection timeout"), { code: "08006" });
+      mockQuery.mockRejectedValueOnce(dbError);
+
+      const intentData = {
+        slotId: "slot-123",
+        professional: "prof-456",
+        customerId: "cust-789",
+        startTime: 1000,
+        endTime: 2000,
+        status: "pending" as const,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+
+      await expect(repository.create(intentData)).rejects.toThrow("connection timeout");
     });
   });
 

--- a/src/modules/booking-intents/pg-booking-intent-repository.ts
+++ b/src/modules/booking-intents/pg-booking-intent-repository.ts
@@ -1,4 +1,5 @@
 import { query } from "../../db/pool.js";
+import { ConflictError } from "../../errors/AppError.js";
 import {
   BookingIntentRecord,
   BookingIntentRepository,
@@ -41,8 +42,18 @@ export class PgBookingIntentRepository implements BookingIntentRepository {
       new Date(intent.createdAt),
     ];
 
-    const res = await this.dbQuery(sql, values);
-    return this.mapRowToRecord(res.rows[0]);
+    try {
+      const res = await this.dbQuery(sql, values);
+      return this.mapRowToRecord(res.rows[0]);
+    } catch (err: any) {
+      // Partial unique index violation — another active intent exists for this slot.
+      if (err?.code === "23505") {
+        throw new ConflictError(
+          "An active booking intent already exists for this slot.",
+        );
+      }
+      throw err;
+    }
   }
 
   // @ts-expect-error - Auto-fixed by script

--- a/src/routes/booking-intents.ts
+++ b/src/routes/booking-intents.ts
@@ -21,6 +21,7 @@ import {
   BookingIntentError,
   parseCreateBookingIntentBody,
 } from "../modules/booking-intents/booking-intent-service.js";
+import { isAppError } from "../errors/AppError.js";
 import { InMemoryBookingIntentRepository } from "../modules/booking-intents/booking-intent-repository.js";
 import { InMemorySlotRepository } from "../modules/slots/slot-repository.js";
 import { logger } from "../utils/logger.js";
@@ -40,6 +41,15 @@ export function createBookingIntentsRouter() {
   function handleServiceError(error: unknown, res: Response): void {
     if (error instanceof BookingIntentError) {
       res.status(error.status).json({
+        success: false,
+        error: error.message,
+        code: error.code,
+      });
+      return;
+    }
+
+    if (isAppError(error)) {
+      res.status(error.statusCode).json({
         success: false,
         error: error.message,
         code: error.code,

--- a/test/mocks/pg.ts
+++ b/test/mocks/pg.ts
@@ -1,5 +1,20 @@
 import { EventEmitter } from "node:events";
 
+// Minimal type stubs so imports of QueryResult, PoolClient, etc. resolve
+// when the real `pg` module is replaced by this mock in Jest.
+export interface QueryResult<R = any> {
+  rows: R[];
+  rowCount: number | null;
+  command: string;
+  oid: number;
+  fields: any[];
+}
+
+export interface PoolClient {
+  query: (text: string, values?: any[]) => Promise<QueryResult>;
+  release: (err?: Error) => void;
+}
+
 export class Pool extends EventEmitter {
   constructor() {
     super();


### PR DESCRIPTION
- migration 019: drop overly-broad UNIQUE(slot_id) from 004 and replace with a partial unique index scoped to status IN ('pending','hold_placed'), allowing new intents once a prior one reaches a terminal state

- PgBookingIntentRepository.create(): catch pg 23505 (unique_violation) and re-raise as ConflictError (409) with a clear message

- booking-intents route: extend handleServiceError to catch any AppError subclass (covers ConflictError from the repo layer)

- tests: 3 new unit tests for the 23505 path in pg-booking-intent-repository; 2 new integration tests (5-concurrent-creates and post-terminal-state)

- fix: export QueryResult/PoolClient stubs from test/mocks/pg.ts so ts-jest typecheck passes when the pg mock replaces the real module

- fix: add migration 019 and pg-booking-intent-repository to test-graph.json

Closes #601