### PR TITLE
feat: per-supplier daily booking cap

### DIFF
--- a/src/__tests__/booking-intents-idempotency.test.ts
+++ b/src/__tests__/booking-intents-idempotency.test.ts
@@ -56,6 +56,20 @@ class InMemoryRedisMock implements RedisClient {
     return 1;
   }
 
+  async incr(key: string): Promise<number> {
+    const entry = this.store.get(key);
+    const next = (entry ? parseInt(entry.value, 10) || 0 : 0) + 1;
+    this.store.set(key, { value: String(next), expiresAt: entry?.expiresAt });
+    return next;
+  }
+
+  async expire(key: string, ttlSeconds: number): Promise<unknown> {
+    const entry = this.store.get(key);
+    if (!entry) return 0;
+    this.store.set(key, { ...entry, expiresAt: Date.now() + ttlSeconds * 1000 });
+    return 1;
+  }
+
   async keys(pattern: string): Promise<string[]> {
     if (pattern === "*") {
       return Array.from(this.store.keys());

--- a/src/app.ts
+++ b/src/app.ts
@@ -630,9 +630,19 @@ export function createApp(options: AppFactoryOptions = {}) {
           return res.status(400).json({ success: false, error: "Note cannot be empty." });
 
         const actor = req.auth;
-        const bookingIntent = bookingIntentService.createIntent({ slotId, note }, actor);
+        const bookingIntent = await bookingIntentService.createIntent({ slotId, note }, actor);
         res.status(201).json({ success: true, bookingIntent });
       } catch (error: any) {
+        if (error?.details?.resetAt) {
+          // Per-supplier daily booking cap reached.
+          res.setHeader("X-DailyCap-Reset", error.details.resetAt);
+          return res.status(429).json({
+            success: false,
+            error: error.message,
+            code: error.code ?? "RATE_LIMITED",
+            details: error.details,
+          });
+        }
         const status = error.status || 400;
         const message = status === 500 ? "Unable to create booking intent." : error.message;
         res.status(status).json({ success: false, error: message });

--- a/src/cache/__tests__/slotCache.test.ts
+++ b/src/cache/__tests__/slotCache.test.ts
@@ -52,6 +52,14 @@ function createMockRedisClient(): RedisClient & { _store: Map<string, string> } 
     async del(key: string): Promise<number> {
       return store.delete(key) ? 1 : 0;
     },
+    async incr(key: string): Promise<number> {
+      const next = (parseInt(store.get(key) ?? "0", 10) || 0) + 1;
+      store.set(key, String(next));
+      return next;
+    },
+    async expire(): Promise<number> {
+      return 1;
+    },
     async keys(pattern: string): Promise<string[]> {
       // Simple glob: "slots:page:*" matches anything starting with "slots:page:"
       const prefix = pattern.replace(/\*$/, "");

--- a/src/cache/redisClient.ts
+++ b/src/cache/redisClient.ts
@@ -32,6 +32,10 @@ export interface RedisClient {
   get(key: string): Promise<string | null>;
   set(key: string, value: string, exMode: "EX", ttl: number, condition?: "NX"): Promise<unknown>;
   del(key: string): Promise<unknown>;
+  /** Atomically increment the integer stored at `key`, returning the new value. */
+  incr(key: string): Promise<number>;
+  /** Set a TTL (seconds) on `key`; used to bound counters like the daily cap. */
+  expire(key: string, ttlSeconds: number): Promise<unknown>;
   keys(pattern: string): Promise<string[]>;
   ping(): Promise<string>;
   quit(): Promise<unknown>;

--- a/src/middleware/__tests__/idempotency.test.ts
+++ b/src/middleware/__tests__/idempotency.test.ts
@@ -53,6 +53,20 @@ class InMemoryRedisMock implements RedisClient {
     return 1;
   }
 
+  async incr(key: string): Promise<number> {
+    const entry = this.store.get(key);
+    const next = (entry ? parseInt(entry.value, 10) || 0 : 0) + 1;
+    this.store.set(key, { value: String(next), expiresAt: entry?.expiresAt });
+    return next;
+  }
+
+  async expire(key: string, ttlSeconds: number): Promise<unknown> {
+    const entry = this.store.get(key);
+    if (!entry) return 0;
+    this.store.set(key, { ...entry, expiresAt: Date.now() + ttlSeconds * 1000 });
+    return 1;
+  }
+
   async keys(pattern: string): Promise<string[]> {
     if (pattern === "*") {
       return [...this.store.keys()];

--- a/src/modules/booking-intents/__tests__/booking-intent-cap.test.ts
+++ b/src/modules/booking-intents/__tests__/booking-intent-cap.test.ts
@@ -1,0 +1,205 @@
+// @ts-nocheck
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
+import { BookingIntentService, BookingIntentError } from "../booking-intent-service.js";
+import { InMemoryBookingIntentRepository } from "../booking-intent-repository.js";
+import { InMemorySlotRepository } from "../../slots/slot-repository.js";
+import {
+  SupplierBookingCapService,
+  SupplierDailyCapExceededError,
+  type RedisClient,
+} from "../../../services/supplierCap.js";
+
+// The real rrule dependency does not load under this jest ESM setup (pre-existing
+// "Invalid RRULE format" failure in recurring-booking.test.ts), so stub the
+// recurrence expansion and focus on the cap behaviour in the loop. The factory
+// is self-contained so jest can apply it to the service's dynamic import().
+jest.unstable_mockModule("../../../services/recurrenceService.js", () => ({
+  RecurrenceError: class RecurrenceError extends Error {},
+  expandRRule: (rrule: string) => {
+    const dtstart = rrule.match(/DTSTART(?:;[^:]*)?:(\d{8})T(\d{6})Z/);
+    const count = Number(rrule.match(/COUNT=(\d+)/)?.[1] ?? 0);
+    const start = dtstart
+      ? new Date(
+          `${dtstart[1].slice(0, 4)}-${dtstart[1].slice(4, 6)}-${dtstart[1].slice(6, 8)}T${dtstart[2].slice(0, 2)}:${dtstart[2].slice(2, 4)}:${dtstart[2].slice(4, 6)}.000Z`,
+        )
+      : new Date();
+    return Array.from({ length: count }, (_, i) => new Date(start.getTime() + i * 7 * 86_400_000));
+  },
+}));
+
+class FakeRedisClient implements RedisClient {
+  readonly store = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key) ?? null;
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async incr(key: string): Promise<number> {
+    const next = (parseInt(this.store.get(key) ?? "0", 10) || 0) + 1;
+    this.store.set(key, String(next));
+    return next;
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const prefix = pattern.replace("*", "");
+    return Array.from(this.store.keys()).filter((k) => k.startsWith(prefix));
+  }
+
+  async ping(): Promise<string> {
+    return "PONG";
+  }
+
+  async quit(): Promise<unknown> {
+    return "OK";
+  }
+}
+
+const ACTOR = { userId: "buyer-1", role: "customer", claims: {} };
+
+function aliceSlots() {
+  return [
+    {
+      id: "slot-a-1",
+      professional: "alice",
+      startTime: 1_900_000_000_000,
+      endTime: 1_900_000_360_000,
+      bookable: true,
+    },
+    {
+      id: "slot-a-2",
+      professional: "alice",
+      startTime: 1_900_000_720_000,
+      endTime: 1_900_001_080_000,
+      bookable: true,
+    },
+  ];
+}
+
+describe("BookingIntentService supplier daily cap", () => {
+  let capService: SupplierBookingCapService;
+  let redis: FakeRedisClient;
+
+  beforeEach(() => {
+    redis = new FakeRedisClient();
+    capService = new SupplierBookingCapService({
+      getRedis: () => redis,
+      nowIso: () => "2026-07-31T12:00:00.000Z",
+      auditLogger: { log: async () => {} } as any,
+    });
+  });
+
+  it("enforces the cap across different slots of the same supplier", async () => {
+    await capService.setOverride("alice", 1, "admin");
+    const service = new BookingIntentService(
+      new InMemoryBookingIntentRepository(),
+      new InMemorySlotRepository(aliceSlots()),
+      () => "2026-07-31T12:00:00.000Z",
+      () => 1_900_000_000_000,
+      undefined,
+      undefined,
+      capService,
+    );
+
+    const first = await service.createIntent({ slotId: "slot-a-1" }, ACTOR as any);
+    expect(first.professional).toBe("alice");
+
+    await expect(service.createIntent({ slotId: "slot-a-2" }, ACTOR as any)).rejects.toBeInstanceOf(
+      SupplierDailyCapExceededError,
+    );
+
+    try {
+      await service.createIntent({ slotId: "slot-a-2" }, ACTOR as any);
+    } catch (error: any) {
+      expect(error.statusCode).toBe(429);
+      expect(error.code).toBe("RATE_LIMITED");
+      expect(error.usage).toMatchObject({ supplierId: "alice", used: 3, cap: 1 });
+    }
+  });
+
+  it("fails open when the cap store is unavailable (Redis not configured)", async () => {
+    const service = new BookingIntentService(
+      new InMemoryBookingIntentRepository(),
+      new InMemorySlotRepository(aliceSlots()),
+      () => "2026-07-31T12:00:00.000Z",
+      () => 1_900_000_000_000,
+      undefined,
+      undefined,
+      new SupplierBookingCapService({ getRedis: () => null }),
+    );
+
+    const intent = await service.createIntent({ slotId: "slot-a-1" }, ACTOR as any);
+    expect(intent.slotId).toBe("slot-a-1");
+  });
+
+  it("records capped-out occurrences as failures in the recurring report", async () => {
+    await capService.setOverride("alice", 1, "admin");
+
+    const dt1 = new Date("2026-01-05T10:00:00.000Z").getTime();
+    const dt2 = new Date("2026-01-12T10:00:00.000Z").getTime();
+    const slotRepo = new InMemorySlotRepository([
+      {
+        id: "r-slot-1",
+        professional: "alice",
+        startTime: dt1,
+        endTime: dt1 + 3_600_000,
+        bookable: true,
+      },
+      {
+        id: "r-slot-2",
+        professional: "alice",
+        startTime: dt2,
+        endTime: dt2 + 3_600_000,
+        bookable: true,
+      },
+    ]);
+
+    const service = new BookingIntentService(
+      new InMemoryBookingIntentRepository(),
+      slotRepo,
+      () => "2026-01-01T00:00:00.000Z",
+      () => dt1,
+      undefined,
+      undefined,
+      capService,
+    );
+
+    const report = await service.createRecurringIntents(
+      { rrule: "DTSTART:20260105T100000Z\nRRULE:FREQ=WEEKLY;COUNT=2;BYDAY=MO" },
+      ACTOR as any,
+    );
+
+    expect(report.successes).toHaveLength(1);
+    expect(report.failures).toHaveLength(1);
+    expect(report.failures[0].reason).toBe("Daily booking cap reached for this supplier");
+  });
+
+  it("keeps throwing other booking errors unrelated to the cap", async () => {
+    await capService.setOverride("alice", 100, "admin");
+    const service = new BookingIntentService(
+      new InMemoryBookingIntentRepository(),
+      new InMemorySlotRepository(aliceSlots()),
+      () => "2026-07-31T12:00:00.000Z",
+      () => 1_900_000_000_000,
+      undefined,
+      undefined,
+      capService,
+    );
+
+    await expect(service.createIntent({ slotId: "missing-slot" }, ACTOR as any)).rejects.toEqual(
+      expect.any(BookingIntentError),
+    );
+  });
+});

--- a/src/modules/booking-intents/booking-intent-service.ts
+++ b/src/modules/booking-intents/booking-intent-service.ts
@@ -25,6 +25,11 @@ import {
   createEmptyHoldFeeRegistry,
   HoldFeePolicyRegistry,
 } from "../../services/holdFeePolicy.js";
+import {
+  SupplierBookingCapService,
+  SupplierDailyCapExceededError,
+  defaultSupplierBookingCapService,
+} from "../../services/supplierCap.js";
 
 export interface CreateBookingIntentInput {
   slotId: string;
@@ -90,6 +95,7 @@ export class BookingIntentService {
     private readonly nowMs: () => number = () => Date.now(),
     policyRegistry?: VersionedPolicyRegistry,
     holdFeeRegistry?: HoldFeePolicyRegistry,
+    private readonly supplierBookingCapService: SupplierBookingCapService = defaultSupplierBookingCapService,
   ) {
     const reg = policyRegistry ?? createDefaultRegistry();
     this.getPolicyRegistrySync = () => reg;
@@ -217,6 +223,10 @@ export class BookingIntentService {
     const holdPlacedAt = bookingType === "refundable_hold" ? this.now() : undefined;
     const holdUntilMs = bookingType === "refundable_hold" ? input.holdDeadlineMs : undefined;
 
+    // Enforce the per-supplier daily booking cap (fail-open when the cap
+    // store/Redis is unavailable). Throws 429 when the supplier is over cap.
+    await this.supplierBookingCapService.increment(slot.supplierId ?? slot.professional);
+
     const intent = this.bookingIntentRepository.create({
       slotId: slot.id,
       professional: slot.professional,
@@ -303,6 +313,21 @@ export class BookingIntentService {
           reason: "Slot already has active booking intent",
         });
         continue;
+      }
+
+      // Per-occurrence supplier daily cap enforcement. A capped-out occurrence
+      // is recorded as a failure for that date rather than aborting the batch.
+      try {
+        await this.supplierBookingCapService.increment(slot.supplierId ?? slot.professional);
+      } catch (error) {
+        if (error instanceof SupplierDailyCapExceededError) {
+          failures.push({
+            date: occ.toISOString(),
+            reason: "Daily booking cap reached for this supplier",
+          });
+          continue;
+        }
+        throw error;
       }
 
       const cancellationPolicySnapshot = this.captureCancellationPolicySnapshot();

--- a/src/routes/__tests__/admin.booking-cap.test.ts
+++ b/src/routes/__tests__/admin.booking-cap.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import adminRouter from "../admin.js";
+import { setRedisClient, type RedisClient } from "../../cache/redisClient.js";
+import {
+  DEFAULT_SUPPLIER_DAILY_BOOKING_CAP,
+  defaultSupplierBookingCapService,
+} from "../../services/supplierCap.js";
+
+class FakeRedisClient implements RedisClient {
+  readonly store = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key) ?? null;
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async incr(key: string): Promise<number> {
+    const next = (parseInt(this.store.get(key) ?? "0", 10) || 0) + 1;
+    this.store.set(key, String(next));
+    return next;
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const prefix = pattern.replace("*", "");
+    return Array.from(this.store.keys()).filter((k) => k.startsWith(prefix));
+  }
+
+  async ping(): Promise<string> {
+    return "PONG";
+  }
+
+  async quit(): Promise<unknown> {
+    return "OK";
+  }
+}
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/admin", adminRouter);
+
+const adminHeaders = { "x-chronopay-admin-token": "test-admin-token" };
+
+describe("Admin Supplier Booking-Cap API", () => {
+  beforeEach(() => {
+    process.env.CHRONOPAY_ADMIN_TOKEN = "test-admin-token";
+    setRedisClient(new FakeRedisClient());
+    defaultSupplierBookingCapService.reset();
+  });
+
+  afterEach(() => {
+    delete process.env.CHRONOPAY_ADMIN_TOKEN;
+    setRedisClient(null);
+    defaultSupplierBookingCapService.reset();
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const res = await request(app).put("/api/v1/admin/suppliers/sup-1/booking-cap").send({ dailyCap: 50 });
+    expect(res.status).toBe(401);
+  });
+
+  it("sets an override via PUT and reads it back via GET", async () => {
+    const put = await request(app)
+      .put("/api/v1/admin/suppliers/sup-1/booking-cap")
+      .set(adminHeaders)
+      .send({ dailyCap: 50, description: "trial promotion" });
+    expect(put.status).toBe(200);
+    expect(put.body.success).toBe(true);
+    expect(put.body.override).toMatchObject({
+      supplierId: "sup-1",
+      dailyCap: 50,
+      description: "trial promotion",
+    });
+
+    const get = await request(app).get("/api/v1/admin/suppliers/sup-1/booking-cap").set(adminHeaders);
+    expect(get.status).toBe(200);
+    expect(get.body).toMatchObject({
+      success: true,
+      supplierId: "sup-1",
+      override: { supplierId: "sup-1", dailyCap: 50 },
+      effectiveCap: 50,
+      defaultCap: DEFAULT_SUPPLIER_DAILY_BOOKING_CAP,
+    });
+    expect(get.body.usage).toMatchObject({ supplierId: "sup-1", used: 0, cap: 50 });
+  });
+
+  it("reports the default cap for suppliers without an override", async () => {
+    const get = await request(app).get("/api/v1/admin/suppliers/sup-2/booking-cap").set(adminHeaders);
+    expect(get.status).toBe(200);
+    expect(get.body.override).toBeNull();
+    expect(get.body.effectiveCap).toBe(DEFAULT_SUPPLIER_DAILY_BOOKING_CAP);
+  });
+
+  it("accepts cap 0 as a soft block", async () => {
+    const put = await request(app)
+      .put("/api/v1/admin/suppliers/sup-1/booking-cap")
+      .set(adminHeaders)
+      .send({ dailyCap: 0 });
+    expect(put.status).toBe(200);
+    expect(put.body.override.dailyCap).toBe(0);
+  });
+
+  it("rejects invalid cap values with 400", async () => {
+    const res = await request(app)
+      .put("/api/v1/admin/suppliers/sup-1/booking-cap")
+      .set(adminHeaders)
+      .send({ dailyCap: -5 });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("deletes an override via DELETE and 404s when none exists", async () => {
+    await request(app)
+      .put("/api/v1/admin/suppliers/sup-1/booking-cap")
+      .set(adminHeaders)
+      .send({ dailyCap: 25 });
+
+    const del = await request(app)
+      .delete("/api/v1/admin/suppliers/sup-1/booking-cap")
+      .set(adminHeaders);
+    expect(del.status).toBe(200);
+    expect(del.body.deleted).toBe(true);
+
+    const second = await request(app)
+      .delete("/api/v1/admin/suppliers/sup-1/booking-cap")
+      .set(adminHeaders);
+    expect(second.status).toBe(404);
+  });
+});

--- a/src/routes/__tests__/booking-intents.supplier-cap.test.ts
+++ b/src/routes/__tests__/booking-intents.supplier-cap.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+import request from "supertest";
+import { createApp } from "../../app.js";
+import { setRedisClient, type RedisClient } from "../../cache/redisClient.js";
+import {
+  defaultSupplierBookingCapService,
+  nextUtcMidnight,
+} from "../../services/supplierCap.js";
+
+class FakeRedisClient implements RedisClient {
+  readonly store = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key) ?? null;
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async incr(key: string): Promise<number> {
+    const next = (parseInt(this.store.get(key) ?? "0", 10) || 0) + 1;
+    this.store.set(key, String(next));
+    return next;
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const prefix = pattern.replace("*", "");
+    return Array.from(this.store.keys()).filter((k) => k.startsWith(prefix));
+  }
+
+  async ping(): Promise<string> {
+    return "PONG";
+  }
+
+  async quit(): Promise<unknown> {
+    return "OK";
+  }
+}
+
+// Bookable slots from InMemorySlotRepository.DEFAULT_SLOTS (alice, bob).
+const ALICE_SLOT_ID = "slot-11111111-1111-4111-8111-111111111111";
+const BOB_SLOT_ID = "slot-22222222-2222-4222-8222-222222222222";
+
+const CUSTOMER_HEADERS = {
+  "x-chronopay-user-id": "buyer-1",
+  "x-chronopay-role": "customer",
+};
+
+// A single app instance is shared across tests (the repo's rate-limit store is a
+// process singleton, so creating multiple apps trips express-rate-limit's
+// store-reuse guard). A blocked (429) create never persists an intent, so the
+// slot assignments below cannot collide across tests.
+const app = createApp({ apiKey: "test-api-key" });
+
+describe("POST /api/v1/booking-intents — supplier daily cap", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+    setRedisClient(new FakeRedisClient());
+    defaultSupplierBookingCapService.reset();
+  });
+
+  afterEach(() => {
+    setRedisClient(null);
+    defaultSupplierBookingCapService.reset();
+  });
+
+  it("allows creates under the default cap", async () => {
+    const res = await request(app)
+      .post("/api/v1/booking-intents")
+      .set(CUSTOMER_HEADERS)
+      .send({ slotId: BOB_SLOT_ID });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("returns 429 + X-DailyCap-Reset when the supplier is soft-blocked (cap 0)", async () => {
+    await defaultSupplierBookingCapService.setOverride("alice", 0, "admin");
+
+    const res = await request(app)
+      .post("/api/v1/booking-intents")
+      .set(CUSTOMER_HEADERS)
+      .send({ slotId: ALICE_SLOT_ID });
+
+    expect(res.status).toBe(429);
+    expect(res.headers["x-dailycap-reset"]).toBe(nextUtcMidnight(new Date()));
+    expect(res.body).toMatchObject({
+      success: false,
+      code: "RATE_LIMITED",
+      details: { supplierId: "alice", used: 1, cap: 0 },
+    });
+  });
+
+  it("fails open (no cap enforcement) when Redis is unavailable", async () => {
+    setRedisClient(null);
+    await defaultSupplierBookingCapService.setOverride("alice", 0, "admin");
+
+    const res = await request(app)
+      .post("/api/v1/booking-intents")
+      .set(CUSTOMER_HEADERS)
+      .send({ slotId: ALICE_SLOT_ID });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -28,6 +28,10 @@ import { query } from "../db/pool.js";
 import { DisputeArbitrationQueueService } from "../services/disputeArbitrationQueue.js";
 import { getPayoutQuarantineService } from "../services/quarantineStore.js";
 import { strikeService } from "../services/strikeService.js";
+import {
+  DEFAULT_SUPPLIER_DAILY_BOOKING_CAP,
+  defaultSupplierBookingCapService,
+} from "../services/supplierCap.js";
 
 /**
  * Singleton cancellation-reversal service. The route handlers reuse
@@ -2164,6 +2168,101 @@ router.get(
       queue,
       total: queue.length,
     });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Supplier Daily Booking-Cap Routes (issue #585)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @route PUT /api/v1/admin/suppliers/:id/booking-cap
+ * @desc Set the per-supplier daily booking-intent cap. A cap of `0` acts as a
+ *   soft block (all creates are rejected until raised or removed).
+ *   Body: { dailyCap: number, description?: string }
+ * @access Private (admin token only)
+ */
+router.put(
+  "/suppliers/:id/booking-cap",
+  requireAdminToken,
+  async (req: Request, res: Response) => {
+    try {
+      const supplierId = String(req.params.id ?? "").trim();
+      const dailyCap = Number(req.body?.dailyCap);
+      const description =
+        typeof req.body?.description === "string" ? req.body.description : undefined;
+
+      const override = await defaultSupplierBookingCapService.setOverride(
+        supplierId,
+        dailyCap,
+        req.auth?.userId ?? req.header("x-chronopay-admin-token")?.slice(0, 8) ?? "admin",
+        description,
+      );
+      return res.status(200).json({ success: true, override });
+    } catch (err: any) {
+      return res
+        .status(400)
+        .json({ success: false, error: err.message ?? "Failed to set booking cap" });
+    }
+  },
+);
+
+/**
+ * @route GET /api/v1/admin/suppliers/:id/booking-cap
+ * @desc Read the supplier's effective booking cap, any admin override, and
+ *   current day usage.
+ * @access Private (admin token only)
+ */
+router.get(
+  "/suppliers/:id/booking-cap",
+  requireAdminToken,
+  async (req: Request, res: Response) => {
+    try {
+      const supplierId = String(req.params.id ?? "").trim();
+      const override = defaultSupplierBookingCapService.getOverride(supplierId) ?? null;
+      const usage = await defaultSupplierBookingCapService.getUsage(supplierId);
+      return res.status(200).json({
+        success: true,
+        supplierId,
+        override,
+        effectiveCap: override?.dailyCap ?? DEFAULT_SUPPLIER_DAILY_BOOKING_CAP,
+        defaultCap: DEFAULT_SUPPLIER_DAILY_BOOKING_CAP,
+        usage,
+      });
+    } catch (err: any) {
+      return res
+        .status(400)
+        .json({ success: false, error: err.message ?? "Failed to read booking cap" });
+    }
+  },
+);
+
+/**
+ * @route DELETE /api/v1/admin/suppliers/:id/booking-cap
+ * @desc Remove the supplier's booking-cap override, reverting to the default.
+ * @access Private (admin token only)
+ */
+router.delete(
+  "/suppliers/:id/booking-cap",
+  requireAdminToken,
+  async (req: Request, res: Response) => {
+    try {
+      const supplierId = String(req.params.id ?? "").trim();
+      const deleted = await defaultSupplierBookingCapService.deleteOverride(
+        supplierId,
+        req.auth?.userId ?? req.header("x-chronopay-admin-token")?.slice(0, 8) ?? "admin",
+      );
+      if (!deleted) {
+        return res
+          .status(404)
+          .json({ success: false, error: "No booking-cap override exists for this supplier" });
+      }
+      return res.status(200).json({ success: true, deleted });
+    } catch (err: any) {
+      return res
+        .status(400)
+        .json({ success: false, error: err.message ?? "Failed to delete booking cap" });
+    }
   },
 );
 

--- a/src/routes/booking-intents.ts
+++ b/src/routes/booking-intents.ts
@@ -22,6 +22,7 @@ import {
   parseCreateBookingIntentBody,
 } from "../modules/booking-intents/booking-intent-service.js";
 import { isAppError } from "../errors/AppError.js";
+import { SupplierDailyCapExceededError } from "../services/supplierCap.js";
 import { InMemoryBookingIntentRepository } from "../modules/booking-intents/booking-intent-repository.js";
 import { InMemorySlotRepository } from "../modules/slots/slot-repository.js";
 import { logger } from "../utils/logger.js";
@@ -39,6 +40,19 @@ export function createBookingIntentsRouter() {
   const bookingIntentService = new BookingIntentService(bookingIntentRepository, slotRepository);
 
   function handleServiceError(error: unknown, res: Response): void {
+    if (error instanceof SupplierDailyCapExceededError) {
+      // Per-supplier daily booking cap reached — expose the reset window so
+      // clients can retry after the next UTC-day boundary.
+      res.setHeader("X-DailyCap-Reset", error.usage.resetAt);
+      res.status(429).json({
+        success: false,
+        error: error.message,
+        code: error.code,
+        details: error.usage,
+      });
+      return;
+    }
+
     if (error instanceof BookingIntentError) {
       res.status(error.status).json({
         success: false,

--- a/src/services/__tests__/supplierCap.test.ts
+++ b/src/services/__tests__/supplierCap.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, beforeEach } from "@jest/globals";
+import {
+  DEFAULT_SUPPLIER_DAILY_BOOKING_CAP,
+  SUPPLIER_DAILY_CAP_KEY_TTL_SECONDS,
+  MAX_SUPPLIER_DAILY_BOOKING_CAP,
+  supplierDailyCapKey,
+  utcDateKey,
+  nextUtcMidnight,
+  SupplierBookingCapService,
+  SupplierDailyCapExceededError,
+  type RedisClient,
+} from "../supplierCap.js";
+
+class FakeRedisClient implements RedisClient {
+  readonly store = new Map<string, string>();
+  incrCalls: string[] = [];
+  expireCalls: { key: string; ttl: number }[] = [];
+  failIncr = false;
+  failGet = false;
+
+  async get(key: string): Promise<string | null> {
+    if (this.failGet) {
+      throw new Error("redis unavailable");
+    }
+    return this.store.get(key) ?? null;
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async incr(key: string): Promise<number> {
+    this.incrCalls.push(key);
+    if (this.failIncr) {
+      throw new Error("redis unavailable");
+    }
+    const next = (parseInt(this.store.get(key) ?? "0", 10) || 0) + 1;
+    this.store.set(key, String(next));
+    return next;
+  }
+
+  async expire(key: string, ttl: number): Promise<unknown> {
+    this.expireCalls.push({ key, ttl });
+    return 1;
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const prefix = pattern.replace("*", "");
+    return Array.from(this.store.keys()).filter((k) => k.startsWith(prefix));
+  }
+
+  async ping(): Promise<string> {
+    return "PONG";
+  }
+
+  async quit(): Promise<unknown> {
+    return "OK";
+  }
+}
+
+describe("supplierCap helpers", () => {
+  it("builds the Redis key per the issue spec", () => {
+    expect(supplierDailyCapKey("sup-1", "2026-07-31")).toBe("supplier:sup-1:booking:2026-07-31");
+  });
+
+  it("derives a UTC date key", () => {
+    expect(utcDateKey(new Date("2026-07-31T23:59:59.999Z"))).toBe("2026-07-31");
+    expect(utcDateKey(new Date("2026-08-01T00:00:00.000Z"))).toBe("2026-08-01");
+  });
+
+  it("computes the next UTC midnight as the reset boundary", () => {
+    expect(nextUtcMidnight(new Date("2026-07-31T12:00:00.000Z"))).toBe("2026-08-01T00:00:00.000Z");
+  });
+});
+
+describe("SupplierBookingCapService", () => {
+  let redis: FakeRedisClient;
+  let clockIso: string;
+  let service: SupplierBookingCapService;
+
+  beforeEach(() => {
+    redis = new FakeRedisClient();
+    clockIso = "2026-07-31T12:00:00.000Z";
+    service = new SupplierBookingCapService({
+      getRedis: () => redis,
+      nowIso: () => clockIso,
+      auditLogger: {
+        log: async () => {},
+      } as any,
+    });
+  });
+
+  describe("increment", () => {
+    it("returns usage with the default cap and a reset timestamp", async () => {
+      const usage = await service.increment("sup-1");
+      expect(usage).toEqual({
+        supplierId: "sup-1",
+        used: 1,
+        cap: DEFAULT_SUPPLIER_DAILY_BOOKING_CAP,
+        resetAt: "2026-08-01T00:00:00.000Z",
+      });
+      expect(redis.incrCalls).toEqual(["supplier:sup-1:booking:2026-07-31"]);
+    });
+
+    it("sets a 26h TTL on the first increment of the day only", async () => {
+      await service.increment("sup-1");
+      await service.increment("sup-1");
+      expect(redis.expireCalls).toEqual([
+        { key: "supplier:sup-1:booking:2026-07-31", ttl: SUPPLIER_DAILY_CAP_KEY_TTL_SECONDS },
+      ]);
+    });
+
+    it("allows exactly at the cap and rejects one over", async () => {
+      await service.setOverride("sup-1", 2, "admin");
+      expect((await service.increment("sup-1"))?.used).toBe(1);
+      expect((await service.increment("sup-1"))?.used).toBe(2);
+
+      const error = await service.increment("sup-1").catch((e) => e);
+      expect(error).toBeInstanceOf(SupplierDailyCapExceededError);
+      expect(error.statusCode).toBe(429);
+      expect(error.code).toBe("RATE_LIMITED");
+      expect(error.usage).toEqual({
+        supplierId: "sup-1",
+        used: 3,
+        cap: 2,
+        resetAt: "2026-08-01T00:00:00.000Z",
+      });
+    });
+
+    it("soft-blocks when the admin override is 0", async () => {
+      await service.setOverride("sup-1", 0, "admin");
+      const error = await service.increment("sup-1").catch((e) => e);
+      expect(error).toBeInstanceOf(SupplierDailyCapExceededError);
+      expect(error.usage.cap).toBe(0);
+      expect(error.usage.used).toBe(1);
+    });
+
+    it("fails open (returns null) when Redis is unavailable", async () => {
+      const offline = new SupplierBookingCapService({
+        getRedis: () => null,
+        nowIso: () => clockIso,
+      });
+      expect(await offline.increment("sup-1")).toBeNull();
+    });
+
+    it("fails open (returns null) when Redis throws", async () => {
+      redis.failIncr = true;
+      expect(await service.increment("sup-1")).toBeNull();
+    });
+
+    it("fails open for an invalid supplier id", async () => {
+      expect(await service.increment("")).toBeNull();
+      expect(await service.increment("  ")).toBeNull();
+    });
+
+    it("uses a fresh counter after midnight rollover", async () => {
+      clockIso = "2026-07-31T23:59:59.000Z";
+      await service.increment("sup-1");
+      expect(redis.store.get("supplier:sup-1:booking:2026-07-31")).toBe("1");
+
+      clockIso = "2026-08-01T00:00:00.000Z";
+      const usage = await service.increment("sup-1");
+      expect(usage?.used).toBe(1);
+      expect(usage?.resetAt).toBe("2026-08-02T00:00:00.000Z");
+      expect(redis.store.get("supplier:sup-1:booking:2026-08-01")).toBe("1");
+    });
+  });
+
+  describe("getUsage", () => {
+    it("reads the current count without consuming", async () => {
+      await service.increment("sup-1");
+      await service.increment("sup-1");
+      const usage = await service.getUsage("sup-1");
+      expect(usage?.used).toBe(2);
+    });
+
+    it("reports zero when the supplier has not booked today", async () => {
+      const usage = await service.getUsage("sup-1");
+      expect(usage?.used).toBe(0);
+      expect(usage?.cap).toBe(DEFAULT_SUPPLIER_DAILY_BOOKING_CAP);
+    });
+
+    it("returns null when Redis is unavailable", async () => {
+      const offline = new SupplierBookingCapService({ getRedis: () => null });
+      expect(await offline.getUsage("sup-1")).toBeNull();
+    });
+
+    it("returns null for an invalid supplier id", async () => {
+      expect(await service.getUsage("")).toBeNull();
+      expect(await service.getUsage("   ")).toBeNull();
+    });
+
+    it("returns null when Redis throws", async () => {
+      const failing = new FakeRedisClient();
+      failing.failGet = true;
+      const broken = new SupplierBookingCapService({
+        getRedis: () => failing,
+        nowIso: () => clockIso,
+      });
+      await expect(broken.getUsage("sup-1")).resolves.toBeNull();
+    });
+  });
+
+  describe("admin overrides", () => {
+    it("defaults the cap for suppliers without an override", () => {
+      expect(service.resolveCap("sup-1")).toBe(DEFAULT_SUPPLIER_DAILY_BOOKING_CAP);
+    });
+
+    it("creates, reads, lists, and deletes overrides", async () => {
+      const created = await service.setOverride("sup-1", 10, "admin-1", "trial");
+      expect(created).toMatchObject({
+        supplierId: "sup-1",
+        dailyCap: 10,
+        createdBy: "admin-1",
+        updatedBy: "admin-1",
+        description: "trial",
+      });
+      expect(service.resolveCap("sup-1")).toBe(10);
+      expect(service.getOverride("sup-1")?.dailyCap).toBe(10);
+      expect(service.listOverrides()).toHaveLength(1);
+
+      const updated = await service.setOverride("sup-1", 25, "admin-2");
+      expect(updated.updatedBy).toBe("admin-2");
+      expect(updated.createdBy).toBe("admin-1");
+
+      expect(await service.deleteOverride("sup-1", "admin-2")).toBe(true);
+      expect(await service.deleteOverride("sup-1", "admin-2")).toBe(false);
+      expect(service.getOverride("sup-1")).toBeUndefined();
+      expect(service.resolveCap("sup-1")).toBe(DEFAULT_SUPPLIER_DAILY_BOOKING_CAP);
+    });
+
+    it("rejects invalid cap values", async () => {
+      await expect(service.setOverride("", 5, "admin")).rejects.toThrow("non-empty");
+      await expect(service.setOverride("sup-1", -1, "admin")).rejects.toThrow("integer");
+      await expect(service.setOverride("sup-1", 1.5, "admin")).rejects.toThrow("integer");
+      await expect(service.setOverride("sup-1", MAX_SUPPLIER_DAILY_BOOKING_CAP + 1, "admin")).rejects.toThrow(
+        "integer",
+      );
+      await expect(service.setOverride("sup-1", NaN, "admin")).rejects.toThrow("integer");
+    });
+
+    it("reset clears all overrides", async () => {
+      await service.setOverride("sup-1", 3, "admin");
+      await service.setOverride("sup-2", 4, "admin");
+      service.reset();
+      expect(service.listOverrides()).toHaveLength(0);
+    });
+
+    it("seeds overrides from constructor options and lists them sorted", () => {
+      const seeded = new SupplierBookingCapService({
+        getRedis: () => redis,
+        seed: [
+          {
+            supplierId: "sup-2",
+            dailyCap: 8,
+            createdAt: "2026-07-31T00:00:00.000Z",
+            updatedAt: "2026-07-31T00:00:00.000Z",
+            createdBy: "admin",
+            updatedBy: "admin",
+          },
+          {
+            supplierId: "sup-1",
+            dailyCap: 7,
+            createdAt: "2026-07-31T00:00:00.000Z",
+            updatedAt: "2026-07-31T00:00:00.000Z",
+            createdBy: "admin",
+            updatedBy: "admin",
+          },
+        ],
+      });
+      expect(seeded.resolveCap("sup-1")).toBe(7);
+      expect(seeded.resolveCap("sup-2")).toBe(8);
+      expect(seeded.listOverrides().map((o) => o.supplierId)).toEqual(["sup-1", "sup-2"]);
+    });
+  });
+});

--- a/src/services/supplierCap.ts
+++ b/src/services/supplierCap.ts
@@ -1,0 +1,302 @@
+/**
+ * @file src/services/supplierCap.ts
+ *
+ * Per-supplier daily booking-intent cap (issue #585).
+ *
+ * The counter lives in Redis, keyed `supplier:{id}:booking:{yyyy-mm-dd}`, with a
+ * 26 h TTL so the key survives a short clock skew into the next day. Every
+ * booking-intent create for a supplier INCRs the counter; once `used > cap` the
+ * create is rejected with HTTP 429 and an `X-DailyCap-Reset` header.
+ *
+ * Fail-open contract: if Redis is unavailable (or errors), the cap check is a
+ * no-op — we never want an infrastructure blip to block legitimate bookings.
+ *
+ * Admin overrides live in an in-memory store (mirroring the repo's other
+ * per-supplier override stores, e.g. `supplierCancellationOverrideStore.ts`) and
+ * are managed through `PUT/GET/DELETE /api/v1/admin/suppliers/:id/booking-cap`.
+ * An override of `0` acts as a soft block (all creates rejected).
+ */
+
+import { AppError } from "../errors/AppError.js";
+import { ERROR_CODES } from "../errors/errorCodes.js";
+import { AuditLogger, defaultAuditLogger } from "./auditLogger.js";
+import { getRedisClient, type RedisClient } from "../cache/redisClient.js";
+import { logger } from "../utils/logger.js";
+
+/** Default maximum booking-intents per supplier per UTC day. */
+export const DEFAULT_SUPPLIER_DAILY_BOOKING_CAP = 500;
+
+/** Redis TTL for the daily counter key (26 h, per issue #585). */
+export const SUPPLIER_DAILY_CAP_KEY_TTL_SECONDS = 26 * 60 * 60;
+
+/** Upper bound for an admin-configured cap (sanity guard against typos). */
+export const MAX_SUPPLIER_DAILY_BOOKING_CAP = 1_000_000;
+
+/** Redis key for a supplier's daily booking counter. */
+export function supplierDailyCapKey(supplierId: string, dateKey: string): string {
+  return `supplier:${supplierId}:booking:${dateKey}`;
+}
+
+/** `yyyy-mm-dd` in UTC for the given date. */
+export function utcDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Start of the next UTC day, as an ISO timestamp. */
+export function nextUtcMidnight(date: Date): string {
+  const next = new Date(date.getTime());
+  next.setUTCHours(24, 0, 0, 0);
+  return next.toISOString();
+}
+
+/** An admin-configured override of the default per-supplier daily cap. */
+export interface SupplierBookingCapOverride {
+  supplierId: string;
+  dailyCap: number;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+  description?: string;
+}
+
+/** Snapshot of a supplier's current daily booking usage. */
+export interface BookingCapUsage {
+  supplierId: string;
+  used: number;
+  cap: number;
+  /** ISO timestamp of the next UTC-day boundary (when the window resets). */
+  resetAt: string;
+}
+
+/** The counter key carries a per-day window, so reset = start of next UTC day. */
+export function computeBookingCapReset(now: Date): string {
+  return nextUtcMidnight(now);
+}
+
+/**
+ * Thrown when a supplier has exhausted their daily booking cap. `details`
+ * carries the usage snapshot so callers can emit the `X-DailyCap-Reset` header.
+ */
+export class SupplierDailyCapExceededError extends AppError {
+  readonly usage: BookingCapUsage;
+
+  constructor(usage: BookingCapUsage) {
+    super(
+      `Daily booking cap of ${usage.cap} reached for supplier ${usage.supplierId}.`,
+      429,
+      ERROR_CODES.RATE_LIMITED.code,
+      true,
+      usage,
+    );
+    this.name = "SupplierDailyCapExceededError";
+    this.usage = usage;
+  }
+}
+
+export interface SupplierBookingCapServiceOptions {
+  /** Source of the shared Redis client. Defaults to `getRedisClient`. */
+  getRedis?: () => RedisClient | null;
+  /** Injectable clock; default `new Date().toISOString()`. */
+  nowIso?: () => string;
+  /** Injectable audit logger; defaults to `defaultAuditLogger`. */
+  auditLogger?: AuditLogger;
+  /** Seed overrides (used by tests). */
+  seed?: SupplierBookingCapOverride[];
+}
+
+export class SupplierBookingCapService {
+  private readonly getRedis: () => RedisClient | null;
+  private readonly nowIso: () => string;
+  private readonly auditLogger: AuditLogger;
+  private readonly overrides: Map<string, SupplierBookingCapOverride>;
+  private readonly defaultCap: number;
+
+  constructor(options: SupplierBookingCapServiceOptions = {}) {
+    this.getRedis = options.getRedis ?? getRedisClient;
+    this.nowIso = options.nowIso ?? (() => new Date().toISOString());
+    this.auditLogger = options.auditLogger ?? defaultAuditLogger;
+    this.overrides = new Map();
+    this.defaultCap = DEFAULT_SUPPLIER_DAILY_BOOKING_CAP;
+    if (options.seed) {
+      for (const override of options.seed) {
+        this.overrides.set(override.supplierId, { ...override });
+      }
+    }
+  }
+
+  /** Effective daily cap for a supplier (admin override, else the default). */
+  resolveCap(supplierId: string): number {
+    const override = this.overrides.get(supplierId);
+    return override ? override.dailyCap : this.defaultCap;
+  }
+
+  /**
+   * Atomically consume one booking slot for the supplier for the current UTC
+   * day and check the cap. Returns `null` when the cap cannot be enforced
+   * (Redis unavailable/error) — a deliberate fail-open. Throws
+   * {@link SupplierDailyCapExceededError} when the cap is exceeded.
+   */
+  async increment(supplierId: string): Promise<BookingCapUsage | null> {
+    if (typeof supplierId !== "string" || supplierId.trim().length === 0) {
+      return null;
+    }
+
+    const redis = this.getRedis();
+    if (!redis) {
+      return null;
+    }
+
+    const now = new Date(this.nowIso());
+    const key = supplierDailyCapKey(supplierId, utcDateKey(now));
+
+    let used: number;
+    try {
+      used = await redis.incr(key);
+      if (used === 1) {
+        await redis.expire(key, SUPPLIER_DAILY_CAP_KEY_TTL_SECONDS);
+      }
+    } catch (error) {
+      // Fail open: a Redis blip must never block legitimate bookings.
+      logger.error(
+        { err: error, supplierId },
+        "supplier-booking-cap: redis error, cap enforcement skipped",
+      );
+      return null;
+    }
+
+    const cap = this.resolveCap(supplierId);
+    const resetAt = computeBookingCapReset(now);
+    const usage: BookingCapUsage = { supplierId, used, cap, resetAt };
+
+    if (used > cap) {
+      throw new SupplierDailyCapExceededError(usage);
+    }
+
+    return usage;
+  }
+
+  /**
+   * Read the current day's usage for a supplier without consuming a booking.
+   * Returns `null` when Redis is unavailable.
+   */
+  async getUsage(supplierId: string): Promise<BookingCapUsage | null> {
+    if (typeof supplierId !== "string" || supplierId.trim().length === 0) {
+      return null;
+    }
+
+    const redis = this.getRedis();
+    if (!redis) {
+      return null;
+    }
+
+    try {
+      const raw = await redis.get(supplierDailyCapKey(supplierId, utcDateKey(new Date(this.nowIso()))));
+      const used = raw === null ? 0 : parseInt(raw, 10) || 0;
+      return {
+        supplierId,
+        used,
+        cap: this.resolveCap(supplierId),
+        resetAt: computeBookingCapReset(new Date(this.nowIso())),
+      };
+    } catch (error) {
+      logger.error(
+        { err: error, supplierId },
+        "supplier-booking-cap: redis error reading usage",
+      );
+      return null;
+    }
+  }
+
+  // ─── Admin overrides ───────────────────────────────────────────────────────
+
+  getOverride(supplierId: string): SupplierBookingCapOverride | undefined {
+    const override = this.overrides.get(supplierId);
+    return override ? { ...override } : undefined;
+  }
+
+  listOverrides(): SupplierBookingCapOverride[] {
+    return Array.from(this.overrides.values())
+      .map((o) => ({ ...o }))
+      .sort((a, b) => a.supplierId.localeCompare(b.supplierId));
+  }
+
+  async setOverride(
+    supplierId: string,
+    dailyCap: number,
+    changedBy: string,
+    description?: string,
+  ): Promise<SupplierBookingCapOverride> {
+    if (typeof supplierId !== "string" || supplierId.trim().length === 0) {
+      throw new Error("supplierId must be a non-empty string");
+    }
+    if (!Number.isInteger(dailyCap) || dailyCap < 0 || dailyCap > MAX_SUPPLIER_DAILY_BOOKING_CAP) {
+      throw new Error(
+        `dailyCap must be an integer between 0 and ${MAX_SUPPLIER_DAILY_BOOKING_CAP}`,
+      );
+    }
+
+    const now = this.nowIso();
+    const existing = this.overrides.get(supplierId);
+    const override: SupplierBookingCapOverride = {
+      supplierId,
+      dailyCap,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      createdBy: existing?.createdBy ?? changedBy,
+      updatedBy: changedBy,
+      description: description ?? existing?.description,
+    };
+    this.overrides.set(supplierId, override);
+
+    await this.auditLogger.log(
+      existing ? "booking_cap.supplier_override_updated" : "booking_cap.supplier_override_created",
+      {
+        context: {
+          supplierId,
+          dailyCap,
+          previousCap: existing?.dailyCap,
+          description,
+        },
+        userId: changedBy,
+      },
+      {
+        resource: `supplier-booking-cap:${supplierId}`,
+        status: 200,
+      },
+    );
+
+    return { ...override };
+  }
+
+  async deleteOverride(supplierId: string, changedBy: string): Promise<boolean> {
+    const existing = this.overrides.get(supplierId);
+    if (!existing) {
+      return false;
+    }
+
+    this.overrides.delete(supplierId);
+
+    await this.auditLogger.log(
+      "booking_cap.supplier_override_deleted",
+      {
+        context: { supplierId, previousCap: existing.dailyCap },
+        userId: changedBy,
+      },
+      {
+        resource: `supplier-booking-cap:${supplierId}`,
+        status: 200,
+      },
+    );
+
+    return true;
+  }
+
+  /** Clear all overrides — used by tests. */
+  reset(): void {
+    this.overrides.clear();
+  }
+}
+
+/** Default process-wide singleton. */
+export const defaultSupplierBookingCapService = new SupplierBookingCapService();


### PR DESCRIPTION
## Description
Enforces a per-supplier daily cap on booking-intent creation (default **500/day**) with a `429` response and `X-DailyCap-Reset` header, plus an admin override on the supplier.

Closes #585

## Requirements and context
- **Secure**: admin endpoints are guarded by `requireAdminToken`; no secrets exposed.
- **Tested**: 34 new tests across service, route, and admin layers (see below).
- **Documented**: JSDoc on all new public APIs (`src/services/supplierCap.ts`, admin routes).

Relevant code: `src/services/supplierCap.ts`, `src/routes/bookingIntents.ts`, `src/routes/admin.ts`, `src/app.ts`, `src/modules/booking-intents/booking-intent-service.ts`

## Implementation
- New `SupplierBookingCapService` in `src/services/supplierCap.ts`:
  - Counter keyed `supplier:{id}:booking:{yyyy-mm-dd}` (UTC) with a **26h TTL** set only on the first increment of the day.
  - `increment()` consumes one booking; throws `SupplierDailyCapExceededError` (HTTP 429, code `RATE_LIMITED`) when `used > cap`, with the usage snapshot (incl. `resetAt`) in `details`.
  - **Fail-open**: Redis unavailable/error → returns `null` and the booking proceeds (a Redis blip never blocks legitimate bookings).
  - Admin override CRUD (`getOverride`/`listOverrides`/`setOverride`/`deleteOverride`/`reset`); `dailyCap: 0` = soft block.
- Booking-intent create (`createIntent`) enforces the cap right before persisting, so a blocked create never leaves a dangling intent.
- Recurring intents (`createRecurringIntents`) enforce the cap per occurrence; capped-out occurrences are reported as failures with reason `Daily booking cap reached for this supplier`.
- Route layer (`src/routes/booking-intents.ts` + inline handler in `src/app.ts`) maps the error to:
  - `status 429`, `X-DailyCap-Reset: <next-utc-midnight>`, body `{ success: false, code: "RATE_LIMITED", details: { supplierId, used, cap, resetAt } }`.
- Admin CRUD:
  - `PUT /api/v1/admin/suppliers/:id/booking-cap` (body `{ dailyCap, description? }`; `400` on invalid cap, `0` = soft block)
  - `GET /api/v1/admin/suppliers/:id/booking-cap` (override, `effectiveCap`, `defaultCap`, current `usage`)
  - `DELETE /api/v1/admin/suppliers/:id/booking-cap` (`404` when no override)

## Tests
Ran with the repo's jest ESM setup:
```
Test Suites: 4 passed, 4 total
Tests:       34 passed, 34 total
```
- `src/services/__tests__/supplierCap.test.ts` (21) — key format, UTC date key, midnight rollover, cap boundary (exactly-at-cap allowed / one-over rejected), soft block (cap 0), 26h TTL only on first increment, fail-open on Redis null/throw/invalid id, `getUsage`, override CRUD, invalid cap values, seeded overrides + sorted listing, reset.
- `src/modules/booking-intents/__tests__/booking-intent-cap.test.ts` (4) — cap enforced across slots, fail-open, per-occurrence cap in recurring intents, unrelated booking errors still propagate.
- `src/routes/__tests__/booking-intents.supplier-cap.test.ts` (3) — allows under default cap, `429` + `X-DailyCap-Reset` + body shape, fail-open at route level.
- `src/routes/__tests__/admin.booking-cap.test.ts` (6) — `401` without admin token, PUT/GET/DELETE, default cap, soft block, invalid cap `400`, `404` delete.

### Coverage
`src/services/supplierCap.ts`: **100% lines**, **97.6% branches** (exceeds the 95% guideline).

## Notes
- The repo's global coverage threshold is 80%; a repo-wide suite currently has pre-existing failures in this environment (node 26 ESM + `rrule` and `express-rate-limit` store-reuse), none introduced by this PR.
- The pre-existing broken `FraudReasonCode` import in `src/routes/booking-intents.ts` (not part of this change) is why the route-level cap tests exercise the app via `createApp` rather than importing that router directly.
- `RedisClient` interface extended with `incr`/`expire` in `src/cache/redisClient.ts`; the three in-repo `implements RedisClient` test fakes were updated accordingly.
