### PR TITLE
feat: soft-limit webhook warnings #538

### DIFF
--- a/docs/partner-token-soft-limit.md
+++ b/docs/partner-token-soft-limit.md
@@ -1,0 +1,70 @@
+# Partner Token Soft-Limit Warning Webhooks
+
+Partners receive an early **soft-limit** warning webhook before token quotas hard-cut requests (HTTP 429). Delivery is **at-least-once** via a durable ledger with dedupe and ack tracking.
+
+## Behavior
+
+1. Operators configure a per-partner soft-limit fraction `(0, 1]` (default `0.8`) and an `https` webhook URL.
+2. When quota consumption crosses the soft-limit (same path as the approaching-quota metric), ChronoPay enqueues a `token_quota_warning` delivery.
+3. Dedupe key: `{partnerId}:{roundedPct}:{15minWindow}` — duplicate warnings in the same window are ignored.
+4. Delivery stays `pending`/`failed` until the partner returns HTTP 2xx (`acked`) or attempts are exhausted.
+
+## Configuration
+
+```http
+POST /webhooks/admin/partner-soft-limit
+Content-Type: application/json
+
+{
+  "partnerId": "apiKey_<sha256>",
+  "webhookUrl": "https://partner.example.com/hooks/quota",
+  "softLimit": 0.8
+}
+```
+
+```http
+GET /webhooks/admin/partner-soft-limit/:partnerId
+```
+
+## Payload
+
+```json
+{
+  "event": "token_quota_warning",
+  "partner_id": "apiKey_...",
+  "token_usage": 8500,
+  "soft_limit": 0.8,
+  "threshold_percent": 85,
+  "message": "Token usage has reached 85% of the hard cutoff.",
+  "timestamp": "2026-08-03T20:00:00.000Z"
+}
+```
+
+## Delivery / retries
+
+- Automatic first attempt on enqueue (fire-and-forget from the quota path).
+- Retry pending/failed rows:
+
+```http
+POST /webhooks/partner-token/deliver
+POST /api/v1/webhooks/partner-token/deliver   # HMAC-protected
+```
+
+HMAC-protected check endpoint (same semantics as usage enqueue):
+
+```http
+POST /api/v1/webhooks/partner-token/check
+```
+
+## Security notes
+
+- Webhook URLs must use `https` outside tests.
+- Soft-limit check on `/api/v1/webhooks/partner-token/*` requires internal HMAC auth.
+- Ledger dedupe prevents webhook storms when usage oscillates near the threshold.
+
+## Schema
+
+Migration `021_create_partner_token_delivery_ledger` creates:
+
+- `partner_token_soft_limit_config`
+- `partner_token_delivery_ledger` (unique `dedupe_key`, retry index on `pending`/`failed`)

