### PR TITLE
feat: SOC2 vendor inventory with CI checks

### DIFF
--- a/.github/workflows/vendor-inventory.yml
+++ b/.github/workflows/vendor-inventory.yml
@@ -1,0 +1,36 @@
+name: SOC2 Vendor Inventory
+
+on:
+  pull_request:
+    paths:
+      - "docs/security/vendors.yaml"
+      - "docs/security/vendor-registry.schema.json"
+      - "scripts/vendor-inventory-check.ts"
+      - ".github/workflows/vendor-inventory.yml"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run vendor inventory check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: npx tsx scripts/vendor-inventory-check.ts

--- a/docs/security/vendor-inventory.md
+++ b/docs/security/vendor-inventory.md
@@ -1,0 +1,92 @@
+# SOC2 Vendor Inventory
+
+ChronoPay maintains a lightweight, in-repo inventory of third-party vendors
+required for SOC 2 (CC3.1 / vendor risk management). It tracks each vendor's
+risk score, criticality, invoicing currency, and the date of the most recent
+risk review.
+
+## Files
+
+| File                                                                                     | Purpose                                                                          |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [`vendors.yaml`](vendors.yaml)                                                           | The vendor registry itself (single source of truth).                             |
+| [`vendor-registry.schema.json`](vendor-registry.schema.json)                             | JSON Schema describing the registry shape.                                       |
+| [`scripts/vendor-inventory-check.ts`](../../scripts/vendor-inventory-check.ts)           | Validator + freshness checker run by CI.                                         |
+| [`.github/workflows/vendor-inventory.yml`](../../.github/workflows/vendor-inventory.yml) | CI job: fails on stale/duplicate/invalid entries and posts a summary PR comment. |
+
+## Adding or updating a vendor
+
+1. Add (or edit) an entry in `vendors.yaml`:
+
+   ```yaml
+   - id: example-vendor
+     name: Example Vendor Inc.
+     category: analytics
+     service: product analytics dashboards
+     owner: data-team
+     risk_score: 2
+     criticality: medium
+     currency: USD
+     review_date: 2026-08-01
+     review_cadence_months: 12
+     data_classification: confidential
+     notes: Shared only aggregated, non-personal metrics.
+   ```
+
+2. Open a PR. CI validates the registry and posts a summary comment with the
+   per-vendor next review date.
+
+### Required fields
+
+- `id` — unique slug (`^[a-z0-9][a-z0-9-]*$`); **duplicates fail CI**.
+- `name`, `category`, `service`, `owner` — free-form strings.
+- `risk_score` — integer 1–5; **a missing risk score fails CI**.
+- `criticality` — `low | medium | high | critical`.
+- `currency` — 3-letter ISO code, must be listed in `allowed_currencies`;
+  a **currency change without a fresh `review_date` fails CI** (the change
+  must be preceded by a re-review).
+- `review_date` — ISO date (YYYY-MM-DD) of the last review; must not be in
+  the future.
+
+### Optional fields
+
+- `review_cadence_months` — tighter cadence (default 12; never looser, CI
+  enforces the 12-month maximum).
+- `data_classification` — highest classification of shared data.
+- `notes` — context for the reviewer.
+
+## Review cadence
+
+- Every entry must be reviewed **at least once every 12 months**.
+- CI fails if any `review_date` is older than 12 months.
+- CI warns when an entry is within 3 months of the limit so reviews can be
+  scheduled before the deadline.
+
+## How CI enforces this
+
+`.github/workflows/vendor-inventory.yml` runs on any PR that touches the
+registry (or the checker itself):
+
+```
+npx tsx scripts/vendor-inventory-check.ts
+```
+
+- Exit code 0 → valid and fresh.
+- Exit code 1 → invalid, stale, duplicated, or unreviewed currency change.
+- When run with `GITHUB_TOKEN`, `GITHUB_REPOSITORY` and `PR_NUMBER` set (CI),
+  it posts a summary comment on the PR.
+
+Run the same check locally:
+
+```
+npx tsx scripts/vendor-inventory-check.ts
+```
+
+## Edge cases covered
+
+- Missing `risk_score` → error.
+- Duplicate vendor `id` → error.
+- `currency` not in `allowed_currencies` → error.
+- `currency` changed vs. the PR base branch without updating `review_date` → error.
+- `review_date` older than 12 months → error; within 3 months of the limit → warning.
+- Malformed dates, future dates, out-of-range risk scores → error.

