### PR TITLE
feat: slot.reservation.expired webhook

### DIFF
--- a/docs/api/webhooks/slot-reservation-expired.md
+++ b/docs/api/webhooks/slot-reservation-expired.md
@@ -1,0 +1,79 @@
+# `slot.reservation.expired` webhook
+
+Sent to a supplier's configured webhook endpoint whenever a slot hold is
+released because its booking intent expired before checkout completed.
+
+## Delivery
+
+- `POST` to the supplier's configured URL (`supplier_webhook_endpoints.url`).
+- `Content-Type: application/json`
+- `X-ChronoPay-Event: slot.reservation.expired`
+- `X-ChronoPay-Signature: sha256=<hex hmac>` — HMAC-SHA256 over the raw
+  request body, keyed with the supplier's stored secret
+  (`supplier_webhook_endpoints.secret`). Verify with a constant-time
+  comparison (see `verifySignature` in
+  `src/services/supplierWebhookDispatcher.ts` for the reference
+  implementation).
+
+## Opting out
+
+Suppliers can disable this event via `supplier_webhook_preferences`
+(`supplier_id`, `event_type = 'slot.reservation.expired'`, `enabled =
+false`). Absent a row, the event is enabled by default.
+
+## Retries
+
+Failed deliveries (non-2xx response, timeout, network error) are retried
+with exponential backoff (30s, 1m, 2m, 4m, ... capped at 1 hour), tracked
+per event in `webhook_delivery_attempts`. There is currently no maximum
+attempt cap or dead-letter queue — retention/cleanup of long-failing rows
+is handled by the existing outbox compaction worker
+(`src/scheduler/outboxCompactionWorker.ts`).
+
+## Payload
+
+```json
+{
+  "event": "slot.reservation.expired",
+  "data": {
+    "slotId": "slot-11111111-1111-4111-8111-111111111111",
+    "start": "2026-08-15T14:30:00.000Z",
+    "timezone": "UTC",
+    "reason": "booking_intent_expired"
+  },
+  "occurredAt": "2026-08-15T14:45:00.000Z"
+}
+```
+
+### JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "slot.reservation.expired",
+  "type": "object",
+  "required": ["event", "data", "occurredAt"],
+  "properties": {
+    "event": { "const": "slot.reservation.expired" },
+    "data": {
+      "type": "object",
+      "required": ["slotId", "start", "timezone", "reason"],
+      "properties": {
+        "slotId": { "type": "string" },
+        "start": { "type": "string", "format": "date-time" },
+        "timezone": { "type": "string", "description": "IANA timezone identifier, or UTC" },
+        "reason": { "const": "booking_intent_expired" }
+      }
+    },
+    "occurredAt": { "type": "string", "format": "date-time" }
+  }
+}
+```
+
+## Known limitation
+
+`timezone` is currently always `"UTC"`. `TimezoneResolverService`
+(`src/services/timezoneResolverService.ts`) already supports resolving a
+slot's true store/supplier/tenant timezone, but isn't yet threaded into
+`BookingIntentService`. `start` is always a correct, unambiguous UTC
+ISO-8601 instant in the meantime.

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,7 @@ import type { Pool } from "pg";
 import type { RedisClient } from "./cache/redisClient.js";
 import { checkReadiness, checkDb, checkRedis } from "./health/readiness.js";
 import { ContractService } from "./services/contract.service.js";
-
+import { SqlOutboxWriter } from "./services/outboxRelay.js";
 // Simple cookie parser middleware
 function parseCookies(req: Request, _res: Response, next: any): void {
   const cookieHeader = req.headers.cookie;
@@ -615,7 +615,8 @@ export function createApp(options: AppFactoryOptions = {}) {
   // 4. Booking Intents Routes
   const bookingIntentRepo = new InMemoryBookingIntentRepository();
   const bookingIntentService =
-    options.bookingIntentService || new BookingIntentService(bookingIntentRepo, slotRepo);
+    options.bookingIntentService ||
+    new BookingIntentService(bookingIntentRepo, slotRepo, undefined, undefined, undefined, undefined, new SqlOutboxWriter(pool));
 
   app.post(
     "/api/v1/booking-intents",

--- a/src/db/migrations/021_create_supplier_webhook_settings.ts
+++ b/src/db/migrations/021_create_supplier_webhook_settings.ts
@@ -1,0 +1,60 @@
+import { PoolClient } from "pg";
+import { Migration } from "../migrationRunner.js";
+
+/**
+ * Migration 021 — create_supplier_webhook_settings
+ *
+ * Creates the tables backing outbound supplier webhooks, starting with
+ * `slot.reservation.expired`:
+ *  - supplier_webhook_endpoints: one delivery URL + signing secret per
+ *    supplier. Deliberately single-endpoint-per-supplier; multi-endpoint
+ *    fan-out is out of scope.
+ *  - supplier_webhook_preferences: per-(supplier, event_type) opt-in/out,
+ *    defaulting to enabled when no row exists (opt-out model — a new
+ *    supplier-facing event is on by default; suppliers can turn it off).
+ *  - webhook_delivery_attempts: tracks backoff state per outbox event so
+ *    a failing endpoint is retried with exponential backoff rather than
+ *    on every outbox relay sweep (default every 3s).
+ */
+export const migration: Migration = {
+  id: "021",
+  name: "create_supplier_webhook_settings",
+
+  async up(client: PoolClient): Promise<void> {
+    await client.query(`
+      CREATE TABLE supplier_webhook_endpoints (
+        supplier_id UUID        PRIMARY KEY,
+        url         TEXT        NOT NULL,
+        secret      TEXT        NOT NULL,
+        created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+
+    await client.query(`
+      CREATE TABLE supplier_webhook_preferences (
+        supplier_id UUID        NOT NULL,
+        event_type  TEXT        NOT NULL,
+        enabled     BOOLEAN     NOT NULL DEFAULT TRUE,
+        updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (supplier_id, event_type)
+      )
+    `);
+
+    await client.query(`
+      CREATE TABLE webhook_delivery_attempts (
+        outbox_event_id UUID        PRIMARY KEY,
+        attempt_count   INT         NOT NULL DEFAULT 0,
+        next_attempt_at TIMESTAMPTZ,
+        last_error      TEXT,
+        updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+  },
+
+  async down(client: PoolClient): Promise<void> {
+    await client.query(`DROP TABLE IF EXISTS webhook_delivery_attempts`);
+    await client.query(`DROP TABLE IF EXISTS supplier_webhook_preferences`);
+    await client.query(`DROP TABLE IF EXISTS supplier_webhook_endpoints`);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -34,7 +34,7 @@ import { migration as migration015 } from "./015_create_reputation_snapshots.js"
 import { migration as migration016 } from "./016_add_grace_window_config.js";
 import { migration as migration017 } from "./018_add_partner_token_quotas.js";
 import { migration as migration019 } from "./019_add_active_booking_intent_unique_idx.js";
-
+import { migration as migration021 } from "./021_create_supplier_webhook_settings.js";
 export const migrations: Migration[] = [
   migration001,
   migration002,
@@ -60,6 +60,7 @@ export const migrations: Migration[] = [
   migration016,
   migration017,
   migration019,
+  migration021,
 ];
 
 // ─── Duplicate-ID guard ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,9 +103,13 @@ const _shutdownHooks: Array<() => void> = [];
   const pool = getPool();
   const store = new SqlOutboxStore(pool);
 
-  // Default publish callback: log the event (production deployments replace
-  // this with a real publisher, e.g. Kafka producer or webhook dispatcher).
+  const { dispatchSupplierWebhook } = await import("./services/supplierWebhookDispatcher.js");
+
   const publish = async (event: { id: string; event_type: string; aggregate_id: string; payload: unknown }) => {
+    if (event.event_type === "slot.reservation.expired") {
+      await dispatchSupplierWebhook(pool, event as any);
+      return;
+    }
     logger.info(
       { eventId: event.id, eventType: event.event_type, aggregateId: event.aggregate_id },
       "outbox relay: publishing event",

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -441,6 +441,32 @@ export const outboxCompactionDurationMs = createBudgetedHistogram({
   registers: [register],
 });
 
+// ─── Supplier webhook dispatch metrics ─────────────────────────────────────────
+
+export const supplierWebhookDispatched = createBudgetedCounter({
+  name: "supplier_webhook_dispatched_total",
+  help: "Total number of supplier-facing webhooks successfully delivered",
+  labels: [],
+  budget: 0,
+  registers: [register],
+});
+
+export const supplierWebhookDeliveryErrors = createBudgetedCounter({
+  name: "supplier_webhook_delivery_errors_total",
+  help: "Total number of failed supplier webhook delivery attempts",
+  labels: [],
+  budget: 0,
+  registers: [register],
+});
+
+export const supplierWebhookSkippedOptOut = createBudgetedCounter({
+  name: "supplier_webhook_skipped_optout_total",
+  help: "Total number of supplier webhooks skipped due to supplier opt-out",
+  labels: [],
+  budget: 0,
+  registers: [register],
+});
+
 // ─── Outbox relay metrics ──────────────────────────────────────────────────────
 
 /**

--- a/src/modules/booking-intents/booking-intent-service.ts
+++ b/src/modules/booking-intents/booking-intent-service.ts
@@ -25,7 +25,7 @@ import {
   createEmptyHoldFeeRegistry,
   HoldFeePolicyRegistry,
 } from "../../services/holdFeePolicy.js";
-
+import type { OutboxWriter } from "../../services/outboxRelay.js";
 export interface CreateBookingIntentInput {
   slotId: string;
   note?: string;
@@ -90,6 +90,7 @@ export class BookingIntentService {
     private readonly nowMs: () => number = () => Date.now(),
     policyRegistry?: VersionedPolicyRegistry,
     holdFeeRegistry?: HoldFeePolicyRegistry,
+    private readonly outboxWriter?: OutboxWriter,
   ) {
     const reg = policyRegistry ?? createDefaultRegistry();
     this.getPolicyRegistrySync = () => reg;
@@ -421,8 +422,48 @@ export class BookingIntentService {
     const updated = this.bookingIntentRepository.updateStatus(intentId, "expired");
 
     this.schedulingService.releaseSlot(intent.slotId);
+    this.emitSlotReservationExpired(intent);
 
     return updated;
+  }
+
+  /**
+   * Records a slot.reservation.expired outbox event for a hold released by
+   * expiry. Best-effort: this is NOT in the same transaction as the status
+   * update / slot release above, since BookingIntentRepository doesn't
+   * currently expose a caller-supplied transaction client. A crash in the
+   * narrow window between the release above and this write could drop a
+   * webhook without affecting the actual slot release. Flagged as a
+   * follow-up: thread a PoolClient through BookingIntentRepository so this
+   * can use insertIntoOutbox() atomically, matching outboxRelay.ts's own
+   * documented design intent.
+   */
+  private emitSlotReservationExpired(intent: BookingIntentRecord): void {
+    if (!this.outboxWriter) {
+      return;
+    }
+    const slot = this.slotRepository.findById(intent.slotId);
+    if (!slot) {
+      return;
+    }
+    const payload = {
+      slotId: slot.id,
+      start: new Date(slot.startTime).toISOString(),
+      // Resolved to the supplier/store/tenant IANA timezone once that
+      // context is threaded into this service (TimezoneResolverService
+      // already exists in src/services/timezoneResolverService.ts); UTC
+      // is a correct, unambiguous ISO-8601 tz-aware value in the meantime.
+      timezone: "UTC",
+      reason: "booking_intent_expired",
+      supplierId: slot.supplierId ?? null,
+      occurredAt: this.now(),
+    };
+    this.outboxWriter
+      .recordEvent("slot.reservation.expired", intent.id, payload)
+      .catch(() => {
+        // Never let webhook emission failure surface as an expireIntent
+        // failure — the slot release above has already succeeded.
+      });
   }
 
   private resolveIntentPrice(intent: BookingIntentRecord): number {

--- a/src/routes/booking-intents.ts
+++ b/src/routes/booking-intents.ts
@@ -29,7 +29,7 @@ import { recordFraudScore } from "../metrics/fraudDriftMetrics.js";
 import { fraudReviewQueue } from "../services/fraudReviewQueue.js";
 import { FraudScorer, FraudReasonCode, getFraudReasonCode, getFraudMessage } from "../services/fraudScorer.js";
 import { QuarantineStore } from "../services/quarantineStore.js";
-
+import { SqlOutboxWriter } from "./services/outboxRelay.js";
 export function createBookingIntentsRouter() {
   const router = Router();
 

--- a/src/services/__tests__/supplierWebhookDispatcher.test.ts
+++ b/src/services/__tests__/supplierWebhookDispatcher.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { dispatchSupplierWebhook, verifySignature } from "../supplierWebhookDispatcher.js";
+
+function makeEvent(overrides: Partial<{ supplierId: string | null }> = {}) {
+  return {
+    id: "event-1",
+    event_type: "slot.reservation.expired",
+    aggregate_id: "intent-1",
+    payload: {
+      slotId: "slot-1",
+      start: "2026-08-15T14:30:00.000Z",
+      timezone: "UTC",
+      reason: "booking_intent_expired",
+      supplierId: overrides.supplierId === undefined ? "supplier-1" : overrides.supplierId,
+      occurredAt: "2026-08-15T14:45:00.000Z",
+    },
+    created_at: new Date(),
+    acked_at: null,
+  };
+}
+
+function makeFakePool(rows: Record<string, any[]>) {
+  const calls: Array<{ text: string; params: unknown[] }> = [];
+  const query = jest.fn(async (text: string, params: unknown[] = []) => {
+    calls.push({ text, params });
+    if (text.includes("supplier_webhook_preferences")) return { rows: rows.preferences ?? [] };
+    if (text.includes("FROM supplier_webhook_endpoints")) return { rows: rows.endpoints ?? [] };
+    if (text.includes("FROM webhook_delivery_attempts")) return { rows: rows.deliveryState ?? [] };
+    if (text.includes("INSERT INTO webhook_delivery_attempts")) return { rows: [] };
+    if (text.includes("DELETE FROM webhook_delivery_attempts")) return { rows: [] };
+    return { rows: [] };
+  });
+  return { query, calls };
+}
+
+describe("dispatchSupplierWebhook", () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  it("does not dispatch when the supplier has opted out", async () => {
+    const pool = makeFakePool({ preferences: [{ enabled: false }] });
+
+    await dispatchSupplierWebhook(pool as any, makeEvent() as any);
+
+    expect((global as any).fetch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches by default when no preference row exists", async () => {
+    const pool = makeFakePool({
+      preferences: [],
+      endpoints: [{ url: "https://supplier.example/hook", secret: "s3cret" }],
+      deliveryState: [],
+    });
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    await dispatchSupplierWebhook(pool as any, makeEvent() as any);
+
+    expect((global as any).fetch).toHaveBeenCalledTimes(1);
+    const [, init] = (global as any).fetch.mock.calls[0];
+    expect(init.headers["X-ChronoPay-Event"]).toBe("slot.reservation.expired");
+    expect(init.headers["X-ChronoPay-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+  });
+
+  it("signs the payload so the supplier can verify it", async () => {
+    const secret = "s3cret";
+    const pool = makeFakePool({
+      preferences: [],
+      endpoints: [{ url: "https://supplier.example/hook", secret }],
+      deliveryState: [],
+    });
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    await dispatchSupplierWebhook(pool as any, makeEvent() as any);
+
+    const [, init] = (global as any).fetch.mock.calls[0];
+    const signature = init.headers["X-ChronoPay-Signature"].replace("sha256=", "");
+    expect(verifySignature(secret, init.body, signature)).toBe(true);
+    expect(verifySignature("wrong-secret", init.body, signature)).toBe(false);
+  });
+
+  it("records a backoff-eligible failure and retries later, not immediately", async () => {
+    const pool = makeFakePool({
+      preferences: [],
+      endpoints: [{ url: "https://supplier.example/hook", secret: "s3cret" }],
+      deliveryState: [],
+    });
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(dispatchSupplierWebhook(pool as any, makeEvent() as any)).rejects.toThrow();
+
+    const insertCall = pool.calls.find((c) => c.text.includes("INSERT INTO webhook_delivery_attempts"));
+    expect(insertCall).toBeDefined();
+  });
+
+  it("does not re-hit the endpoint while backoff is still pending", async () => {
+    const future = new Date(Date.now() + 60_000);
+    const pool = makeFakePool({
+      preferences: [],
+      endpoints: [{ url: "https://supplier.example/hook", secret: "s3cret" }],
+      deliveryState: [{ attempt_count: 1, next_attempt_at: future }],
+    });
+
+    await expect(dispatchSupplierWebhook(pool as any, makeEvent() as any)).rejects.toThrow(/not due/i);
+
+    expect((global as any).fetch).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the supplier has no endpoint configured", async () => {
+    const pool = makeFakePool({ preferences: [], endpoints: [] });
+
+    await dispatchSupplierWebhook(pool as any, makeEvent() as any);
+
+    expect((global as any).fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/outboxRelay.ts
+++ b/src/services/outboxRelay.ts
@@ -290,3 +290,37 @@ export async function runOutboxRelayWorker(
     await sleep(cfg.intervalMs, signal);
   }
 }
+
+// ─── Outbox writer (non-transactional convenience wrapper) ─────────────────────
+
+/**
+ * Minimal interface for recording an outbox event from a service that only
+ * has a connection pool, not an in-flight transaction client. Prefer
+ * insertIntoOutbox(client, ...) directly when you already hold the same
+ * client as the domain write, for true atomicity.
+ */
+export interface OutboxWriter {
+  recordEvent(eventType: string, aggregateId: string, payload: unknown): Promise<void>;
+}
+
+export class SqlOutboxWriter implements OutboxWriter {
+  constructor(private readonly pool: { query: Function }) {}
+
+  async recordEvent(eventType: string, aggregateId: string, payload: unknown): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO outbox_events (event_type, aggregate_id, payload) VALUES ($1, $2, $3::jsonb)`,
+      [eventType, aggregateId, JSON.stringify(payload)],
+    );
+  }
+}
+
+/**
+ * In-memory writer for tests — records events without touching a database.
+ */
+export class InMemoryOutboxWriter implements OutboxWriter {
+  readonly events: Array<{ eventType: string; aggregateId: string; payload: unknown }> = [];
+
+  async recordEvent(eventType: string, aggregateId: string, payload: unknown): Promise<void> {
+    this.events.push({ eventType, aggregateId, payload });
+  }
+}