--- a/src/db/migrations/021_create_partner_token_delivery_ledger.ts
+++ b/src/db/migrations/021_create_partner_token_delivery_ledger.ts
@@ -1,0 +1,62 @@
+import { PoolClient } from "pg";
+import { Migration } from "../migrationRunner.js";
+
+/**
+ * Migration 021 — partner token soft-limit config + delivery ledger.
+ *
+ * Stores per-partner soft-limit webhook configuration and an at-least-once
+ * delivery ledger with dedupe keys so warning webhooks fire before hard cutoff.
+ */
+export const migration: Migration = {
+  id: "021",
+  name: "create_partner_token_delivery_ledger",
+
+  async up(client: PoolClient): Promise<void> {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS partner_token_soft_limit_config (
+        partner_id    TEXT        PRIMARY KEY,
+        soft_limit    REAL        NOT NULL DEFAULT 0.80,
+        webhook_url   TEXT        NOT NULL,
+        created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT partner_token_soft_limit_range
+          CHECK (soft_limit > 0 AND soft_limit <= 1)
+      )
+    `);
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS partner_token_delivery_ledger (
+        id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+        partner_id     TEXT        NOT NULL,
+        token_usage    REAL        NOT NULL,
+        soft_limit     REAL        NOT NULL,
+        threshold_pct  REAL        NOT NULL,
+        webhook_url    TEXT        NOT NULL,
+        status         TEXT        NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending', 'delivered', 'acked', 'failed')),
+        attempt_count  INTEGER     NOT NULL DEFAULT 0,
+        last_error     TEXT,
+        acked_at       TIMESTAMPTZ,
+        dedupe_key     TEXT        NOT NULL,
+        created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+
+    await client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_partner_token_delivery_dedupe
+        ON partner_token_delivery_ledger (dedupe_key)
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_partner_token_delivery_retryable
+        ON partner_token_delivery_ledger (status, created_at)
+        WHERE status IN ('pending', 'failed')
+    `);
+  },
+
+  async down(client: PoolClient): Promise<void> {
+    await client.query(`DROP TABLE IF EXISTS partner_token_delivery_ledger`);
+    await client.query(`DROP TABLE IF EXISTS partner_token_soft_limit_config`);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -34,6 +34,7 @@ import { migration as migration015 } from "./015_create_reputation_snapshots.js"
 import { migration as migration016 } from "./016_add_grace_window_config.js";
 import { migration as migration017 } from "./018_add_partner_token_quotas.js";
 import { migration as migration019 } from "./019_add_active_booking_intent_unique_idx.js";
+import { migration as migration021 } from "./021_create_partner_token_delivery_ledger.js";
 
 export const migrations: Migration[] = [
   migration001,
@@ -60,6 +61,7 @@ export const migrations: Migration[] = [
   migration016,
   migration017,
   migration019,
+  migration021,
 ];
 
 // ─── Duplicate-ID guard ───────────────────────────────────────────────────────

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -4,6 +4,10 @@ import { internalHmacAuth } from "../middleware/internalHmacAuth.js";
 import { _settlements } from "../services/settlementReconciler.js";
 import { WebhookIdempotencyStore } from "../services/webhookIdempotencyStore.js";
 import { defaultAuditLogger } from "../services/auditLogger.js";
+import {
+  PartnerTokenSoftLimitService,
+  processPendingDeliveries,
+} from "../services/partnerTokenSoftLimitService.js";
 
 const allowedEventTypes = new Set([
   "settlement_completed",
@@ -120,6 +124,73 @@ router.post("/admin/idempotency/sweep", async (req, res, next) => {
   }
 });
 
+// Partner token soft-limit admin routes
+router.post("/admin/partner-soft-limit", async (req, res, next) => {
+  try {
+    const { partnerId, webhookUrl, softLimit } = req.body;
+    if (!partnerId || !webhookUrl) {
+      return res.status(400).json({ success: false, error: "partnerId and webhookUrl are required" });
+    }
+    await PartnerTokenSoftLimitService.upsertConfig(partnerId, webhookUrl, softLimit);
+    await defaultAuditLogger.log({
+      action: "partner_soft_limit.configure",
+      status: "success",
+      resource: `partner:${partnerId}`,
+      metadata: { softLimit, webhookUrl },
+    });
+    return res.json({ success: true });
+  } catch (err: any) {
+    if (err?.message) {
+      return res.status(400).json({ success: false, error: err.message });
+    }
+    next(err);
+  }
+});
+
+router.get("/admin/partner-soft-limit/:partnerId", async (req, res, next) => {
+  try {
+    const { partnerId } = req.params;
+    const config = await PartnerTokenSoftLimitService.getConfig(partnerId);
+    if (!config) {
+      return res.status(404).json({ success: false, error: "Partner config not found" });
+    }
+    return res.json({ success: true, data: config });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Token usage check — soft-limit enqueue (also wired into quota consume path)
+router.post("/partner-token/usage", async (req, res, next) => {
+  try {
+    const { partnerId, usage, hardCutoff } = req.body;
+    if (!partnerId || typeof usage !== "number" || typeof hardCutoff !== "number") {
+      return res.status(400).json({
+        success: false,
+        error: "partnerId, usage (number), and hardCutoff (number) are required",
+      });
+    }
+
+    const entry = await PartnerTokenSoftLimitService.checkAndWarn(partnerId, usage, hardCutoff);
+    if (entry) {
+      return res.status(200).json({ success: true, warningEnqueued: true, entryId: entry.id });
+    }
+    return res.status(200).json({ success: true, warningEnqueued: false });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Process pending/failed soft-limit deliveries (scheduler/cron)
+router.post("/partner-token/deliver", async (req, res, next) => {
+  try {
+    const result = await processPendingDeliveries();
+    return res.json({ success: true, ...result });
+  } catch (err) {
+    next(err);
+  }
+});
+
 export default router;
 
 export function registerWebhookRoutes(app: Express, options: WebhookRouteOptions = {}) {
@@ -128,6 +199,50 @@ export function registerWebhookRoutes(app: Express, options: WebhookRouteOptions
     internalHmacAuth(options.signingSecret),
     validateRequiredFields(["eventType", "transactionId", "amount", "timestamp"]),
     (req, res, next) => handleSettlementWebhook(req, res).catch(next),
+  );
+
+  app.post(
+    "/api/v1/webhooks/partner-token/check",
+    internalHmacAuth(options.signingSecret),
+    async (req, res, next) => {
+      try {
+        const { partnerId, usage, hardCutoff } = req.body;
+        if (!partnerId || typeof usage !== "number" || typeof hardCutoff !== "number") {
+          return res.status(400).json({
+            success: false,
+            error: "partnerId, usage (number), and hardCutoff (number) are required",
+          });
+        }
+        const entry = await PartnerTokenSoftLimitService.checkAndWarn(
+          partnerId,
+          usage,
+          hardCutoff,
+        );
+        if (entry) {
+          return res.status(200).json({
+            success: true,
+            warningEnqueued: true,
+            entryId: entry.id,
+          });
+        }
+        return res.status(200).json({ success: true, warningEnqueued: false });
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  app.post(
+    "/api/v1/webhooks/partner-token/deliver",
+    internalHmacAuth(options.signingSecret),
+    async (_req, res, next) => {
+      try {
+        const result = await processPendingDeliveries();
+        return res.json({ success: true, ...result });
+      } catch (err) {
+        next(err);
+      }
+    },
   );
 }
 

--- a/src/services/__tests__/partnerTokenSoftLimitService.test.ts
+++ b/src/services/__tests__/partnerTokenSoftLimitService.test.ts
@@ -1,0 +1,329 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+const mockQuery = jest.fn() as any;
+jest.unstable_mockModule("../../db/pool.js", () => ({
+  query: mockQuery,
+  default: { query: mockQuery },
+}));
+
+jest.unstable_mockModule("../auditLogger.js", () => ({
+  defaultAuditLogger: { log: jest.fn(async () => undefined) },
+}));
+
+const {
+  PartnerTokenSoftLimitService,
+  deliverWarningWebhook,
+  processPendingDeliveries,
+  maybeEnqueueSoftLimitWarning,
+  _setSoftLimitDeps,
+  _resetSoftLimitDeps,
+} = await import("../partnerTokenSoftLimitService.js");
+
+describe("PartnerTokenSoftLimitService", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    _resetSoftLimitDeps();
+    process.env.NODE_ENV = "test";
+  });
+
+  afterEach(() => {
+    _resetSoftLimitDeps();
+  });
+
+  describe("computeThreshold", () => {
+    it("returns breached=true when usage meets soft limit", () => {
+      const result = PartnerTokenSoftLimitService.computeThreshold(80, 100, 0.8);
+      expect(result.breached).toBe(true);
+      expect(result.thresholdPct).toBe(0.8);
+    });
+
+    it("returns breached=true at softLimit === 1.0 (threshold at 100%)", () => {
+      const result = PartnerTokenSoftLimitService.computeThreshold(100, 100, 1.0);
+      expect(result.breached).toBe(true);
+      expect(result.thresholdPct).toBe(1);
+    });
+
+    it("returns breached=false below soft limit", () => {
+      const result = PartnerTokenSoftLimitService.computeThreshold(50, 100, 0.8);
+      expect(result.breached).toBe(false);
+    });
+
+    it("returns breached=false when hard cutoff is zero or negative", () => {
+      expect(PartnerTokenSoftLimitService.computeThreshold(50, 0, 0.8).breached).toBe(false);
+      expect(PartnerTokenSoftLimitService.computeThreshold(50, -1, 0.8).breached).toBe(false);
+    });
+  });
+
+  describe("dedupeKey", () => {
+    it("produces a stable key for the same partner and window", () => {
+      const nowMs = 1_700_000_000_000;
+      const key1 = PartnerTokenSoftLimitService.dedupeKey("partner-1", 0.85, nowMs);
+      const key2 = PartnerTokenSoftLimitService.dedupeKey("partner-1", 0.85, nowMs);
+      expect(key1).toBe(key2);
+    });
+
+    it("produces different keys for different partners", () => {
+      const nowMs = 1_700_000_000_000;
+      const key1 = PartnerTokenSoftLimitService.dedupeKey("partner-1", 0.85, nowMs);
+      const key2 = PartnerTokenSoftLimitService.dedupeKey("partner-2", 0.85, nowMs);
+      expect(key1).not.toBe(key2);
+    });
+
+    it("rounds threshold to integer percentage", () => {
+      const key = PartnerTokenSoftLimitService.dedupeKey("partner-1", 0.856, 0);
+      expect(key).toContain(":86:");
+    });
+  });
+
+  describe("upsertConfig", () => {
+    it("throws if softLimit is out of range", async () => {
+      await expect(
+        PartnerTokenSoftLimitService.upsertConfig("p1", "https://hook.example.com", 0),
+      ).rejects.toThrow("softLimit must be in the range");
+      await expect(
+        PartnerTokenSoftLimitService.upsertConfig("p1", "https://hook.example.com", 1.5),
+      ).rejects.toThrow("softLimit must be in the range");
+    });
+
+    it("allows softLimit === 1.0", async () => {
+      mockQuery.mockResolvedValue({ rowCount: 1 });
+      await PartnerTokenSoftLimitService.upsertConfig("p1", "https://hook.example.com", 1.0);
+      expect(mockQuery.mock.calls[0][1][1]).toBe(1.0);
+    });
+
+    it("throws if webhookUrl is empty", async () => {
+      await expect(PartnerTokenSoftLimitService.upsertConfig("p1", "")).rejects.toThrow(
+        "webhookUrl is required",
+      );
+    });
+
+    it("performs upsert query when valid", async () => {
+      mockQuery.mockResolvedValue({ rowCount: 1 });
+      await PartnerTokenSoftLimitService.upsertConfig("p1", "https://hook.example.com", 0.85);
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect(mockQuery.mock.calls[0][0]).toContain("INSERT INTO partner_token_soft_limit_config");
+    });
+  });
+
+  describe("getConfig", () => {
+    it("returns null when no config exists", async () => {
+      mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+      expect(await PartnerTokenSoftLimitService.getConfig("unknown")).toBeNull();
+    });
+
+    it("returns parsed config when found", async () => {
+      mockQuery.mockResolvedValue({
+        rowCount: 1,
+        rows: [{ partner_id: "p1", soft_limit: 0.8, webhook_url: "https://hook.example.com" }],
+      });
+      await expect(PartnerTokenSoftLimitService.getConfig("p1")).resolves.toEqual({
+        partnerId: "p1",
+        softLimit: 0.8,
+        webhookUrl: "https://hook.example.com",
+      });
+    });
+  });
+
+  describe("enqueueWarning", () => {
+    it("inserts a ledger entry and returns it", async () => {
+      const fakeRow = {
+        id: "uuid-1",
+        partner_id: "p1",
+        token_usage: 85,
+        soft_limit: 0.8,
+        threshold_pct: 0.85,
+        webhook_url: "https://hook.example.com",
+        status: "pending",
+        attempt_count: 0,
+        last_error: null,
+        acked_at: null,
+        dedupe_key: "p1:85:123",
+        created_at: new Date(),
+      };
+      mockQuery.mockResolvedValue({ rows: [fakeRow] });
+
+      const entry = await PartnerTokenSoftLimitService.enqueueWarning(
+        "p1",
+        85,
+        0.85,
+        "https://hook.example.com",
+        0.8,
+      );
+      expect(entry).not.toBeNull();
+      expect(entry!.partnerId).toBe("p1");
+      expect(entry!.status).toBe("pending");
+    });
+
+    it("returns null on duplicate warning (unique_violation)", async () => {
+      const pgError: any = new Error("duplicate key");
+      pgError.code = "23505";
+      mockQuery.mockRejectedValue(pgError);
+
+      const entry = await PartnerTokenSoftLimitService.enqueueWarning(
+        "p1",
+        85,
+        0.85,
+        "https://hook.example.com",
+        0.8,
+      );
+      expect(entry).toBeNull();
+    });
+  });
+
+  describe("checkAndWarn", () => {
+    it("returns null when partner has no config", async () => {
+      mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+      expect(await PartnerTokenSoftLimitService.checkAndWarn("p1", 90, 100)).toBeNull();
+    });
+
+    it("returns null when usage is below soft limit", async () => {
+      mockQuery.mockResolvedValue({
+        rowCount: 1,
+        rows: [{ partner_id: "p1", soft_limit: 0.8, webhook_url: "https://hook.example.com" }],
+      });
+      expect(await PartnerTokenSoftLimitService.checkAndWarn("p1", 50, 100)).toBeNull();
+    });
+  });
+
+  describe("getRetryableDeliveries", () => {
+    it("queries pending and failed entries under max attempts", async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await PartnerTokenSoftLimitService.getRetryableDeliveries(5);
+      expect(mockQuery.mock.calls[0][0]).toContain("status IN ('pending', 'failed')");
+      expect(mockQuery.mock.calls[0][1]).toEqual([5]);
+    });
+  });
+});
+
+describe("deliverWarningWebhook", () => {
+  const entry = {
+    id: "uuid-1",
+    partnerId: "p1",
+    tokenUsage: 85,
+    softLimit: 0.8,
+    thresholdPct: 0.85,
+    webhookUrl: "https://hook.example.com/warn",
+    status: "pending" as const,
+    attemptCount: 0,
+    lastError: null,
+    ackedAt: null,
+    dedupeKey: "p1:85:1",
+    createdAt: new Date(),
+  };
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rowCount: 1 });
+    _resetSoftLimitDeps();
+  });
+
+  afterEach(() => {
+    _resetSoftLimitDeps();
+  });
+
+  it("acks ledger on 2xx response", async () => {
+    const fetchFn = jest.fn(async () => ({ ok: true, status: 200 })) as any;
+    _setSoftLimitDeps({ fetchFn, queryFn: mockQuery });
+
+    await expect(deliverWarningWebhook(entry)).resolves.toBe(true);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0][0]).toContain("status = 'acked'");
+  });
+
+  it("marks failed and stays retryable when partner webhook is down", async () => {
+    const fetchFn = jest.fn(async () => ({ ok: false, status: 503 })) as any;
+    _setSoftLimitDeps({ fetchFn, queryFn: mockQuery });
+
+    await expect(deliverWarningWebhook(entry)).resolves.toBe(false);
+    expect(mockQuery.mock.calls[0][0]).toContain("status = 'failed'");
+    expect(mockQuery.mock.calls[0][1][1]).toContain("503");
+  });
+
+  it("marks failed on network error", async () => {
+    const fetchFn = jest.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as any;
+    _setSoftLimitDeps({ fetchFn, queryFn: mockQuery });
+
+    await expect(deliverWarningWebhook(entry)).resolves.toBe(false);
+    expect(mockQuery.mock.calls[0][1][1]).toContain("ECONNREFUSED");
+  });
+});
+
+describe("processPendingDeliveries", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    _resetSoftLimitDeps();
+  });
+
+  afterEach(() => {
+    _resetSoftLimitDeps();
+  });
+
+  it("delivers retryable entries and counts successes/failures", async () => {
+    const rows = [
+      {
+        id: "a",
+        partner_id: "p1",
+        token_usage: 85,
+        soft_limit: 0.8,
+        threshold_pct: 0.85,
+        webhook_url: "https://ok.example.com",
+        status: "pending",
+        attempt_count: 0,
+        last_error: null,
+        acked_at: null,
+        dedupe_key: "p1:85:1",
+        created_at: new Date(),
+      },
+      {
+        id: "b",
+        partner_id: "p2",
+        token_usage: 90,
+        soft_limit: 0.8,
+        threshold_pct: 0.9,
+        webhook_url: "https://down.example.com",
+        status: "failed",
+        attempt_count: 1,
+        last_error: "HTTP 500",
+        acked_at: null,
+        dedupe_key: "p2:90:1",
+        created_at: new Date(),
+      },
+    ];
+
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT") && sql.includes("partner_token_delivery_ledger")) {
+        return { rows };
+      }
+      return { rowCount: 1 };
+    });
+
+    const fetchFn = jest.fn(async (_url: string) => {
+      if (String(_url).includes("down")) {
+        return { ok: false, status: 500 };
+      }
+      return { ok: true, status: 200 };
+    }) as any;
+    _setSoftLimitDeps({ fetchFn, queryFn: mockQuery });
+
+    const result = await processPendingDeliveries();
+    expect(result).toEqual({ delivered: 1, failed: 1 });
+  });
+});
+
+describe("maybeEnqueueSoftLimitWarning", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    _resetSoftLimitDeps();
+  });
+
+  afterEach(() => {
+    _resetSoftLimitDeps();
+  });
+
+  it("does not throw when config lookup fails", async () => {
+    mockQuery.mockRejectedValue(new Error("db down"));
+    await expect(maybeEnqueueSoftLimitWarning("p1", 90, 100)).resolves.toBeUndefined();
+  });
+});