--- a/docs/security/vendor-registry.schema.json
+++ b/docs/security/vendor-registry.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ChronoPay/ChronoPay-Backend/blob/main/docs/security/vendor-registry.schema.json",
+  "title": "SOC2 Vendor Inventory",
+  "description": "Registry of third-party vendors with periodic risk review dates. Enforced by scripts/vendor-inventory-check.ts in CI (entries older than 12 months fail the build).",
+  "type": "object",
+  "required": ["schema_version", "last_updated", "allowed_currencies", "vendors"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Bump when the entry shape changes."
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO date (YYYY-MM-DD) the registry was last edited."
+    },
+    "allowed_currencies": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3, "maxLength": 3, "pattern": "^[A-Z]{3}$" },
+      "description": "ISO 4217 currencies vendors are permitted to invoice in. A vendor whose currency changes must be re-reviewed (review_date must move)."
+    },
+    "vendors": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Vendor entries. IDs must be unique.",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "category", "service", "owner", "risk_score", "criticality", "currency", "review_date"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]*$",
+            "description": "Stable, unique identifier (slug). Duplicate IDs are rejected by CI."
+          },
+          "name": { "type": "string", "minLength": 1 },
+          "category": { "type": "string", "minLength": 1 },
+          "service": { "type": "string", "minLength": 1 },
+          "owner": { "type": "string", "minLength": 1, "description": "Team or person accountable for the vendor relationship." },
+          "risk_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "1 = low risk, 5 = critical risk. Missing risk scores are rejected by CI."
+          },
+          "criticality": { "enum": ["low", "medium", "high", "critical"] },
+          "currency": { "type": "string", "minLength": 3, "maxLength": 3, "pattern": "^[A-Z]{3}$", "description": "Invoicing currency; must appear in allowed_currencies." },
+          "review_date": { "type": "string", "format": "date", "description": "ISO date (YYYY-MM-DD) of the most recent risk review. Must not be in the future." },
+          "review_cadence_months": { "type": "integer", "minimum": 1, "default": 12, "description": "Optional tighter cadence; never looser than the 12-month CI limit." },
+          "data_classification": { "type": "string", "description": "Highest classification of data shared with the vendor (public/confidential/restricted)." },
+          "notes": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/security/vendors.yaml
+++ b/docs/security/vendors.yaml
@@ -1,0 +1,60 @@
+# SOC2 vendor inventory
+#
+# Every entry must be reviewed at least once every 12 months. CI fails when an
+# entry is older than that (see scripts/vendor-inventory-check.ts and
+# .github/workflows/vendor-inventory.yml). Schema:
+# docs/security/vendor-registry.schema.json. Guide: docs/security/vendor-inventory.md
+schema_version: 1
+last_updated: 2026-07-28
+
+allowed_currencies:
+  - USD
+  - EUR
+  - GBP
+
+vendors:
+  - id: amazon-web-services
+    name: Amazon Web Services
+    category: cloud_infrastructure
+    service: compute, storage, networking
+    owner: platform-engineering
+    risk_score: 3
+    criticality: high
+    currency: USD
+    review_date: 2026-06-12
+    review_cadence_months: 12
+    data_classification: confidential
+    notes: Primary cloud provider; SOC 2 Type II report reviewed at last audit.
+  - id: stripe
+    name: Stripe
+    category: payment_processing
+    service: card payments and payouts
+    owner: payments-team
+    risk_score: 4
+    criticality: critical
+    currency: USD
+    review_date: 2026-07-01
+    review_cadence_months: 12
+    data_classification: confidential
+    notes: PCI-DSS level 1 certified.
+  - id: google-cloud
+    name: Google Cloud Platform
+    category: cloud_infrastructure
+    service: KMS, object storage, container runtime
+    owner: platform-engineering
+    risk_score: 3
+    criticality: high
+    currency: USD
+    review_date: 2026-03-19
+    review_cadence_months: 12
+    data_classification: confidential
+  - id: twilio-sendgrid
+    name: Twilio SendGrid
+    category: email_services
+    service: transactional email delivery
+    owner: notifications-team
+    risk_score: 2
+    criticality: medium
+    currency: USD
+    review_date: 2026-05-22
+    data_classification: public