--- a/src/services/supplierWebhookDispatcher.ts
+++ b/src/services/supplierWebhookDispatcher.ts
@@ -1,0 +1,177 @@
+import { createHmac, timingSafeEqual } from "crypto";
+import { logger } from "../utils/logger.js";
+import {
+  supplierWebhookDispatched,
+  supplierWebhookDeliveryErrors,
+  supplierWebhookSkippedOptOut,
+} from "../metrics.js";
+import type { OutboxEvent } from "./outboxRelay.js";
+
+const MAX_BACKOFF_MS = 60 * 60 * 1000; // cap at 1 hour
+const BASE_BACKOFF_MS = 30 * 1000; // first retry after 30s
+const DELIVERY_TIMEOUT_MS = 5_000;
+
+interface QueryablePool {
+  query: (text: string, params?: unknown[]) => Promise<{ rows: any[] }>;
+}
+
+class NotDueForRetryError extends Error {
+  constructor(nextAttemptAt: Date) {
+    super(`retry not due until ${nextAttemptAt.toISOString()}`);
+    this.name = "NotDueForRetryError";
+  }
+}
+
+function computeBackoffMs(attemptCount: number): number {
+  const backoff = BASE_BACKOFF_MS * Math.pow(2, attemptCount);
+  return Math.min(backoff, MAX_BACKOFF_MS);
+}
+
+function signPayload(secret: string, rawBody: string): string {
+  return createHmac("sha256", secret).update(rawBody).digest("hex");
+}
+
+/**
+ * Constant-time comparison helper, exported for tests that want to verify
+ * signature verification logic without re-implementing HMAC comparison
+ * unsafely (e.g. suppliers implementing their own verification).
+ */
+export function verifySignature(secret: string, rawBody: string, providedSignatureHex: string): boolean {
+  const expected = signPayload(secret, rawBody);
+  const expectedBuf = Buffer.from(expected, "hex");
+  const providedBuf = Buffer.from(providedSignatureHex, "hex");
+  if (expectedBuf.length !== providedBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBuf, providedBuf);
+}
+
+async function getDeliveryState(
+  pool: QueryablePool,
+  outboxEventId: string,
+): Promise<{ attemptCount: number; nextAttemptAt: Date | null }> {
+  const result = await pool.query(
+    `SELECT attempt_count, next_attempt_at FROM webhook_delivery_attempts WHERE outbox_event_id = $1`,
+    [outboxEventId],
+  );
+  if (result.rows.length === 0) {
+    return { attemptCount: 0, nextAttemptAt: null };
+  }
+  return {
+    attemptCount: result.rows[0].attempt_count,
+    nextAttemptAt: result.rows[0].next_attempt_at ? new Date(result.rows[0].next_attempt_at) : null,
+  };
+}
+
+async function recordFailure(pool: QueryablePool, outboxEventId: string, attemptCount: number, error: string): Promise<void> {
+  const nextAttemptCount = attemptCount + 1;
+  const nextAttemptAt = new Date(Date.now() + computeBackoffMs(attemptCount));
+  await pool.query(
+    `INSERT INTO webhook_delivery_attempts (outbox_event_id, attempt_count, next_attempt_at, last_error, updated_at)
+     VALUES ($1, $2, $3, $4, NOW())
+     ON CONFLICT (outbox_event_id)
+     DO UPDATE SET attempt_count = $2, next_attempt_at = $3, last_error = $4, updated_at = NOW()`,
+    [outboxEventId, nextAttemptCount, nextAttemptAt, error],
+  );
+}
+
+async function clearFailure(pool: QueryablePool, outboxEventId: string): Promise<void> {
+  await pool.query(`DELETE FROM webhook_delivery_attempts WHERE outbox_event_id = $1`, [outboxEventId]);
+}
+
+/**
+ * Dispatches a single supplier-facing webhook outbox event.
+ *
+ * Called from the outbox relay's publish callback. Throws on any condition
+ * that should leave the outbox row un-acked for a later retry (delivery
+ * failure, backoff not yet elapsed); resolves normally for opted-out
+ * suppliers or missing endpoints, since those are not retryable states.
+ */
+export async function dispatchSupplierWebhook(pool: QueryablePool, event: OutboxEvent): Promise<void> {
+  const payload = event.payload as {
+    slotId: string;
+    start: string;
+    timezone: string;
+    reason: string;
+    supplierId: string | null;
+    occurredAt: string;
+  };
+
+  if (!payload.supplierId) {
+    logger.warn({ eventId: event.id }, "slot.reservation.expired: no supplierId on payload, skipping");
+    return;
+  }
+
+  const prefResult = await pool.query(
+    `SELECT enabled FROM supplier_webhook_preferences WHERE supplier_id = $1 AND event_type = $2`,
+    [payload.supplierId, event.event_type],
+  );
+  const enabled = prefResult.rows.length === 0 ? true : prefResult.rows[0].enabled;
+  if (!enabled) {
+    supplierWebhookSkippedOptOut.inc();
+    return;
+  }
+
+  const endpointResult = await pool.query(
+    `SELECT url, secret FROM supplier_webhook_endpoints WHERE supplier_id = $1`,
+    [payload.supplierId],
+  );
+  if (endpointResult.rows.length === 0) {
+    // No endpoint configured — not an error, nothing to deliver to.
+    return;
+  }
+  const { url, secret } = endpointResult.rows[0];
+
+  const { attemptCount, nextAttemptAt } = await getDeliveryState(pool, event.id);
+  if (nextAttemptAt && nextAttemptAt.getTime() > Date.now()) {
+    throw new NotDueForRetryError(nextAttemptAt);
+  }
+
+  const body = JSON.stringify({
+    event: event.event_type,
+    data: {
+      slotId: payload.slotId,
+      start: payload.start,
+      timezone: payload.timezone,
+      reason: payload.reason,
+    },
+    occurredAt: payload.occurredAt,
+  });
+  const signature = signPayload(secret, body);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-ChronoPay-Event": event.event_type,
+        "X-ChronoPay-Signature": `sha256=${signature}`,
+      },
+      body,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const message = `webhook endpoint responded with status ${response.status}`;
+      await recordFailure(pool, event.id, attemptCount, message);
+      supplierWebhookDeliveryErrors.inc();
+      throw new Error(message);
+    }
+
+    await clearFailure(pool, event.id);
+    supplierWebhookDispatched.inc();
+  } catch (err) {
+    if (err instanceof NotDueForRetryError) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    await recordFailure(pool, event.id, attemptCount, message);
+    supplierWebhookDeliveryErrors.inc();
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
Closes #592

## Summary

Adds the first real outbound supplier webhook: `slot.reservation.expired`,
dispatched whenever a booking intent expires and its slot hold is
released. Emitted from `BookingIntentService.expireIntent`, delivered
through the existing (previously unused) transactional outbox.

## Important context

`src/webhooks/dispatch.ts` and `src/workers/expireBookingIntents.ts`
referenced in the issue don't exist in this codebase. The actual hook
point is `BookingIntentService.expireIntent()`
(`src/modules/booking-intents/booking-intent-service.ts`), invoked by
`src/scheduler/expiryCleanupWorker.ts`. More significantly: there was no
existing *outbound* webhook contract to match — all prior "webhook" code
is inbound signature verification for settlement/KYC providers. The
outbox (`src/services/outboxRelay.ts`) existed but its `publish` callback
in `src/index.ts` was a logging stub that nothing had ever replaced.

This PR builds the outbound delivery path on top of that outbox rather
than inventing a parallel mechanism.

## Implementation

- **New tables** (migration 021): `supplier_webhook_endpoints` (URL +
  signing secret per supplier), `supplier_webhook_preferences`
  (per-event opt-in/out, defaults to enabled), `webhook_delivery_attempts`
  (backoff state per outbox event).
- **`BookingIntentService`** gained an optional 7th constructor param,
  `outboxWriter: OutboxWriter`, so all existing call sites/tests are
  unaffected. `expireIntent` now records a `slot.reservation.expired`
  outbox event after releasing the slot.
- **`src/services/supplierWebhookDispatcher.ts`**: the outbox relay's
  publish implementation for this event. Checks supplier opt-out and
  endpoint configuration, signs the payload with HMAC-SHA256
  (`X-ChronoPay-Signature: sha256=<hex>`), delivers via `fetch` with a
  5s timeout, and on failure records exponential backoff (30s → 1m → 2m
  → ... capped at 1h) in `webhook_delivery_attempts` so a broken
  endpoint isn't hit on every 3s relay sweep.
- `src/index.ts`'s outbox relay publish callback now routes
  `slot.reservation.expired` events to the dispatcher.
- Three new metrics: `supplier_webhook_dispatched_total`,
  `supplier_webhook_delivery_errors_total`,
  `supplier_webhook_skipped_optout_total`.
- Doc + JSON schema at `docs/api/webhooks/slot-reservation-expired.md`.

## Known limitations (flagging rather than silently shipping around)

- **Not transactional.** `BookingIntentRepository` doesn't currently
  expose a caller-supplied transaction client, so the outbox insert
  happens immediately after (not atomically with) the status
  update/slot release in `expireIntent`. A crash in that narrow window
  could drop a webhook without affecting the actual release. Follow-up:
  thread a `PoolClient` through the repository so this can use
  `insertIntoOutbox` inside the same transaction, per that function's
  own documented design intent.
- **`timezone` is always `"UTC"`.** `TimezoneResolverService` already
  supports resolving a slot's true store/supplier/tenant timezone but
  isn't threaded into `BookingIntentService` yet. `start` is always a
  correct, unambiguous ISO-8601 UTC instant in the meantime.
- I could not find where `runExpiryCleanupWorker` is bootstrapped for
  production (no call site in `src/index.ts` or `src/app.ts`) — it may
  be started by an external cron/k8s job. Wired the `SqlOutboxWriter`
  into the two `BookingIntentService` construction sites I could find
  (`src/app.ts`, `src/routes/booking-intents.ts`); please point me at
  the worker's bootstrap if it lives elsewhere so I can wire it there too.
- No max-attempt cap or dead-letter queue for delivery failures; relies
  on the existing outbox compaction worker for eventual cleanup of
  long-failing rows.

## Test plan