--- a/src/services/partnerQuotaService.ts
+++ b/src/services/partnerQuotaService.ts
@@ -18,6 +18,7 @@
 
 import { partnerQuotaApproachingLimit, partnerQuotaExceededTotal } from "../metrics.js";
 import { logger } from "../utils/logger.js";
+import { maybeEnqueueSoftLimitWarning } from "./partnerTokenSoftLimitService.js";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
@@ -396,6 +397,16 @@ export async function checkAndConsume(
       { tokenId: row.token_id, dailyUsed: nextDailyUsed, dailyLimit: row.daily_limit, monthlyUsed: nextMonthlyUsed, monthlyLimit: row.monthly_limit },
       "partner quota: approaching limit",
     );
+
+    // Soft-limit warning webhook (deduped, at-least-once) before hard cutoff.
+    // Prefer the limit that is closer to exhaustion as the hard cutoff context.
+    const dailyPct = nextDailyUsed / row.daily_limit;
+    const monthlyPct = nextMonthlyUsed / row.monthly_limit;
+    if (dailyPct >= monthlyPct) {
+      void maybeEnqueueSoftLimitWarning(row.token_id, nextDailyUsed, row.daily_limit);
+    } else {
+      void maybeEnqueueSoftLimitWarning(row.token_id, nextMonthlyUsed, row.monthly_limit);
+    }
   }
 
   // Consume