--- a/scripts/__tests__/vendor-inventory-check.test.ts
+++ b/scripts/__tests__/vendor-inventory-check.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for scripts/vendor-inventory-check.ts (issue #521).
+ *
+ * Covers:
+ *  - the YAML subset parser (maps, sequences, scalars, comments)
+ *  - schema validation (missing risk score, duplicate vendors, bad currency)
+ *  - the 12-month freshness rule (stale vs. warning vs. fresh)
+ *  - currency-change re-review detection
+ *  - end-to-end runCheck behaviour and summary output
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  buildSummary,
+  checkFreshness,
+  detectCurrencyChanges,
+  parseRegistry,
+  parseYaml,
+  runCheck,
+  validateRegistry,
+  VendorRegistry,
+} from "../vendor-inventory-check";
+
+const NOW = new Date("2026-08-02T00:00:00Z");
+
+function baseRegistry(overrides: Partial<VendorRegistry> = {}): VendorRegistry {
+  return {
+    schemaVersion: 1,
+    lastUpdated: "2026-07-28",
+    allowedCurrencies: ["USD", "EUR"],
+    vendors: [
+      {
+        id: "stripe",
+        name: "Stripe",
+        category: "payment_processing",
+        service: "card payments",
+        owner: "payments-team",
+        riskScore: 4,
+        criticality: "critical",
+        currency: "USD",
+        reviewDate: "2026-07-01",
+        reviewCadenceMonths: 12,
+      },
+      {
+        id: "twilio-sendgrid",
+        name: "Twilio SendGrid",
+        category: "email_services",
+        service: "transactional email",
+        owner: "notifications-team",
+        riskScore: 2,
+        criticality: "medium",
+        currency: "USD",
+        reviewDate: "2026-05-22",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const VALID_YAML = `
+# SOC2 vendor inventory
+schema_version: 1
+last_updated: 2026-07-28
+allowed_currencies:
+  - USD
+  - EUR
+vendors:
+  - id: stripe
+    name: Stripe
+    category: payment_processing
+    service: card payments
+    owner: payments-team
+    risk_score: 4
+    criticality: critical
+    currency: USD
+    review_date: 2026-07-01
+  - id: twilio-sendgrid
+    name: Twilio SendGrid
+    category: email_services
+    service: transactional email
+    owner: notifications-team
+    risk_score: 2
+    criticality: medium
+    currency: USD
+    review_date: 2026-05-22
+`;
+
+// ---------------------------------------------------------------------------
+// YAML subset parser
+// ---------------------------------------------------------------------------
+
+describe("parseYaml", () => {
+  it("parses maps, sequences, nested blocks and scalars", () => {
+    const value = parseYaml(`
+schema_version: 1
+allowed_currencies:
+  - USD
+  - EUR
+vendors:
+  - id: stripe
+    name: Stripe
+    risk_score: 4
+    active: true
+`);
+    expect(value).toEqual({
+      schema_version: 1,
+      allowed_currencies: ["USD", "EUR"],
+      vendors: [{ id: "stripe", name: "Stripe", risk_score: 4, active: true }],
+    });
+  });
+
+  it("ignores comments and blank lines", () => {
+    const value = parseYaml("# top comment\n\nkey: value # trailing comment\nlist:\n  - a\n");
+    expect(value).toEqual({ key: "value", list: ["a"] });
+  });
+
+  it("handles quoted scalars", () => {
+    const value = parseYaml("title: \"hello: world\"\nliteral: 'a#b'\n");
+    expect(value).toEqual({ title: "hello: world", literal: "a#b" });
+  });
+
+  it("throws on malformed input", () => {
+    expect(() => parseYaml("just some text\n")).toThrow(/expected "key: value"/);
+    expect(() => parseYaml("key:\n  nested: 1\nother: 2\n")).not.toThrow();
+    expect(() => parseYaml("key:\n  nested: 1\n  - item\n")).toThrow(
+      /unexpected|indentation|trailing/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRegistry
+// ---------------------------------------------------------------------------
+
+describe("parseRegistry", () => {
+  it("parses a valid registry", () => {
+    const registry = parseRegistry(parseYaml(VALID_YAML));
+    expect(registry.schemaVersion).toBe(1);
+    expect(registry.allowedCurrencies).toEqual(["USD", "EUR"]);
+    expect(registry.vendors).toHaveLength(2);
+    expect(registry.vendors[0].id).toBe("stripe");
+  });
+
+  it("rejects an unsupported schema version", () => {
+    const root = parseYaml(VALID_YAML) as Record<string, unknown>;
+    root.schema_version = 2;
+    expect(() => parseRegistry(root)).toThrow(/unsupported schema_version/);
+  });
+
+  it("rejects a missing risk_score", () => {
+    const root = parseYaml(VALID_YAML.replace("    risk_score: 4\n", "")) as Record<
+      string,
+      unknown
+    >;
+    expect(() => parseRegistry(root)).toThrow(/risk_score/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateRegistry
+// ---------------------------------------------------------------------------
+
+describe("validateRegistry", () => {
+  it("accepts a valid registry", () => {
+    expect(validateRegistry(baseRegistry(), NOW)).toEqual([]);
+  });
+
+  it("flags a duplicate vendor entry", () => {
+    const reg = baseRegistry();
+    reg.vendors.push({ ...reg.vendors[0] });
+    expect(validateRegistry(reg, NOW)).toContain("[stripe] duplicate vendor entry");
+  });
+
+  it("flags a risk score outside 1..5", () => {
+    const reg = baseRegistry();
+    reg.vendors[0].riskScore = 6;
+    expect(validateRegistry(reg, NOW)).toContain(
+      "[stripe] risk_score must be an integer between 1 and 5",
+    );
+  });
+
+  it("flags an invalid criticality", () => {
+    const reg = baseRegistry();
+    reg.vendors[0].criticality = "extreme";
+    expect(validateRegistry(reg, NOW)).toContain(
+      "[stripe] criticality must be one of low, medium, high, critical",
+    );
+  });
+
+  it("flags a currency not in allowed_currencies", () => {
+    const reg = baseRegistry();
+    reg.vendors[0].currency = "BTC";
+    expect(validateRegistry(reg, NOW)).toContain(
+      '[stripe] currency "BTC" is not in allowed_currencies',
+    );
+  });
+
+  it("flags a malformed or future review_date", () => {
+    const reg = baseRegistry();
+    reg.vendors[0].reviewDate = "2026-13-45";
+    expect(validateRegistry(reg, NOW)).toContain(
+      "[stripe] review_date must be a valid YYYY-MM-DD date",
+    );
+
+    const reg2 = baseRegistry();
+    reg2.vendors[0].reviewDate = "2027-01-01";
+    expect(validateRegistry(reg2, NOW)).toContain("[stripe] review_date cannot be in the future");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Freshness
+// ---------------------------------------------------------------------------
+
+describe("checkFreshness", () => {
+  it("passes fresh entries", () => {
+    const result = checkFreshness(baseRegistry(), NOW);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("fails entries older than 12 months", () => {
+    const reg = baseRegistry();
+    reg.vendors[0].reviewDate = "2025-06-01";
+    const result = checkFreshness(reg, NOW);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("older than the 12-month limit");
+  });
+
+  it("warns when an entry approaches the limit", () => {
+    const reg = baseRegistry();
+    reg.vendors[0].reviewDate = "2025-10-02";
+    const result = checkFreshness(reg, NOW);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("review due within");
+  });
+
+  it("honours a tighter review_cadence_months", () => {
+    const reg = baseRegistry();
+    reg.vendors[0].reviewDate = "2026-03-01";
+    reg.vendors[0].reviewCadenceMonths = 4;
+    const result = checkFreshness(reg, NOW);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("4-month limit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Currency changes
+// ---------------------------------------------------------------------------
+
+describe("detectCurrencyChanges", () => {
+  it("rejects a currency change without a fresh review", () => {
+    const prev = baseRegistry();
+    const next = baseRegistry();
+    next.vendors[0].currency = "EUR";
+    const errors = detectCurrencyChanges(prev, next);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("currency changed (USD -> EUR)");
+    expect(errors[0]).toContain("review_date was not updated");
+  });
+
+  it("accepts a currency change that was re-reviewed", () => {
+    const prev = baseRegistry();
+    const next = baseRegistry();
+    next.vendors[0].currency = "EUR";
+    next.vendors[0].reviewDate = "2026-07-29";
+    expect(detectCurrencyChanges(prev, next)).toEqual([]);
+  });
+
+  it("ignores unrelated changes", () => {
+    const prev = baseRegistry();
+    const next = baseRegistry();
+    next.vendors[1].riskScore = 3;
+    expect(detectCurrencyChanges(prev, next)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runCheck + summary
+// ---------------------------------------------------------------------------
+
+describe("runCheck", () => {
+  it("passes a valid registry", () => {
+    const report = runCheck(VALID_YAML, null, NOW);
+    expect(report.ok).toBe(true);
+    expect(report.errors).toEqual([]);
+  });
+
+  it("fails a stale registry", () => {
+    const stale = VALID_YAML.replace("review_date: 2026-07-01", "review_date: 2025-05-01");
+    const report = runCheck(stale, null, NOW);
+    expect(report.ok).toBe(false);
+    expect(report.errors.some((e) => e.includes("older than the 12-month limit"))).toBe(true);
+  });
+
+  it("fails a duplicate vendor", () => {
+    const dup = `${VALID_YAML}\n  - id: stripe\n    name: Stripe 2\n    category: payments\n    service: backup\n    owner: payments-team\n    risk_score: 3\n    criticality: medium\n    currency: USD\n    review_date: 2026-07-01\n`;
+    const report = runCheck(dup, null, NOW);
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain("[stripe] duplicate vendor entry");
+  });
+
+  it("fails unparsable YAML", () => {
+    const report = runCheck("not: [valid\n", null, NOW);
+    expect(report.ok).toBe(false);
+    expect(report.errors[0]).toMatch(/could not be parsed/);
+  });
+
+  it("fails on a currency change against the base registry", () => {
+    const next = VALID_YAML.replace(
+      "currency: USD\n    review_date: 2026-07-01",
+      "currency: EUR\n    review_date: 2026-07-01",
+    );
+    const report = runCheck(next, VALID_YAML, NOW);
+    expect(report.ok).toBe(false);
+    expect(report.errors.some((e) => e.includes("currency changed"))).toBe(true);
+  });
+});
+
+describe("buildSummary", () => {
+  it("reports vendor count and next review dates", () => {
+    const summary = buildSummary(baseRegistry(), [], [], NOW);
+    expect(summary).toContain("## SOC2 Vendor Inventory Summary");
+    expect(summary).toContain("Vendors: 2");
+    expect(summary).toContain("all entries are within the 12-month review limit");
+    expect(summary).toContain("`stripe`");
+  });
+
+  it("lists errors when present", () => {
+    const summary = buildSummary(baseRegistry(), ["[stripe] broken"], [], NOW);
+    expect(summary).toContain("[ERROR] [stripe] broken");
+  });
+});

--- a/scripts/vendor-inventory-check.ts
+++ b/scripts/vendor-inventory-check.ts
@@ -1,0 +1,584 @@
+/**
+ * SOC2 vendor inventory checker (issue #521).
+ *
+ * Validates `docs/security/vendors.yaml` against the documented schema,
+ * enforces the 12-month review freshness rule, detects duplicate vendors and
+ * currency changes that were not re-reviewed, and (in CI) posts a summary as
+ * a PR comment.
+ *
+ * Exit codes:
+ *  - 0: registry is valid and every entry is fresh
+ *  - 1: validation or freshness errors (CI must fail)
+ *
+ * Usage:
+ *   npx tsx scripts/vendor-inventory-check.ts [path-to-vendors.yaml]
+ */
+
+import { execSync } from "child_process";
+import fs from "fs";
+import https from "https";
+
+process.on("unhandledRejection", (err) => {
+  console.error("Unhandled Rejection:", err && err.stack ? err.stack : err);
+  process.exit(1);
+});
+
+process.on("uncaughtException", (err) => {
+  console.error("Uncaught Exception:", err && err.stack ? err.stack : err);
+  process.exit(1);
+});
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type YamlValue = string | number | boolean | null | YamlValue[] | Record<string, YamlValue>;
+
+export interface VendorEntry {
+  id: string;
+  name: string;
+  category: string;
+  service: string;
+  owner: string;
+  riskScore: number;
+  criticality: string;
+  currency: string;
+  reviewDate: string;
+  reviewCadenceMonths?: number;
+  dataClassification?: string;
+  notes?: string;
+}
+
+export interface VendorRegistry {
+  schemaVersion: number;
+  lastUpdated: string;
+  allowedCurrencies: string[];
+  vendors: VendorEntry[];
+}
+
+export interface InventoryReport {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  summary: string;
+}
+
+export const DEFAULT_REGISTRY_PATH = "docs/security/vendors.yaml";
+export const STALE_THRESHOLD_MONTHS = 12;
+export const WARN_THRESHOLD_MONTHS = 9;
+export const VALID_CRITICALITY = ["low", "medium", "high", "critical"];
+
+// ---------------------------------------------------------------------------
+// Minimal YAML subset parser (block maps/sequences + scalars)
+// ---------------------------------------------------------------------------
+
+interface YamlLine {
+  indent: number;
+  text: string;
+  line: number;
+}
+
+class YamlParseError extends Error {
+  constructor(message: string, line?: number) {
+    super(line ? `line ${line}: ${message}` : message);
+    this.name = "YamlParseError";
+  }
+}
+
+function stripComment(raw: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === "#" && !inSingle && !inDouble) return raw.slice(0, i);
+  }
+  return raw;
+}
+
+function parseScalar(text: string): YamlValue {
+  const t = text.trim();
+  if (t.startsWith('"') && t.endsWith('"')) return t.slice(1, -1);
+  if (t.startsWith("'") && t.endsWith("'")) return t.slice(1, -1);
+  if (t === "null" || t === "~") return null;
+  if (t === "true") return true;
+  if (t === "false") return false;
+  if (/^-?\d+$/.test(t)) return parseInt(t, 10);
+  if (/^-?\d+\.\d+$/.test(t)) return parseFloat(t);
+  return t;
+}
+
+function isSequenceItem(text: string): boolean {
+  return text === "-" || text.startsWith("- ");
+}
+
+function splitKeyValue(text: string): { key: string; rest: string } {
+  const idx = text.indexOf(":");
+  if (idx === -1) throw new YamlParseError(`expected "key: value"`);
+  return { key: text.slice(0, idx).trim(), rest: text.slice(idx + 1).trim() };
+}
+
+function parseBlock(lines: YamlLine[], state: { pos: number }, indent: number): YamlValue {
+  if (state.pos >= lines.length) return {};
+  const first = lines[state.pos];
+  if (first.indent < indent) return {};
+  if (first.indent > indent) {
+    throw new YamlParseError(`unexpected indentation (${first.text})`, first.line);
+  }
+
+  if (isSequenceItem(first.text)) {
+    const items: YamlValue[] = [];
+    while (state.pos < lines.length) {
+      const line = lines[state.pos];
+      if (line.indent !== indent || !isSequenceItem(line.text)) break;
+      const rest = line.text === "-" ? "" : line.text.slice(2).trim();
+      if (rest === "") {
+        state.pos++;
+        items.push(parseBlock(lines, state, line.indent + 2));
+      } else if (rest.includes(":")) {
+        state.pos++;
+        const { key, rest: valueRest } = splitKeyValue(rest);
+        const item: Record<string, YamlValue> = {};
+        if (valueRest !== "") {
+          item[key] = parseScalar(valueRest);
+        } else {
+          item[key] = parseBlock(lines, state, lines[state.pos]?.indent ?? line.indent + 2);
+        }
+        while (state.pos < lines.length && lines[state.pos].indent > line.indent) {
+          const nested = lines[state.pos];
+          if (isSequenceItem(nested.text)) {
+            items.push(...(parseBlock(lines, state, nested.indent) as YamlValue[]));
+            continue;
+          }
+          const { key: nk, rest: nv } = splitKeyValue(nested.text);
+          if (nv === "") {
+            state.pos++;
+            item[nk] = parseBlock(lines, state, lines[state.pos]?.indent ?? nested.indent + 2);
+          } else {
+            item[nk] = parseScalar(nv);
+            state.pos++;
+          }
+        }
+        items.push(item);
+      } else {
+        items.push(parseScalar(rest));
+        state.pos++;
+      }
+    }
+    return items;
+  }
+
+  const map: Record<string, YamlValue> = {};
+  while (state.pos < lines.length) {
+    const line = lines[state.pos];
+    if (line.indent !== indent || isSequenceItem(line.text)) break;
+    const { key, rest } = splitKeyValue(line.text);
+    if (rest === "") {
+      const childIndent = lines[state.pos + 1]?.indent ?? indent + 2;
+      if (childIndent <= indent) {
+        throw new YamlParseError(`missing value for key "${key}"`, line.line);
+      }
+      state.pos++;
+      map[key] = parseBlock(lines, state, childIndent);
+    } else {
+      map[key] = parseScalar(rest);
+      state.pos++;
+    }
+  }
+  return map;
+}
+
+export function parseYaml(source: string): YamlValue {
+  const lines: YamlLine[] = [];
+  source.split(/\r?\n/).forEach((raw, idx) => {
+    const stripped = stripComment(raw);
+    const trimmed = stripped.trim();
+    if (trimmed === "") return;
+    const indent = stripped.length - stripped.trimStart().length;
+    lines.push({ indent, text: trimmed, line: idx + 1 });
+  });
+  if (lines.length === 0) return {};
+  const state = { pos: 0 };
+  const value = parseBlock(lines, state, lines[0].indent);
+  if (state.pos !== lines.length) {
+    throw new YamlParseError(
+      `unexpected trailing content ("${lines[state.pos].text}")`,
+      lines[state.pos].line,
+    );
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Registry parsing + validation
+// ---------------------------------------------------------------------------
+
+function asRecord(value: YamlValue, what: string): Record<string, YamlValue> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${what} must be a mapping`);
+  }
+  return value;
+}
+
+function asString(value: YamlValue | undefined, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`"${field}" must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function asInt(value: YamlValue | undefined, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`"${field}" must be an integer`);
+  }
+  return value;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parseRegistry(root: YamlValue): VendorRegistry {
+  const record = asRecord(root, "registry");
+  const schemaVersion = asInt(record.schema_version, "schema_version");
+  if (schemaVersion !== 1) {
+    throw new Error(`unsupported schema_version ${schemaVersion} (expected 1)`);
+  }
+  const lastUpdated = asString(record.last_updated, "last_updated");
+  if (!DATE_RE.test(lastUpdated)) {
+    throw new Error(`"last_updated" must be a YYYY-MM-DD date`);
+  }
+  const allowed = record.allowed_currencies;
+  if (!Array.isArray(allowed) || allowed.length === 0) {
+    throw new Error(`"allowed_currencies" must be a non-empty list`);
+  }
+  const allowedCurrencies = allowed.map((c) => asString(c, "allowed_currencies entry"));
+  const vendorsRaw = record.vendors;
+  if (!Array.isArray(vendorsRaw)) {
+    throw new Error(`"vendors" must be a list`);
+  }
+  const vendors = vendorsRaw.map((raw) => {
+    const v = asRecord(raw, "vendor entry");
+    const entry: VendorEntry = {
+      id: asString(v.id, "id"),
+      name: asString(v.name, "name"),
+      category: asString(v.category, "category"),
+      service: asString(v.service, "service"),
+      owner: asString(v.owner, "owner"),
+      riskScore: asInt(v.risk_score, "risk_score"),
+      criticality: asString(v.criticality, "criticality"),
+      currency: asString(v.currency, "currency"),
+      reviewDate: asString(v.review_date, "review_date"),
+    };
+    if (v.review_cadence_months !== undefined) {
+      entry.reviewCadenceMonths = asInt(v.review_cadence_months, "review_cadence_months");
+    }
+    if (v.data_classification !== undefined) {
+      entry.dataClassification = asString(v.data_classification, "data_classification");
+    }
+    if (v.notes !== undefined) {
+      entry.notes = asString(v.notes, "notes");
+    }
+    return entry;
+  });
+  return { schemaVersion, lastUpdated, allowedCurrencies, vendors };
+}
+
+function validDate(s: string): boolean {
+  if (!DATE_RE.test(s)) return false;
+  const d = new Date(`${s}T00:00:00Z`);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+}
+
+export function validateRegistry(reg: VendorRegistry, now: Date = new Date()): string[] {
+  const errors: string[] = [];
+  const seen = new Set<string>();
+
+  reg.vendors.forEach((vendor) => {
+    const tag = `[${vendor.id}]`;
+
+    if (seen.has(vendor.id)) {
+      errors.push(`${tag} duplicate vendor entry`);
+    }
+    seen.add(vendor.id);
+
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(vendor.id)) {
+      errors.push(`${tag} id must match ^[a-z0-9][a-z0-9-]*$`);
+    }
+    if (vendor.riskScore < 1 || vendor.riskScore > 5) {
+      errors.push(`${tag} risk_score must be an integer between 1 and 5`);
+    }
+    if (!VALID_CRITICALITY.includes(vendor.criticality)) {
+      errors.push(`${tag} criticality must be one of ${VALID_CRITICALITY.join(", ")}`);
+    }
+    if (!reg.allowedCurrencies.includes(vendor.currency)) {
+      errors.push(`${tag} currency "${vendor.currency}" is not in allowed_currencies`);
+    }
+    if (!validDate(vendor.reviewDate)) {
+      errors.push(`${tag} review_date must be a valid YYYY-MM-DD date`);
+    } else {
+      const review = new Date(`${vendor.reviewDate}T00:00:00Z`);
+      if (review.getTime() > now.getTime()) {
+        errors.push(`${tag} review_date cannot be in the future`);
+      }
+    }
+    if (vendor.reviewCadenceMonths !== undefined && vendor.reviewCadenceMonths < 1) {
+      errors.push(`${tag} review_cadence_months must be >= 1`);
+    }
+  });
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Freshness + currency-change checks
+// ---------------------------------------------------------------------------
+
+function monthsBetween(from: Date, to: Date): number {
+  return (to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24 * 30.4375);
+}
+
+export function checkFreshness(
+  reg: VendorRegistry,
+  now: Date = new Date(),
+): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  reg.vendors.forEach((vendor) => {
+    if (!validDate(vendor.reviewDate)) return;
+    const review = new Date(`${vendor.reviewDate}T00:00:00Z`);
+    const ageMonths = monthsBetween(review, now);
+    const cadence = vendor.reviewCadenceMonths ?? STALE_THRESHOLD_MONTHS;
+    const staleAt = Math.min(cadence, STALE_THRESHOLD_MONTHS);
+    if (ageMonths > staleAt) {
+      errors.push(
+        `[${vendor.id}] review is ${ageMonths.toFixed(1)} months old; older than the ${staleAt}-month limit ` +
+          `(last reviewed ${vendor.reviewDate})`,
+      );
+    } else if (ageMonths > WARN_THRESHOLD_MONTHS) {
+      warnings.push(
+        `[${vendor.id}] review is ${ageMonths.toFixed(1)} months old; review due within ` +
+          `${(staleAt - ageMonths).toFixed(1)} months (last reviewed ${vendor.reviewDate})`,
+      );
+    }
+  });
+
+  return { errors, warnings };
+}
+
+/** A currency change must be accompanied by a fresh review of the vendor. */
+export function detectCurrencyChanges(prev: VendorRegistry, next: VendorRegistry): string[] {
+  const errors: string[] = [];
+  const prevById = new Map(prev.vendors.map((v) => [v.id, v]));
+  next.vendors.forEach((vendor) => {
+    const before = prevById.get(vendor.id);
+    if (before && before.currency !== vendor.currency) {
+      if (before.reviewDate === vendor.reviewDate) {
+        errors.push(
+          `[${vendor.id}] currency changed (${before.currency} -> ${vendor.currency}) but review_date was ` +
+            `not updated; a fresh review is required`,
+        );
+      }
+    }
+  });
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Report + summary
+// ---------------------------------------------------------------------------
+
+export function buildSummary(
+  reg: VendorRegistry,
+  errors: string[],
+  warnings: string[],
+  now: Date = new Date(),
+): string {
+  const lines: string[] = [];
+  lines.push("## SOC2 Vendor Inventory Summary");
+  lines.push("");
+  lines.push(`- Vendors: ${reg.vendors.length}`);
+  if (errors.length === 0) {
+    lines.push("- Freshness: all entries are within the 12-month review limit");
+  } else {
+    lines.push(
+      `- Freshness: ${errors.filter((e) => e.includes("older than the")).length} stale entr${errors.filter((e) => e.includes("older than the")).length === 1 ? "y" : "ies"}`,
+    );
+  }
+  if (warnings.length > 0) {
+    lines.push(`- Approaching review: ${warnings.length}`);
+  }
+  lines.push("");
+  lines.push("Next reviews due:");
+  const due: Array<{ id: string; date: string; when: string }> = [];
+  reg.vendors.forEach((vendor) => {
+    if (!validDate(vendor.reviewDate)) return;
+    const cadence = vendor.reviewCadenceMonths ?? STALE_THRESHOLD_MONTHS;
+    const review = new Date(`${vendor.reviewDate}T00:00:00Z`);
+    const dueAt = new Date(review);
+    dueAt.setUTCMonth(dueAt.getUTCMonth() + cadence);
+    const months = monthsBetween(now, dueAt);
+    const when =
+      months < 0 ? "OVERDUE" : months <= 3 ? `in ${months.toFixed(1)} months` : "on track";
+    due.push({ id: vendor.id, date: vendor.reviewDate, when });
+  });
+  due.forEach((d) => lines.push(`- \`${d.id}\` — last reviewed ${d.date}, ${d.when}`));
+  if (due.length === 0) lines.push("- (none)");
+
+  if (errors.length > 0) {
+    lines.push("");
+    lines.push("Errors:");
+    errors.forEach((e) => lines.push(`- [ERROR] ${e}`));
+  }
+  if (warnings.length > 0) {
+    lines.push("");
+    lines.push("Warnings:");
+    warnings.forEach((w) => lines.push(`- [WARN] ${w}`));
+  }
+  return lines.join("\n");
+}
+
+export function runCheck(
+  source: string,
+  baseSource: string | null,
+  now: Date = new Date(),
+): InventoryReport {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let registry: VendorRegistry;
+  try {
+    registry = parseRegistry(parseYaml(source));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      errors: [`registry could not be parsed: ${message}`],
+      warnings: [],
+      summary: `## SOC2 Vendor Inventory Summary\n\nRegistry could not be parsed:\n- ❌ ${message}`,
+    };
+  }
+
+  errors.push(...validateRegistry(registry, now));
+  const freshness = checkFreshness(registry, now);
+  errors.push(...freshness.errors);
+  warnings.push(...freshness.warnings);
+
+  if (baseSource !== null) {
+    try {
+      const prev = parseRegistry(parseYaml(baseSource));
+      errors.push(...detectCurrencyChanges(prev, registry));
+    } catch {
+      // Base registry could not be parsed (e.g. pre-schema shape): skip diff.
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: buildSummary(registry, errors, warnings, now),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI + PR comment
+// ---------------------------------------------------------------------------
+
+function postComment(body: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const token = process.env.GITHUB_TOKEN;
+    const repo = process.env.GITHUB_REPOSITORY;
+    const pr = process.env.PR_NUMBER;
+    if (!token || !repo || !pr) {
+      resolve();
+      return;
+    }
+    const data = JSON.stringify({ body });
+    const req = https.request(
+      `https://api.github.com/repos/${repo}/issues/${pr}/comments`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+          "User-Agent": "vendor-inventory-check",
+          Accept: "application/vnd.github+json",
+        },
+      },
+      (res) => {
+        res.resume();
+        if (res.statusCode && res.statusCode >= 400) {
+          console.log(`Comment failed. Status: ${res.statusCode}`);
+          resolve();
+          return;
+        }
+        console.log("Comment posted. Status:", res.statusCode);
+        resolve();
+      },
+    );
+    req.on("error", (e) => reject(e));
+    req.write(data);
+    req.end();
+  });
+}
+
+export function readBaseRegistry(baseSha: string | undefined, path: string): string | null {
+  if (!baseSha) return null;
+  try {
+    return execSync(`git show ${baseSha}:${path}`, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function main(): Promise<number> {
+  const registryPath = process.argv[2] ?? DEFAULT_REGISTRY_PATH;
+  let source: string;
+  try {
+    source = fs.readFileSync(registryPath, "utf8");
+  } catch (err) {
+    console.error(
+      `ERROR: cannot read registry at "${registryPath}": ${err instanceof Error ? err.message : err}`,
+    );
+    return 1;
+  }
+
+  const baseSource = readBaseRegistry(process.env.BASE_SHA, registryPath);
+  const report = runCheck(source, baseSource);
+
+  console.log(report.summary);
+  console.log("");
+  if (report.ok) {
+    console.log("Vendor inventory OK.");
+  } else {
+    console.error(`Vendor inventory FAILED with ${report.errors.length} error(s).`);
+  }
+
+  try {
+    await postComment(report.summary);
+  } catch (err) {
+    console.error("Error posting comment:", err);
+  }
+  return report.ok ? 0 : 1;
+}
+
+const isMainModule =
+  typeof process !== "undefined" &&
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith("vendor-inventory-check.ts") ||
+    process.argv[1] === new URL(import.meta.url).pathname);
+
+if (isMainModule) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Overview

Adds a lightweight, in-repo **SOC2 vendor-management inventory** with periodic risk review dates and CI enforcement, per issue #521.

- **Registry**: `docs/security/vendors.yaml` — YAML entries with risk score, criticality, owner, invoicing currency, and `review_date`.
- **Schema**: `docs/security/vendor-registry.schema.json` — documents the exact entry shape.
- **Checker**: `scripts/vendor-inventory-check.ts` — dependency-free validator + freshness checker (no new npm packages).
- **CI**: `.github/workflows/vendor-inventory.yml` — runs on PRs touching the registry, **fails if any entry is older than 12 months**, and posts a summary comment (vendor count, per-vendor next review date, errors/warnings) on the PR.

## Related Issue

Closes #521

## Changes

- `docs/security/vendors.yaml` — registry with 4 vendors (cloud, payments, email) and allowed currencies.
- `docs/security/vendor-registry.schema.json` — JSON Schema (schema_version 1) with required fields, risk_score 1–5, criticality enum, currency ISO-4217, review_date format.
- `docs/security/vendor-inventory.md` — guide: how to add/update vendors, review cadence, CI behavior, edge cases.
- `scripts/vendor-inventory-check.ts` — includes a small, strict YAML-subset parser (block maps/sequences/scalars, comments, quoted scalars) so no YAML dependency is introduced. Checks:
  - schema validation (missing `risk_score`, out-of-range values, malformed/future dates, invalid criticality, currency not allowed),
  - duplicate vendor `id` detection,
  - **freshness: any `review_date` older than 12 months fails**; entries within 3 months of the limit produce warnings,
  - **currency change**: when a vendor's `currency` changes vs. the PR base branch without an updated `review_date`, the check fails (change requires re-review),
  - posts the summary as a PR comment when `GITHUB_TOKEN`/`PR_NUMBER`/`GITHUB_REPOSITORY` are present (mirrors `scripts/dep-alerter.js`).
- `.github/workflows/vendor-inventory.yml` — node 24, `npm ci`, `npx tsx scripts/vendor-inventory-check.ts`, full checkout depth so the base registry can be diffed.
- `scripts/__tests__/vendor-inventory-check.test.ts` — 27 tests covering parser, registry parsing, validation, freshness (fresh/warning/stale), currency-change edge cases, and end-to-end `runCheck`.

## Verification Results

- `npm test -- --testPathPattern=vendor-inventory-check` → **27 passed, 0 failed**.
- `npx tsx scripts/vendor-inventory-check.ts` (real registry) → exit 0, "Vendor inventory OK."
- `npx eslint` on new files → clean. Prettier → clean.
- Full `npm test`: **pre-existing failures** in several `src/` suites (e.g. `src/utils/__tests__/redact.test.ts`, `src/routes/__tests__/admin.gdprDsr.test.ts`) — reproduced **identically on clean `upstream/main`** (89 failed / 10 passed for those suites with this PR's changes stashed). They appear to be local-environment issues (Node v25 vs CI Node 24) and are unrelated to this PR, which only adds new files and touches no existing source.

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Vendor YAML registry with schema | Done (`vendors.yaml` + `vendor-registry.schema.json`) |
| CI fails if any entry is older than 12 months | Done (freshness check + workflow) |
| Summary emitted in PR comment on change | Done (posts on registry-touching PRs) |
| Edge case: missing risk score | Covered (test + validation error) |
| Edge case: duplicate vendor entry | Covered (test + validation error) |
| Edge case: currency change | Covered (re-review required; test + check) |
| Tests (`npm test`) | 27 new tests pass; pre-existing suite failures reproduced on clean main |
| Documentation | `docs/security/vendor-inventory.md` |