--- a/src/services/partnerTokenSoftLimitService.ts
+++ b/src/services/partnerTokenSoftLimitService.ts
@@ -1,0 +1,390 @@
+/**
+ * partnerTokenSoftLimitService.ts
+ *
+ * Soft-limit warning webhooks for partner token quotas.
+ *
+ * Partners configure a soft-limit threshold (fraction of hard cutoff) and a
+ * webhook URL. When usage crosses that threshold, a warning is enqueued into
+ * a delivery ledger with a 15-minute dedupe key, then delivered with
+ * at-least-once semantics (pending/failed entries are retried until acked).
+ */
+
+import { query } from "../db/pool.js";
+import { defaultAuditLogger } from "./auditLogger.js";
+import { logger } from "../utils/logger.js";
+
+export interface PartnerSoftLimitConfig {
+  partnerId: string;
+  softLimit: number;
+  webhookUrl: string;
+}
+
+export type DeliveryStatus = "pending" | "delivered" | "acked" | "failed";
+
+export interface DeliveryLedgerEntry {
+  id: string;
+  partnerId: string;
+  tokenUsage: number;
+  softLimit: number;
+  thresholdPct: number;
+  webhookUrl: string;
+  status: DeliveryStatus;
+  attemptCount: number;
+  lastError: string | null;
+  ackedAt: Date | null;
+  dedupeKey: string;
+  createdAt: Date;
+}
+
+export const DEFAULT_SOFT_LIMIT = 0.8;
+export const MAX_DELIVERY_ATTEMPTS = 8;
+const DEDUPE_WINDOW_MS = 15 * 60 * 1000;
+
+/** Optional injectable query fn + fetch for tests. */
+export type SoftLimitDeps = {
+  queryFn?: typeof query;
+  fetchFn?: typeof fetch;
+  nowMs?: () => number;
+};
+
+let deps: SoftLimitDeps = {};
+
+export function _setSoftLimitDeps(next: SoftLimitDeps): void {
+  deps = next;
+}
+
+export function _resetSoftLimitDeps(): void {
+  deps = {};
+}
+
+function q(): typeof query {
+  return deps.queryFn ?? query;
+}
+
+function fetchImpl(): typeof fetch {
+  return deps.fetchFn ?? fetch;
+}
+
+function now(): number {
+  return (deps.nowMs ?? Date.now)();
+}
+
+function assertHttpsWebhookUrl(webhookUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(webhookUrl);
+  } catch {
+    throw new Error("webhookUrl must be a valid URL");
+  }
+  if (parsed.protocol !== "https:" && process.env.NODE_ENV !== "test") {
+    throw new Error("webhookUrl must use https");
+  }
+}
+
+export class PartnerTokenSoftLimitService {
+  /**
+   * Configures the soft-limit threshold for a partner.
+   * softLimit is a fraction of the hard cutoff in (0, 1].
+   */
+  static async upsertConfig(
+    partnerId: string,
+    webhookUrl: string,
+    softLimit: number = DEFAULT_SOFT_LIMIT,
+  ): Promise<void> {
+    if (softLimit <= 0 || softLimit > 1) {
+      throw new Error("softLimit must be in the range (0, 1]");
+    }
+    if (!webhookUrl) {
+      throw new Error("webhookUrl is required");
+    }
+    assertHttpsWebhookUrl(webhookUrl);
+
+    await q()(
+      `INSERT INTO partner_token_soft_limit_config (partner_id, soft_limit, webhook_url, updated_at)
+       VALUES ($1, $2, $3, NOW())
+       ON CONFLICT (partner_id)
+       DO UPDATE SET soft_limit = EXCLUDED.soft_limit,
+                     webhook_url = EXCLUDED.webhook_url,
+                     updated_at = NOW()`,
+      [partnerId, softLimit, webhookUrl],
+    );
+  }
+
+  static async getConfig(partnerId: string): Promise<PartnerSoftLimitConfig | null> {
+    const res = await q()(
+      `SELECT partner_id, soft_limit, webhook_url
+       FROM partner_token_soft_limit_config WHERE partner_id = $1`,
+      [partnerId],
+    );
+    if (res.rowCount && res.rowCount > 0) {
+      const row = res.rows[0];
+      return {
+        partnerId: row.partner_id,
+        softLimit: Number(row.soft_limit),
+        webhookUrl: row.webhook_url,
+      };
+    }
+    return null;
+  }
+
+  static computeThreshold(
+    usage: number,
+    hardCutoff: number,
+    softLimit: number,
+  ): { breached: boolean; thresholdPct: number } {
+    if (hardCutoff <= 0) {
+      return { breached: false, thresholdPct: 0 };
+    }
+    const thresholdPct = usage / hardCutoff;
+    return {
+      breached: thresholdPct >= softLimit,
+      thresholdPct,
+    };
+  }
+
+  /**
+   * Dedupe key: partner + rounded percent + 15-minute window.
+   * Multiple checks in the same window share one ledger row.
+   */
+  static dedupeKey(partnerId: string, thresholdPct: number, nowMs: number = now()): string {
+    const windowStart = Math.floor(nowMs / DEDUPE_WINDOW_MS);
+    const roundedPct = Math.round(thresholdPct * 100);
+    return `${partnerId}:${roundedPct}:${windowStart}`;
+  }
+
+  static async enqueueWarning(
+    partnerId: string,
+    tokenUsage: number,
+    thresholdPct: number,
+    webhookUrl: string,
+    softLimit: number,
+  ): Promise<DeliveryLedgerEntry | null> {
+    const key = this.dedupeKey(partnerId, thresholdPct);
+
+    try {
+      const res = await q()(
+        `INSERT INTO partner_token_delivery_ledger
+         (partner_id, token_usage, soft_limit, threshold_pct, webhook_url, status, dedupe_key)
+         VALUES ($1, $2, $3, $4, $5, 'pending', $6)
+         RETURNING id, partner_id, token_usage, soft_limit, threshold_pct, webhook_url,
+                   status, attempt_count, last_error, acked_at, dedupe_key, created_at`,
+        [partnerId, tokenUsage, softLimit, thresholdPct, webhookUrl, key],
+      );
+      return this.rowToEntry(res.rows[0]);
+    } catch (error: any) {
+      if (error?.code === "23505") {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Entries eligible for retry: pending or failed, under max attempts.
+   * At-least-once: failed deliveries stay retryable until acked or exhausted.
+   */
+  static async getRetryableDeliveries(
+    maxAttempts: number = MAX_DELIVERY_ATTEMPTS,
+  ): Promise<DeliveryLedgerEntry[]> {
+    const res = await q()(
+      `SELECT id, partner_id, token_usage, soft_limit, threshold_pct, webhook_url,
+              status, attempt_count, last_error, acked_at, dedupe_key, created_at
+       FROM partner_token_delivery_ledger
+       WHERE status IN ('pending', 'failed')
+         AND attempt_count < $1
+       ORDER BY created_at ASC`,
+      [maxAttempts],
+    );
+    return res.rows.map((row: any) => this.rowToEntry(row));
+  }
+
+  /** @deprecated Prefer getRetryableDeliveries for at-least-once retries. */
+  static async getPendingDeliveries(): Promise<DeliveryLedgerEntry[]> {
+    return this.getRetryableDeliveries();
+  }
+
+  static async recordAttempt(
+    entryId: string,
+    ok: boolean,
+    errorMessage?: string,
+  ): Promise<void> {
+    if (ok) {
+      await q()(
+        `UPDATE partner_token_delivery_ledger
+         SET status = 'acked',
+             acked_at = NOW(),
+             attempt_count = attempt_count + 1,
+             last_error = NULL,
+             updated_at = NOW()
+         WHERE id = $1 AND status IN ('pending', 'failed', 'delivered')`,
+        [entryId],
+      );
+      return;
+    }
+
+    await q()(
+      `UPDATE partner_token_delivery_ledger
+       SET status = 'failed',
+           attempt_count = attempt_count + 1,
+           last_error = $2,
+           updated_at = NOW()
+       WHERE id = $1 AND status IN ('pending', 'failed', 'delivered')`,
+      [entryId, errorMessage ?? "delivery failed"],
+    );
+  }
+
+  /**
+   * Main entrypoint: if soft-limit breached, enqueue a deduped warning.
+   */
+  static async checkAndWarn(
+    partnerId: string,
+    usage: number,
+    hardCutoff: number,
+  ): Promise<DeliveryLedgerEntry | null> {
+    const config = await this.getConfig(partnerId);
+    if (!config) {
+      return null;
+    }
+
+    const { breached, thresholdPct } = this.computeThreshold(
+      usage,
+      hardCutoff,
+      config.softLimit,
+    );
+    if (!breached) {
+      return null;
+    }
+
+    const entry = await this.enqueueWarning(
+      partnerId,
+      usage,
+      thresholdPct,
+      config.webhookUrl,
+      config.softLimit,
+    );
+
+    if (entry) {
+      await defaultAuditLogger.log({
+        action: "partner_token.soft_limit_breach",
+        status: "warning",
+        resource: `partner:${partnerId}`,
+        metadata: { usage, thresholdPct, softLimit: config.softLimit },
+      });
+    }
+
+    return entry;
+  }
+
+  private static rowToEntry(row: any): DeliveryLedgerEntry {
+    return {
+      id: row.id,
+      partnerId: row.partner_id,
+      tokenUsage: Number(row.token_usage),
+      softLimit: Number(row.soft_limit),
+      thresholdPct: Number(row.threshold_pct),
+      webhookUrl: row.webhook_url,
+      status: row.status,
+      attemptCount: Number(row.attempt_count ?? 0),
+      lastError: row.last_error ?? null,
+      ackedAt: row.acked_at ?? null,
+      dedupeKey: row.dedupe_key,
+      createdAt: row.created_at,
+    };
+  }
+}
+
+/**
+ * Deliver one warning. Stays retryable on failure (at-least-once).
+ * Only marks acked after a successful 2xx response.
+ */
+export async function deliverWarningWebhook(
+  entry: DeliveryLedgerEntry,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  const payload = {
+    event: "token_quota_warning",
+    partner_id: entry.partnerId,
+    token_usage: entry.tokenUsage,
+    soft_limit: entry.softLimit,
+    threshold_percent: Math.round(entry.thresholdPct * 100),
+    message: `Token usage has reached ${Math.round(entry.thresholdPct * 100)}% of the hard cutoff.`,
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    const response = await fetchImpl()(entry.webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal,
+    });
+
+    if (response.ok) {
+      await PartnerTokenSoftLimitService.recordAttempt(entry.id, true);
+      return true;
+    }
+
+    await PartnerTokenSoftLimitService.recordAttempt(
+      entry.id,
+      false,
+      `HTTP ${response.status}`,
+    );
+    return false;
+  } catch (err: any) {
+    await PartnerTokenSoftLimitService.recordAttempt(
+      entry.id,
+      false,
+      err?.message ?? "network error",
+    );
+    return false;
+  }
+}
+
+export async function processPendingDeliveries(): Promise<{
+  delivered: number;
+  failed: number;
+}> {
+  const pending = await PartnerTokenSoftLimitService.getRetryableDeliveries();
+  let delivered = 0;
+  let failed = 0;
+
+  for (const entry of pending) {
+    const ok = await deliverWarningWebhook(entry);
+    if (ok) {
+      delivered++;
+    } else {
+      failed++;
+    }
+  }
+
+  return { delivered, failed };
+}
+
+/**
+ * Best-effort hook for the quota consume path.
+ * Never throws into the request path — failures are logged only.
+ */
+export async function maybeEnqueueSoftLimitWarning(
+  partnerId: string,
+  usage: number,
+  hardCutoff: number,
+): Promise<void> {
+  try {
+    const entry = await PartnerTokenSoftLimitService.checkAndWarn(
+      partnerId,
+      usage,
+      hardCutoff,
+    );
+    if (entry) {
+      // Fire-and-forget first delivery attempt; cron can retry.
+      void deliverWarningWebhook(entry).catch((err) => {
+        logger.warn(
+          { err, partnerId, entryId: entry.id },
+          "partner soft-limit webhook delivery failed",
+        );
+      });
+    }
+  } catch (err) {
+    logger.warn({ err, partnerId }, "partner soft-limit check failed");
+  }
+}


### PR DESCRIPTION
## Overview

This PR adds **partner-token overage soft-limit warning webhooks** so partners get an early warning before quotas hard-cut them off. Includes configurable thresholds, deduplicated enqueueing, and at-least-once delivery with ack tracking in a durable ledger.

## Related Issue

Closes #538

## Changes

### Soft-limit warning engine

* **[ADD]** `src/services/partnerTokenSoftLimitService.ts`
  * Soft-limit threshold config per partner `(0, 1]` (default `0.8`) + HTTPS webhook URL.
  * Dedupe key `{partnerId}:{roundedPct}:{15minWindow}` to avoid warning storms.
  * Delivery ledger with `pending` / `failed` / `acked` and retry until ack (at-least-once).
  * Wired into the quota consume path via `maybeEnqueueSoftLimitWarning`.

* **[ADD]** `src/db/migrations/021_create_partner_token_delivery_ledger.ts`
  * Tables: `partner_token_soft_limit_config`, `partner_token_delivery_ledger`.

* **[MODIFY]** `src/services/partnerQuotaService.ts`
  * Enqueues soft-limit warning when approaching quota (before hard cutoff).

* **[MODIFY]** `src/routes/webhooks.ts`
  * Admin config + usage check + deliver endpoints; HMAC-protected `/api/v1/webhooks/partner-token/*`.

* **[ADD]** `src/services/__tests__/partnerTokenSoftLimitService.test.ts`
  * Covers threshold at 100%, duplicate warnings, partner webhook down, retries/acks.

* **[ADD]** `docs/partner-token-soft-limit.md`

## Verification Results

```
npm test -- --testPathPattern=partnerTokenSoftLimitService --coverage=false
✅ 23/23 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Soft-limit threshold config | ✅ Per-partner config + default 0.8 |
| Enqueue warning webhook with dedupe | ✅ Unique dedupe key + PG 23505 |
| Track ack in delivery ledger | ✅ `acked` only after HTTP 2xx |
| At-least-once delivery | ✅ Retries `pending`/`failed` until ack |
| Edge: webhook down / softLimit=1.0 / duplicates | ✅ Covered in unit tests |